### PR TITLE
Add configurable test verbosity via TEST_VERBOSITY variable (fixes #93)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ ifeq (,$(filter $(GOTESTSUM_FORMAT),$(ALLOWED_FORMATS)))
   $(error Invalid GOTESTSUM_FORMAT "$(GOTESTSUM_FORMAT)". Allowed: $(ALLOWED_FORMATS))
 endif
 
+# Test verbosity configuration
+# Set to -v for verbose output (default), or empty string for quiet output
+TEST_VERBOSITY ?= -v
+
 # Results directory configuration
 # Create unique results directory for each test run using timestamp
 TIMESTAMP := $(shell date +%Y%m%d_%H%M%S)
@@ -47,7 +51,7 @@ test: check-gotestsum ## Run all tests
 	@echo "=== Running All Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-all.xml -- -v ./test -timeout 60m
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-all.xml -- $(TEST_VERBOSITY) ./test -timeout 60m
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-all.xml"
 
@@ -56,7 +60,7 @@ test-short: check-gotestsum ## Run quick tests only (skip long-running tests)
 	@echo "=== Running Quick Tests (Short Mode) ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-short.xml -- -v -short ./test
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-short.xml -- $(TEST_VERBOSITY) -short ./test
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-short.xml"
 
@@ -65,7 +69,7 @@ test-prereq: check-gotestsum ## Run prerequisite verification tests only
 	@echo "=== Running Prerequisites Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-prereq.xml -- -v ./test -run TestPrerequisites
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-prereq.xml -- $(TEST_VERBOSITY) ./test -run TestPrerequisites
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-prereq.xml"
 
@@ -74,7 +78,7 @@ test-setup: check-gotestsum ## Run repository setup tests only
 	@echo "=== Running Repository Setup Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-setup.xml -- -v ./test -run TestSetup
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-setup.xml -- $(TEST_VERBOSITY) ./test -run TestSetup
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-setup.xml"
 
@@ -83,7 +87,7 @@ test-kind: check-gotestsum ## Run Kind cluster deployment tests only
 	@echo "=== Running Kind Cluster Deployment Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-kind.xml -- -v ./test -run TestKindCluster -timeout 30m
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-kind.xml -- $(TEST_VERBOSITY) ./test -run TestKindCluster -timeout 30m
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-kind.xml"
 
@@ -92,7 +96,7 @@ test-infra: check-gotestsum ## Run infrastructure generation tests only
 	@echo "=== Running Infrastructure Generation Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-infra.xml -- -v ./test -run TestInfrastructure -timeout 20m
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-infra.xml -- $(TEST_VERBOSITY) ./test -run TestInfrastructure -timeout 20m
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-infra.xml"
 
@@ -101,7 +105,7 @@ test-deploy: check-gotestsum ## Run deployment monitoring tests only
 	@echo "=== Running Deployment Monitoring Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy.xml -- -v ./test -run TestDeployment -timeout 40m
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy.xml -- $(TEST_VERBOSITY) ./test -run TestDeployment -timeout 40m
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-deploy.xml"
 
@@ -110,7 +114,7 @@ test-verify: check-gotestsum ## Run cluster verification tests only
 	@echo "=== Running Cluster Verification Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-verify.xml -- -v ./test -run TestVerification -timeout 20m
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-verify.xml -- $(TEST_VERBOSITY) ./test -run TestVerification -timeout 20m
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-verify.xml"
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Tests are configured via environment variables:
 ### Test Behavior
 
 - `DEPLOYMENT_TIMEOUT` - Control plane deployment timeout (default: `30m`). Use Go duration format: `1h`, `45m`, `90m`, etc.
+- `TEST_VERBOSITY` - Test output verbosity (default: `-v` for verbose). Set to empty string for quiet output: `TEST_VERBOSITY= make test-prereq`
 
 ## Getting Started
 
@@ -104,6 +105,12 @@ make test-verify      # Cluster verification
 
 # Run quick tests (skip long-running operations)
 make test-short
+
+# Run tests with quiet output (no verbose flag)
+TEST_VERBOSITY= make test-prereq
+
+# Run tests with verbose output (default)
+TEST_VERBOSITY=-v make test-prereq
 ```
 
 **Note**: All test targets automatically generate JUnit XML reports in a timestamped `results/` directory. The path to the results directory is displayed when tests run.


### PR DESCRIPTION
## Summary
Implements configurable test output verbosity by extracting the `-v` flag into a `TEST_VERBOSITY` Makefile variable. Tests run with verbose output by default but can be run quietly by setting the variable to an empty string.

## Problem
Issue #93 requested the ability to run go tests with different verbosity levels. Previously, all test targets had the `-v` (verbose) flag hardcoded, making it impossible to run tests with quieter output.

## Solution
Extracted the `-v` flag into a configurable `TEST_VERBOSITY` Makefile variable with the following characteristics:

1. **Default Behavior**: Set to `-v` (verbose) by default to maintain existing behavior
2. **Configurable**: Users can override via environment variable
3. **Quiet Mode**: Set to empty string for non-verbose output
4. **Flexible**: Can be set to any valid go test verbosity flag

### Implementation Details

**Makefile Changes**:
- Added `TEST_VERBOSITY ?= -v` variable definition with documentation
- Updated all 8 test targets to use `$(TEST_VERBOSITY)` instead of hardcoded `-v`:
  - `test` - Full test suite
  - `test-short` - Quick tests
  - `test-prereq` - Prerequisites verification
  - `test-setup` - Repository setup
  - `test-kind` - Kind cluster deployment
  - `test-infra` - Infrastructure generation
  - `test-deploy` - Deployment monitoring
  - `test-verify` - Cluster verification

**Documentation Changes**:
- Added `TEST_VERBOSITY` to "Test Behavior" configuration section in README.md
- Added usage examples showing both verbose and quiet modes
- Included practical examples in the "Running Tests" section

## Changes

### Files Modified
- **Makefile** (11 lines changed)
  - Added `TEST_VERBOSITY` variable configuration
  - Replaced hardcoded `-v` with `$(TEST_VERBOSITY)` in all test targets

- **README.md** (8 lines added)
  - Documented `TEST_VERBOSITY` variable in configuration section
  - Added usage examples for verbose and quiet modes

## Testing

### Validation Steps
- ✅ Validated Makefile syntax with `make help`
- ✅ Tested default verbose mode: `make test-prereq`
- ✅ Tested quiet mode: `TEST_VERBOSITY= make test-prereq`
- ✅ Verified variable substitution with dry-run: `make -n test-prereq`

### Test Results

**Default Verbose Mode** (includes `-v` flag):
```bash
$ make -n test-prereq 2>&1 | grep gotestsum
/home/user/go/bin/gotestsum --format='testname' --junitfile=results/.../junit-prereq.xml -- -v ./test -run TestPrerequisites
```

**Quiet Mode** (no `-v` flag):
```bash
$ TEST_VERBOSITY= make -n test-prereq 2>&1 | grep gotestsum
/home/user/go/bin/gotestsum --format='testname' --junitfile=results/.../junit-prereq.xml -- ./test -run TestPrerequisites
```

## Usage Examples

### Verbose Output (Default)
```bash
# Uses -v flag automatically
make test-prereq

# Explicit verbose (same as default)
TEST_VERBOSITY=-v make test-prereq
```

### Quiet Output
```bash
# No verbose flag
TEST_VERBOSITY= make test-prereq

# Works with all test targets
TEST_VERBOSITY= make test-all
```

### Custom Verbosity
```bash
# Could potentially use other go test flags
TEST_VERBOSITY="-v -json" make test-prereq
```

## Benefits

1. **Backward Compatible** - Default behavior unchanged (still verbose)
2. **Flexible** - Users can control output verbosity for all test targets
3. **Consistent** - Single variable controls all 8 test targets
4. **CI/CD Friendly** - Easier to reduce output noise in automated environments
5. **Simple** - Follows existing Makefile variable pattern (like `GOTESTSUM_FORMAT`)

## Notes

- The `TEST_VERBOSITY` variable uses the `?=` operator, allowing it to be overridden via environment variable
- Setting to empty string (`TEST_VERBOSITY=`) produces standard go test output without verbose details
- The variable can technically be set to other go test flags, though `-v` or empty are the primary use cases
- All test targets use the same verbosity setting; individual target control would require separate variables

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)