### PR TITLE
Remove duplicate Prerequisites section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,6 @@ Tests are configured via environment variables:
 
 - `DEPLOYMENT_TIMEOUT` - Control plane deployment timeout (default: `30m`). Use Go duration format: `1h`, `45m`, `90m`, etc.
 
-## Prerequisites
-
-### CLI and Development Tools
-*Required command-line tools and development dependencies will be defined here.*
-
-### Runtime Requirements
-- Kubernetes cluster access (can be created by tests or provided via configuration)
-- Cloud provider credentials configured according to the specific CAPI implementation being tested
-
 ## Getting Started
 
 ### Quick Start


### PR DESCRIPTION
## Summary

This PR removes the duplicate Prerequisites section from the README to eliminate redundancy and improve documentation clarity.

## Problem

The README currently has **two** Prerequisites sections:

1. **Lines 52-70** - Complete, well-structured section with:
   - Required Tools subsection (Docker/Podman, Kind, Azure CLI, etc.)
   - Azure Access subsection (authentication requirements)

2. **Lines 96-104** - Incomplete duplicate section with:
   - Placeholder text ("*will be defined here*")
   - Generic runtime requirements
   - No specific tool listings

## Changes

- ✅ Removed the second, incomplete Prerequisites section (lines 96-104)
- ✅ Kept the comprehensive Prerequisites section (lines 52-70)
- ✅ Improved document flow from Configuration → Getting Started

## Benefits

**Eliminates Confusion**: Only one Prerequisites section to reference

**Single Source of Truth**: All prerequisite information in one place

**Better Organization**: Cleaner README structure and improved readability

**Removes Dead Content**: The duplicate section contained placeholder text that was never completed

## Before & After

### Before
```
## Prerequisites (line 52)
[Complete section with all tools listed]

## Configuration
[Config details]

## Prerequisites (line 96) ← DUPLICATE
[Placeholder content]

## Getting Started
```

### After
```
## Prerequisites (line 52)
[Complete section with all tools listed]

## Configuration
[Config details]

## Getting Started
```

## Test Plan

- [x] Identify both Prerequisites sections
- [x] Verify first section is complete and comprehensive
- [x] Remove second, incomplete section
- [x] Verify document flow is logical
- [x] Commit and push changes

## Verification

- No functional changes, documentation only
- All prerequisite information remains available in the first section
- Document structure is now more logical and less confusing

🤖 Generated with [Claude Code](https://claude.com/claude-code)