### PR TITLE
Fix Kind cluster workflow ARO_REPO_DIR mismatch (fixes #69)

### DIFF
--- a/.github/workflows/test-kind-cluster.yml
+++ b/.github/workflows/test-kind-cluster.yml
@@ -55,6 +55,8 @@ jobs:
         fi
 
     - name: Run Kind cluster tests
+      env:
+        ARO_REPO_DIR: /tmp/cluster-api-installer-aro
       run: |
         mkdir -p test-results
         go run gotest.tools/gotestsum@v1.13.0 --format testname --jsonfile test-results/tests.json --junitfile test-results/junit.xml -- -v ./test -run TestKindCluster -timeout 30m


### PR DESCRIPTION
## Summary

Fixes the Kind cluster workflow failure caused by ARO_REPO_DIR path mismatch after PR #67.

## Problem

After PR #67 introduced unique `ARO_REPO_DIR` paths for parallel test execution, the Kind cluster workflow started failing because:

1. **Workflow** clones repository to hardcoded `/tmp/cluster-api-installer-aro` (line 53)
2. **Tests** expect repository at unique path like `/tmp/cluster-api-installer-aro-{pid}-{timestamp}`
3. **Result**: Tests can't find the repository and fail

**Failed run**: https://github.com/RadekCap/CAPZTests/actions/runs/19874759345

**Error logs**:
```
TestKindCluster_Deploy: SKIP - Repository not cloned yet at /tmp/cluster-api-installer-aro-4270-1764712438174354208
TestKindCluster_Verify: FAIL - Kind cluster 'capz-stage' not found in cluster list
```

## Solution

Set `ARO_REPO_DIR=/tmp/cluster-api-installer-aro` as an environment variable in the "Run Kind cluster tests" step.

**Changes**:
- Added `env:` section with `ARO_REPO_DIR: /tmp/cluster-api-installer-aro`
- Tests will now use the same path as the workflow clone operation
- Maintains backward compatibility

## Why This Works

The `getDefaultRepoDir()` function checks for the `ARO_REPO_DIR` environment variable first:
```go
if dir := os.Getenv("ARO_REPO_DIR"); dir != "" {
    defaultRepoDir = dir
    return
}
```

By setting this env var, tests will use `/tmp/cluster-api-installer-aro` instead of generating a unique path.

## Testing

- [x] Verified `ARO_REPO_DIR` env var is respected by `TestGetDefaultRepoDir_EnvVariable`
- [x] Code formatted with `go fmt`
- [ ] CI will validate workflow runs successfully

## Related

- Fixes #69
- Related to PR #67 (introduced unique paths)
- Related to Issue #66 (original request for unique paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)