### PR TITLE
Add auto-assign workflow for issues (fixes #74)

### DIFF
--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -1,0 +1,28 @@
+name: Auto-assign Issues
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  assign-issue:
+    name: Assign Issue to RadekCap
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+    - name: Assign Issue to RadekCap
+      run: |
+        echo "Issue #${{ github.event.issue.number }} opened by ${{ github.event.issue.user.login }}"
+        echo "Assigning to RadekCap..."
+
+        # Assign the issue to RadekCap using GitHub API
+        gh api \
+          --method POST \
+          /repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees \
+          -f assignees[]='RadekCap' \
+          || echo "Failed to assign issue (user may not have permissions)"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Implements automatic assignment of newly created issues to RadekCap, addressing issue #74.

## Problem
Currently, when issues are created, they need to be manually assigned. This adds friction and can lead to issues being overlooked or not properly tracked.

## Solution
Created a new GitHub Actions workflow that automatically assigns all newly opened issues to RadekCap using the GitHub API.

## Changes
- Created `.github/workflows/auto-assign-issue.yml`
- Workflow triggers on `issues` `opened` event
- Uses GitHub API (`gh api`) to add RadekCap as assignee
- Includes proper permissions (`issues: write`)
- Error handling for permission failures

## Implementation Details

### Trigger
The workflow activates when an issue is opened:
```yaml
on:
  issues:
    types:
      - opened
```

### API Call
Uses GitHub's assignees endpoint to add RadekCap:
```bash
gh api \
  --method POST \
  /repos/{repo}/issues/{issue}/assignees \
  -f assignees[]='RadekCap'
```

### Permissions
Requires:
- `issues: write` - to modify issue assignees

### Pattern Consistency
Follows the same pattern as the recently added `auto-assign-pr.yml` workflow, ensuring consistency across the repository's automation workflows.

## Testing
- YAML syntax validated
- Uses built-in `GITHUB_TOKEN` (no additional secrets needed)
- Will be tested in real-world usage when issues are created

## Benefits
- Streamlines issue workflow
- Ensures all issues are tracked and assigned
- Reduces manual work for repository maintainers
- No additional configuration required
- Consistent with PR auto-assignment workflow

Fixes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)