### PR TITLE
Fix gotestsum syntax error causing test failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,42 +26,42 @@ help: ## Display this help message
 test: check-gotestsum ## Run all tests
 	@echo "=== Running All Tests ==="
 	@echo ""
-	@$(GOTESTSUM) go test -v ./test -timeout 60m
+	@$(GOTESTSUM) -v ./test -timeout 60m
 
 test-short: check-gotestsum ## Run quick tests only (skip long-running tests)
 	@echo "=== Running Quick Tests (Short Mode) ==="
 	@echo ""
-	@$(GOTESTSUM) go test -v -short ./test
+	@$(GOTESTSUM) -v -short ./test
 
 test-prereq: check-gotestsum ## Run prerequisite verification tests only
 	@echo "=== Running Prerequisites Tests ==="
 	@echo ""
-	@$(GOTESTSUM) go test -v ./test -run TestPrerequisites
+	@$(GOTESTSUM) -v ./test -run TestPrerequisites
 
 test-setup: check-gotestsum ## Run repository setup tests only
 	@echo "=== Running Repository Setup Tests ==="
 	@echo ""
-	@$(GOTESTSUM) go test -v ./test -run TestSetup
+	@$(GOTESTSUM) -v ./test -run TestSetup
 
 test-kind: check-gotestsum ## Run Kind cluster deployment tests only
 	@echo "=== Running Kind Cluster Deployment Tests ==="
 	@echo ""
-	@$(GOTESTSUM) go test -v ./test -run TestKindCluster -timeout 30m
+	@$(GOTESTSUM) -v ./test -run TestKindCluster -timeout 30m
 
 test-infra: check-gotestsum ## Run infrastructure generation tests only
 	@echo "=== Running Infrastructure Generation Tests ==="
 	@echo ""
-	@$(GOTESTSUM) go test -v ./test -run TestInfrastructure -timeout 20m
+	@$(GOTESTSUM) -v ./test -run TestInfrastructure -timeout 20m
 
 test-deploy: check-gotestsum ## Run deployment monitoring tests only
 	@echo "=== Running Deployment Monitoring Tests ==="
 	@echo ""
-	@$(GOTESTSUM) go test -v ./test -run TestDeployment -timeout 40m
+	@$(GOTESTSUM) -v ./test -run TestDeployment -timeout 40m
 
 test-verify: check-gotestsum ## Run cluster verification tests only
 	@echo "=== Running Cluster Verification Tests ==="
 	@echo ""
-	@$(GOTESTSUM) go test -v ./test -run TestVerification -timeout 20m
+	@$(GOTESTSUM) -v ./test -run TestVerification -timeout 20m
 
 test-all: ## Run all test phases sequentially
 	@echo "========================================"


### PR DESCRIPTION
## Summary

Fixes #51 by correcting the gotestsum command syntax in all test targets.

## Problem

All test targets (`make test`, `make test-prereq`, etc.) were failing with errors:

```
FAIL go
FAIL test

=== FAIL: go  (0.00s)
FAIL	go [setup failed]

=== FAIL: test  (0.00s)
FAIL	test [setup failed]

=== Errors
package go is not in std (/usr/lib/golang/src/go)
package test is not in std (/usr/lib/golang/src/test)

DONE 0 tests, 2 failures, 2 errors in 0.000s
make: *** [Makefile:39: test-prereq] Error 1
```

## Root Cause

The gotestsum commands were incorrectly including `go test` as arguments:

```makefile
@$(GOTESTSUM) go test -v ./test -run TestPrerequisites
```

This caused gotestsum to interpret "go" and "test" as **package names** instead of recognizing them as the command to run.

## Why This Happened

In PR #48, GitHub Copilot suggested adding `go test` to all gotestsum commands, claiming this was required syntax. However, **this was incorrect advice**.

The gotestsum tool automatically runs `go test` with whatever arguments are provided after the `--` separator. Including `go test` explicitly causes the error.

## Solution

Removed `go test` from all 8 test target commands:

**Before (BROKEN):**
```makefile
GOTESTSUM := gotestsum --format='$(GOTESTSUM_FORMAT)' --
# ...
@$(GOTESTSUM) go test -v ./test -run TestPrerequisites
```

This expanded to:
```bash
gotestsum --format='testname' -- go test -v ./test -run TestPrerequisites
```

Which gotestsum interpreted as: "Run tests on packages named 'go' and 'test'"

**After (FIXED):**
```makefile
GOTESTSUM := gotestsum --format='$(GOTESTSUM_FORMAT)' --
# ...
@$(GOTESTSUM) -v ./test -run TestPrerequisites
```

This expands to:
```bash
gotestsum --format='testname' -- -v ./test -run TestPrerequisites
```

Which gotestsum correctly interprets as: "Run `go test -v ./test -run TestPrerequisites`"

## Changes

Updated all 8 test targets in `Makefile`:
- ✅ `test` - All tests
- ✅ `test-short` - Quick tests  
- ✅ `test-prereq` - Prerequisites
- ✅ `test-setup` - Repository setup
- ✅ `test-kind` - Kind cluster deployment
- ✅ `test-infra` - Infrastructure generation
- ✅ `test-deploy` - Deployment monitoring
- ✅ `test-verify` - Cluster verification

## Testing

Verified the fix works correctly:

```bash
$ make test-prereq
=== Running Prerequisites Tests ===

PASS test.TestPrerequisites_ToolsAvailable/docker (0.00s)
PASS test.TestPrerequisites_ToolsAvailable/kind (0.00s)
PASS test.TestPrerequisites_ToolsAvailable/az (0.00s)
PASS test.TestPrerequisites_ToolsAvailable/oc (0.00s)
PASS test.TestPrerequisites_ToolsAvailable/helm (0.00s)
PASS test.TestPrerequisites_ToolsAvailable/git (0.00s)
PASS test.TestPrerequisites_ToolsAvailable (0.00s)
PASS test.TestPrerequisites_AzureCLILogin (0.25s)
PASS test.TestPrerequisites_OpenShiftCLI (0.05s)
PASS test.TestPrerequisites_HelmVersion (0.03s)
PASS test.TestPrerequisites_KindVersion (0.00s)
PASS test

DONE 11 tests in 0.345s
```

All tests now run successfully with proper gotestsum formatting and summaries! ✅

## Impact

- **Before**: All test commands broken, no tests could run
- **After**: All test commands work, proper test summaries displayed

## Note on Copilot Suggestion

This fix **supersedes and corrects** the Copilot suggestion from PR #48 (Findings #3-11). While Copilot's other suggestions in that PR were valid (security fix for GOTESTSUM_FORMAT, workflow improvements), the recommendation to add `go test` was incorrect.

**Lesson learned**: AI code review suggestions should always be validated with testing, especially when modifying build/test infrastructure.

## Test Plan

- [x] Fix gotestsum syntax in all test targets
- [x] Test with `make test-prereq` - works ✅
- [x] Verify test summaries display correctly - works ✅
- [x] Commit changes
- [x] Create pull request
- [x] Link to issue #51

Fixes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)