### PR TITLE
Add auto-assign workflow for pull requests (fixes #75)

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -12,9 +12,11 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+    if: github.event.pull_request.draft == false
 
     steps:
     - name: Assign PR to RadekCap
+      if: github.event.pull_request.head.repo.full_name == github.repository
       run: |
         echo "PR #${{ github.event.pull_request.number }} opened by ${{ github.event.pull_request.user.login }}"
         echo "Assigning to RadekCap..."


### PR DESCRIPTION
## Summary
Implements automatic assignment of newly created pull requests to RadekCap, addressing issue #75.

## Problem
Currently, when pull requests are created, they need to be manually assigned to reviewers. This adds friction and can lead to PRs being overlooked.

## Solution
Created a new GitHub Actions workflow that automatically assigns all newly opened pull requests to RadekCap using the GitHub API.

## Changes
- Created `.github/workflows/auto-assign-pr.yml`
- Workflow triggers on `pull_request` `opened` event
- Uses GitHub API (`gh api`) to add RadekCap as assignee
- Includes proper permissions (`pull-requests: write`, `issues: write`)
- Error handling for permission failures

## Implementation Details

### Trigger
The workflow activates when a PR is opened:
```yaml
on:
  pull_request:
    types:
      - opened
```

### API Call
Uses GitHub's assignees endpoint to add RadekCap:
```bash
gh api \
  --method POST \
  /repos/{repo}/issues/{pr}/assignees \
  -f assignees[]='RadekCap'
```

### Permissions
Requires:
- `pull-requests: write` - to modify PR assignees
- `issues: write` - PRs use the issues API for assignees

### Self-Testing
This PR will test the workflow - if it works correctly, RadekCap should be automatically assigned to this PR when it's opened!

## Testing
- YAML syntax validated
- Workflow will be tested when this PR is created
- Uses built-in `GITHUB_TOKEN` (no additional secrets needed)

## Benefits
- Streamlines PR workflow
- Ensures all PRs are tracked and assigned
- Reduces manual work for repository maintainers
- No additional configuration required

Fixes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)