### PR TITLE
Limit GitHub Actions to prerequisite tests only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,5 @@ jobs:
       with:
         go-version: '1.21'
 
-    - name: Run tests
-      run: go test -v ./test
+    - name: Run prerequisite tests only
+      run: go test -v ./test -run TestPrerequisites


### PR DESCRIPTION
## Summary

This PR updates the `test.yml` GitHub Actions workflow to run only prerequisite tests instead of the full test suite. This prevents CI from attempting to run long-running deployment tests that require Azure credentials and infrastructure.

## Changes

- Modified `.github/workflows/test.yml` to run only `TestPrerequisites`
- Changed from: `go test -v ./test`
- Changed to: `go test -v ./test -run TestPrerequisites`

## Benefits

**Quick Validation**: Prerequisite tests complete in under 2 minutes, providing fast feedback on PRs

**No Azure Credentials Required**: Tests only verify that required tools are installed, not actual deployment

**Focused Feedback**: Developers get immediate feedback on whether their environment has the necessary tools

**Cost Effective**: Avoids spinning up Azure infrastructure in CI for every push

## What Still Runs

The prerequisite tests validate:
- ✓ Docker/Podman availability
- ✓ Kind installation
- ✓ Azure CLI presence
- ✓ OpenShift CLI availability
- ✓ Helm installation
- ✓ Git version
- ✓ kubectl availability

## Full Test Suite

The complete test suite (including deployment tests) can still be run:
- Manually via `make test`
- Through the `test-prerequisites.yml` workflow (manually triggered)
- Locally by developers with Azure credentials

## Test Plan

- [x] Update workflow to run only prerequisite tests
- [x] Verify command runs correct test subset
- [x] Update step name to reflect change
- [x] Commit and push changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)