### PR TITLE
Print commands used to retrieve kubeconfig (fixes #100)

### DIFF
--- a/test/06_verification_test.go
+++ b/test/06_verification_test.go
@@ -26,6 +26,7 @@ func TestVerification_RetrieveKubeconfig(t *testing.T) {
 	// Method 1: Using kubectl to get secret
 	secretName := fmt.Sprintf("%s-kubeconfig", config.ClusterName)
 
+	t.Logf("Attempting Method 1: kubectl --context %s get secret %s -o jsonpath={.data.value}", context, secretName)
 	output, err := RunCommand(t, "kubectl", "--context", context, "get", "secret",
 		secretName, "-o", "jsonpath={.data.value}")
 
@@ -39,7 +40,7 @@ func TestVerification_RetrieveKubeconfig(t *testing.T) {
 		}
 
 		if FileExists(clusterctlPath) || CommandExists("clusterctl") {
-			t.Log("Trying method 2: clusterctl get kubeconfig")
+			t.Logf("Attempting Method 2: %s get kubeconfig %s", clusterctlPath, config.ClusterName)
 
 			output, err = RunCommand(t, clusterctlPath, "get", "kubeconfig", config.ClusterName)
 			if err != nil {


### PR DESCRIPTION
## Summary

Adds logging to display the exact commands used when retrieving cluster kubeconfig in the TestVerification_RetrieveKubeconfig test.

## Problem

As requested in #100, the test should print the commands being used to retrieve the kubeconfig. This improves debugging and transparency, making it clear which retrieval method is being attempted and what the exact command syntax is.

## Solution

Added `t.Logf()` statements before each kubeconfig retrieval command:

**Method 1 (kubectl)**:
```
t.Logf("Attempting Method 1: kubectl --context %s get secret %s -o jsonpath={.data.value}", context, secretName)
```

**Method 2 (clusterctl)**:
```
t.Logf("Attempting Method 2: %s get kubeconfig %s", clusterctlPath, config.ClusterName)
```

## Changes

- **test/06_verification_test.go**:
  - Added command logging before kubectl secret retrieval (line 29)
  - Added command logging before clusterctl kubeconfig retrieval (line 43)

## Testing

- [x] Prerequisite tests pass
- [x] Code formatted with `go fmt ./...`
- [x] Changes follow existing test logging patterns

## Example Output

When the test runs, users will now see output like:
```
=== RUN   TestVerification_RetrieveKubeconfig
    06_verification_test.go:24: Retrieving kubeconfig for cluster 'capz-tests-cluster'
    06_verification_test.go:29: Attempting Method 1: kubectl --context kind-capz-tests-stage get secret capz-tests-cluster-kubeconfig -o jsonpath={.data.value}
    06_verification_test.go:85: Kubeconfig retrieved using kubectl and saved to /tmp/capz-tests-cluster-kubeconfig.yaml
--- PASS: TestVerification_RetrieveKubeconfig (0.45s)
```

This makes it immediately clear which method succeeded and what command was executed.

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)