### PR TITLE
Add real-time progress output to deployment tests (fixes #64)

### DIFF
--- a/test/deployment_progress_demo_test.go
+++ b/test/deployment_progress_demo_test.go
@@ -9,13 +9,17 @@ import (
 
 // TestDeployment_ProgressDemo demonstrates the real-time progress output
 // This test simulates the waiting behavior to verify progress is shown in real-time
-// Run with: go test -v ./test -run TestDeployment_ProgressDemo
+// Run with: RUN_DEMO_TESTS=1 go test -v ./test -run TestDeployment_ProgressDemo
 func TestDeployment_ProgressDemo(t *testing.T) {
+	if os.Getenv("RUN_DEMO_TESTS") != "1" {
+		t.Skip("Skipping demo test (set RUN_DEMO_TESTS=1 to run)")
+	}
 	if testing.Short() {
 		t.Skip("Skipping progress demo in short mode")
 	}
 
-	// Simulate a 30-second wait with 5-second intervals (like the real test but faster)
+	// Simulate a wait with a 30-second timeout and 5-second intervals
+	// Demo completes after 15 seconds to show the success case
 	timeout := 30 * time.Second
 	pollInterval := 5 * time.Second
 	startTime := time.Now()
@@ -39,18 +43,9 @@ func TestDeployment_ProgressDemo(t *testing.T) {
 		// In real test, this would be: kubectl get kubeadmcontrolplane ...
 
 		iteration++
-		percentage := int((float64(elapsed) / float64(timeout)) * 100)
 
-		// Print progress to stderr for real-time visibility
-		fmt.Fprintf(os.Stderr, "[%d] ⏳ Waiting... | Elapsed: %v | Remaining: %v | Progress: %d%%\n",
-			iteration,
-			elapsed.Round(time.Second),
-			remaining.Round(time.Second),
-			percentage)
-
-		// Also log to test output
-		t.Logf("Demo iteration %d (elapsed: %v, remaining: %v, %d%%)",
-			iteration, elapsed.Round(time.Second), remaining.Round(time.Second), percentage)
+		// Report progress using helper function
+		ReportProgress(t, os.Stderr, iteration, elapsed, remaining, timeout)
 
 		// For demo, complete after 15 seconds
 		if elapsed > 15*time.Second {

--- a/test/deployment_test.go
+++ b/test/deployment_test.go
@@ -106,18 +106,9 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 		}
 
 		iteration++
-		percentage := int((float64(elapsed) / float64(timeout)) * 100)
 
-		// Print progress to stderr for real-time visibility
-		fmt.Fprintf(os.Stderr, "[%d] ⏳ Waiting... | Elapsed: %v | Remaining: %v | Progress: %d%%\n",
-			iteration,
-			elapsed.Round(time.Second),
-			remaining.Round(time.Second),
-			percentage)
-
-		// Also log to test output
-		t.Logf("Control plane not ready yet, waiting %v... (elapsed: %v, remaining: %v, %d%%)",
-			pollInterval, elapsed.Round(time.Second), remaining.Round(time.Second), percentage)
+		// Report progress using helper function
+		ReportProgress(t, os.Stderr, iteration, elapsed, remaining, timeout)
 
 		time.Sleep(pollInterval)
 	}

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1,10 +1,13 @@
 package test
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
 
 // CommandExists checks if a command is available in the system PATH
@@ -56,6 +59,25 @@ func GetEnvOrDefault(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+// ReportProgress prints progress information to stderr for real-time visibility
+// and to test log for test output. This helper ensures consistent progress
+// reporting across all deployment tests.
+func ReportProgress(t *testing.T, w io.Writer, iteration int, elapsed, remaining, timeout time.Duration) {
+	t.Helper()
+	percentage := int((float64(elapsed) / float64(timeout)) * 100)
+
+	// Print to stderr for real-time visibility (unbuffered)
+	fmt.Fprintf(w, "[%d] ⏳ Waiting... | Elapsed: %v | Remaining: %v | Progress: %d%%\n",
+		iteration,
+		elapsed.Round(time.Second),
+		remaining.Round(time.Second),
+		percentage)
+
+	// Also log to test output
+	t.Logf("Waiting iteration %d (elapsed: %v, remaining: %v, %d%%)",
+		iteration, elapsed.Round(time.Second), remaining.Round(time.Second), percentage)
 }
 
 // IsKubectlApplySuccess checks if kubectl apply output indicates success.


### PR DESCRIPTION
## Summary

Fixes #64 - `make test-deploy` now shows real-time progress updates while waiting for the control plane to be ready. Previously, progress was only visible when the test was interrupted, making it difficult to track long-running deployments.

## Problem

When running `make test-deploy`, the test would appear to hang with no output, even though it was actively polling for the control plane status. The only way to see progress was to interrupt the test with Ctrl+C, which would then show buffered log output.

This was caused by Go's testing framework buffering `t.Logf()` output, which is only displayed when:
- The test completes
- The test fails
- The test is interrupted

## Solution

Added real-time progress output by printing to `stderr` (which is unbuffered) while maintaining test log output via `t.Logf()` for test reports.

### Changes

**test/deployment_test.go:**
- Modified `TestDeployment_WaitForControlPlane` to show real-time progress:
  - Iteration number
  - Elapsed time
  - Remaining time until timeout
  - Progress percentage
  - Visual indicators (⏳ waiting, ✅ complete, ❌ timeout)
- Improved `TestDeployment_MonitorCluster` with real-time status updates

**test/deployment_progress_demo_test.go:**
- Added demo test (`TestDeployment_ProgressDemo`) to showcase the feature
- Runs a 15-second simulation showing progress updates every 5 seconds
- Can be used to verify progress output without deploying a full cluster

## Output Example

**Before** (no output until interrupted or complete):
```
=== RUN   TestDeployment_WaitForControlPlane
[waiting... no output visible]
```

**After** (real-time progress):
```
=== RUN   TestDeployment_WaitForControlPlane

=== Waiting for control plane to be ready ===
Timeout: 30m0s | Poll interval: 30s

[1] ⏳ Waiting... | Elapsed: 0s | Remaining: 30m0s | Progress: 0%
[2] ⏳ Waiting... | Elapsed: 30s | Remaining: 29m30s | Progress: 1%
[3] ⏳ Waiting... | Elapsed: 1m0s | Remaining: 29m0s | Progress: 3%
...
[11] ⏳ Waiting... | Elapsed: 5m0s | Remaining: 25m0s | Progress: 16%

✅ Control plane is ready! (took 5m30s)
```

## Testing

### Run the demo test:
```bash
go test -v ./test -run TestDeployment_ProgressDemo
```

Expected output (completes in ~15 seconds):
```
=== Demo: Simulating control plane wait ===
Timeout: 30s | Poll interval: 5s

[1] ⏳ Waiting... | Elapsed: 0s | Remaining: 30s | Progress: 0%
[2] ⏳ Waiting... | Elapsed: 5s | Remaining: 25s | Progress: 16%
[3] ⏳ Waiting... | Elapsed: 10s | Remaining: 20s | Progress: 33%
[4] ⏳ Waiting... | Elapsed: 15s | Remaining: 15s | Progress: 50%

✅ Demo complete! (took 15s)
```

### Test with actual deployment (requires cluster):
```bash
make test-deploy
```

## Benefits

1. **Better UX**: Users can see progress in real-time
2. **Time awareness**: Shows both elapsed time and time remaining
3. **Progress tracking**: Percentage indicator shows how far along the wait is
4. **Visual clarity**: Emoji indicators make status immediately recognizable
5. **Debugging**: Easier to identify if tests are stuck vs. just waiting
6. **Test reports**: Still maintains full test log output via `t.Logf()`

## Technical Details

- Uses `fmt.Fprintf(os.Stderr, ...)` for unbuffered real-time output
- Maintains `t.Logf()` calls for test framework compatibility
- Calculates progress percentage as `(elapsed / timeout) * 100`
- Rounds times to seconds for cleaner display
- Zero dependencies added

🤖 Generated with [Claude Code](https://claude.com/claude-code)