### PR TITLE
Change default region from eastus to uksouth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ See `docs/INTEGRATION.md` for detailed integration patterns.
 - `CLUSTER_NAME` - ARO cluster name (default: `test-cluster`)
 - `RESOURCE_GROUP` - Azure resource group
 - `OPENSHIFT_VERSION` - OpenShift version (default: `4.18`)
-- `REGION` - Azure region (default: `eastus`)
+- `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID (required for deployment)
 - `ENV` - Environment identifier (default: `stage`)
 - `USER` - User identifier (default: current user)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Default values
 CLUSTER_NAME ?= test-cluster
 ENV ?= stage
-REGION ?= eastus
+REGION ?= uksouth
 KIND_CLUSTER_NAME ?= capz-stage
 
 help: ## Display this help message

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Tests are configured via environment variables:
 - `CLUSTER_NAME` - ARO cluster name (default: `test-cluster`)
 - `RESOURCE_GROUP` - Azure resource group
 - `OPENSHIFT_VERSION` - OpenShift version (default: `4.18`)
-- `REGION` - Azure region (default: `eastus`)
+- `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `ENV` - Environment identifier (default: `stage`)
 - `USER` - User identifier

--- a/TEST_COVERAGE.md
+++ b/TEST_COVERAGE.md
@@ -416,7 +416,7 @@ make check-prereq
 ```bash
 # Set configuration
 export CLUSTER_NAME=my-test-cluster
-export REGION=eastus
+export REGION=uksouth
 export AZURE_SUBSCRIPTION_NAME=your-subscription-id
 
 # Run all tests

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -215,7 +215,7 @@ KIND_CLUSTER_NAME=capz-stage
 CLUSTER_NAME=test-cluster
 RESOURCE_GROUP=test-rg
 OPENSHIFT_VERSION=4.18
-REGION=eastus
+REGION=uksouth
 ENV=stage
 
 # Azure Configuration (set your actual values)

--- a/test/README.md
+++ b/test/README.md
@@ -81,7 +81,7 @@ Tests are configured via environment variables:
 - `CLUSTER_NAME` - ARO cluster name (default: `test-cluster`)
 - `RESOURCE_GROUP` - Azure resource group
 - `OPENSHIFT_VERSION` - OpenShift version (default: `4.18`)
-- `REGION` - Azure region (default: `eastus`)
+- `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `ENV` - Environment (stage/prod) (default: `stage`)
 - `USER` - User identifier

--- a/test/config.go
+++ b/test/config.go
@@ -41,7 +41,7 @@ func NewTestConfig() *TestConfig {
 		ClusterName:       GetEnvOrDefault("CLUSTER_NAME", "test-cluster"),
 		ResourceGroup:     GetEnvOrDefault("RESOURCE_GROUP", "test-rg"),
 		OpenShiftVersion:  GetEnvOrDefault("OPENSHIFT_VERSION", "4.18"),
-		Region:            GetEnvOrDefault("REGION", "eastus"),
+		Region:            GetEnvOrDefault("REGION", "uksouth"),
 		AzureSubscription: os.Getenv("AZURE_SUBSCRIPTION_NAME"),
 		Environment:       GetEnvOrDefault("ENV", "stage"),
 		User:              GetEnvOrDefault("USER", os.Getenv("USER")),


### PR DESCRIPTION
## Summary

Changes the default Azure region from `eastus` to `uksouth` across all configuration files and documentation to fix deployment failures caused by region mismatch.

## Problem

The deployment test (`TestDeployment_WaitForControlPlane`) was failing with the following error:

```
InvalidResourceGroupLocation: Invalid resource group location 'eastus'. 
The Resource group already exists in location 'uksouth'.
```

**Root Cause**: The infrastructure generation was attempting to create resources in `eastus`, but the Azure resource group `rcap-stage-resgroup` already exists in `uksouth`, causing a conflict.

**Error Details**:
- Control Plane Status: `READY = false`
- Cluster Phase: `Provisioning` (stuck)
- Resource Group Error: HTTP 409 Conflict from Azure API

## Solution

Updated the default `REGION` configuration from `eastus` to `uksouth` in all locations to align with the existing Azure infrastructure.

## Files Changed

All 7 occurrences of `eastus` updated to `uksouth`:

1. **`test/config.go`** - Default region in `TestConfig` struct
   ```go
   Region: GetEnvOrDefault("REGION", "uksouth"),
   ```

2. **`Makefile`** - Default REGION variable
   ```makefile
   REGION ?= uksouth
   ```

3. **`README.md`** - Configuration documentation
   ```markdown
   - `REGION` - Azure region (default: `uksouth`)
   ```

4. **`CLAUDE.md`** - Environment variables documentation
5. **`test/README.md`** - Test configuration documentation
6. **`TEST_COVERAGE.md`** - Example configuration
7. **`docs/INTEGRATION.md`** - Environment file example

## Verification

✅ All `eastus` occurrences replaced with `uksouth`  
✅ No remaining `eastus` references in codebase  
✅ All 7 files updated consistently

```bash
# Verified with:
grep -r "eastus" --include="*.go" --include="*.md" --include="Makefile" .
# (no results)

grep -r "uksouth" --include="*.go" --include="*.md" --include="Makefile" .
# Shows 7 updated files
```

## Impact

### Fixes
- ✅ Resolves `InvalidResourceGroupLocation` deployment error
- ✅ Aligns with existing Azure resource group location
- ✅ Allows deployment tests to proceed without region conflicts

### Behavior Changes
- Default region changes from `eastus` to `uksouth`
- Existing deployments in `uksouth` continue working
- Users can still override with `REGION` environment variable

### No Breaking Changes
- Environment variable override still supported: `export REGION=<any-region>`
- Only affects default value when `REGION` is not set
- Backward compatible for users explicitly setting `REGION`

## Testing

After this change, the deployment will:
1. Use `uksouth` as the default region
2. Match the existing resource group location
3. Proceed past the resource group creation step
4. Continue with control plane provisioning

## Example Usage

**Before (would fail with existing resources)**:
```bash
make test-infra  # Would try eastus, conflict with existing uksouth resources
```

**After (works with existing resources)**:
```bash
make test-infra  # Uses uksouth, matches existing resources
```

**Custom region (still supported)**:
```bash
REGION=westus2 make test-infra  # Override still works
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)