### PR TITLE
Add repository clone step to Kind cluster workflow (#38)

### DIFF
--- a/.github/workflows/test-kind-cluster.yml
+++ b/.github/workflows/test-kind-cluster.yml
@@ -45,6 +45,15 @@ jobs:
       with:
         version: 'latest'
 
+    - name: Clone cluster-api-installer repository
+      run: |
+        if [ -d "/tmp/cluster-api-installer-aro" ]; then
+          echo "Repository already exists, skipping clone"
+        else
+          git clone -b ARO-ASO https://github.com/RadekCap/cluster-api-installer.git /tmp/cluster-api-installer-aro
+          echo "Repository cloned successfully"
+        fi
+
     - name: Run Kind cluster tests
       run: |
         mkdir -p test-results


### PR DESCRIPTION
## Summary

This PR addresses Issue #38 by adding the missing repository setup step to the Kind cluster workflow, allowing tests to run successfully instead of being skipped.

## Problem

The Kind cluster workflow was failing with:
- **SKIP**: `TestKindCluster_Deploy` - "Repository not cloned yet at /tmp/cluster-api-installer-aro"
- **FAIL**: `TestKindCluster_Verify` - "Kind cluster 'capz-stage' not found" (because deployment was skipped)

### Root Cause
The Kind cluster tests require the `cluster-api-installer` repository to be present at `/tmp/cluster-api-installer-aro` for:
- Kind cluster deployment scripts
- CAPZ component installation
- Cluster configuration files

However, the workflow didn't include a step to clone this repository before running tests.

## Solution

Added **"Clone cluster-api-installer repository"** step to the workflow.

### New Step Details
```yaml
- name: Clone cluster-api-installer repository
  run: |
    if [ -d "/tmp/cluster-api-installer-aro" ]; then
      echo "Repository already exists, skipping clone"
    else
      git clone -b ARO-ASO https://github.com/RadekCap/cluster-api-installer.git /tmp/cluster-api-installer-aro
      echo "Repository cloned successfully"
    fi
```

**Position**: After Helm installation, before Kind cluster tests

**Features**:
- ✅ **Idempotent**: Checks if directory exists before cloning
- ✅ **Correct branch**: Clones ARO-ASO branch as required
- ✅ **Proper location**: Uses /tmp/cluster-api-installer-aro matching test expectations

## Changes

**Modified**: `.github/workflows/test-kind-cluster.yml`
- Added repository clone step between Helm installation and test execution
- Ensures cluster-api-installer is available for all Kind cluster tests

## Benefits

✅ **Tests no longer skip**: `TestKindCluster_Deploy` can now run successfully

✅ **Proper test execution**: All three Kind cluster tests can execute

✅ **Workflow independence**: Kind cluster workflow can run standalone

✅ **Idempotent operation**: Safe to run multiple times

✅ **Consistent with setup workflow**: Follows same repository handling pattern

## Expected Test Results

After this fix:
- ✅ `TestKindCluster_Deploy` - Will deploy Kind cluster (not skipped)
- ✅ `TestKindCluster_Verify` - Will verify cluster exists
- ✅ `TestKindCluster_CAPIComponents` - Will check CAPI components

## Test Plan

- [x] Identify root cause (missing repository clone)
- [x] Add clone step to workflow
- [x] Make it idempotent with directory check
- [x] Position after Helm, before tests
- [x] Use correct repository URL and branch
- [x] Commit and push changes

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)