### PR TITLE
Make test phase targets private and simplify help output (fixes #107)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-prereq test-setup test-kind test-infra test-deploy test-verify test-all test-short clean help
+.PHONY: test _test-prereq _test-setup _test-kind _test-infra _test-deploy _test-verify test-all test-short clean help
 
 # Default values
 CLUSTER_NAME ?= test-cluster
@@ -35,16 +35,6 @@ help: ## Display this help message
 	@echo ""
 	@echo "Available targets:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-20s %s\n", $$1, $$2}'
-	@echo ""
-	@echo "Expected order for manual execution:"
-	@echo "  1. make test-prereq   - Prerequisites verification"
-	@echo "  2. make test-setup    - Repository setup"
-	@echo "  3. make test-kind     - Kind cluster deployment"
-	@echo "  4. make test-infra    - Infrastructure generation"
-	@echo "  5. make test-deploy   - Deployment monitoring"
-	@echo "  6. make test-verify   - Cluster verification"
-	@echo ""
-	@echo "Or run all phases sequentially with: make test-all"
 
 test: check-gotestsum ## Run all tests
 	@mkdir -p $(RESULTS_DIR)
@@ -64,7 +54,7 @@ test-short: check-gotestsum ## Run quick tests only (skip long-running tests)
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-short.xml"
 
-test-prereq: check-gotestsum ## Run prerequisite verification tests only
+_test-prereq: check-gotestsum
 	@mkdir -p $(RESULTS_DIR)
 	@echo "=== Running Prerequisites Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
@@ -73,7 +63,7 @@ test-prereq: check-gotestsum ## Run prerequisite verification tests only
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-prereq.xml"
 
-test-setup: check-gotestsum ## Run repository setup tests only
+_test-setup: check-gotestsum
 	@mkdir -p $(RESULTS_DIR)
 	@echo "=== Running Repository Setup Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
@@ -82,7 +72,7 @@ test-setup: check-gotestsum ## Run repository setup tests only
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-setup.xml"
 
-test-kind: check-gotestsum ## Run Kind cluster deployment tests only
+_test-kind: check-gotestsum
 	@mkdir -p $(RESULTS_DIR)
 	@echo "=== Running Kind Cluster Deployment Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
@@ -91,7 +81,7 @@ test-kind: check-gotestsum ## Run Kind cluster deployment tests only
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-kind.xml"
 
-test-infra: check-gotestsum ## Run infrastructure generation tests only
+_test-infra: check-gotestsum
 	@mkdir -p $(RESULTS_DIR)
 	@echo "=== Running Infrastructure Generation Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
@@ -100,7 +90,7 @@ test-infra: check-gotestsum ## Run infrastructure generation tests only
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-infra.xml"
 
-test-deploy: check-gotestsum ## Run deployment monitoring tests only
+_test-deploy: check-gotestsum
 	@mkdir -p $(RESULTS_DIR)
 	@echo "=== Running Deployment Monitoring Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
@@ -109,7 +99,7 @@ test-deploy: check-gotestsum ## Run deployment monitoring tests only
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-deploy.xml"
 
-test-verify: check-gotestsum ## Run cluster verification tests only
+_test-verify: check-gotestsum
 	@mkdir -p $(RESULTS_DIR)
 	@echo "=== Running Cluster Verification Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
@@ -126,12 +116,12 @@ test-all: ## Run all test phases sequentially
 	@echo ""
 	@echo "All test results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(MAKE) --no-print-directory test-prereq && \
-	$(MAKE) --no-print-directory test-setup && \
-	$(MAKE) --no-print-directory test-kind && \
-	$(MAKE) --no-print-directory test-infra && \
-	$(MAKE) --no-print-directory test-deploy && \
-	$(MAKE) --no-print-directory test-verify && \
+	@$(MAKE) --no-print-directory _test-prereq && \
+	$(MAKE) --no-print-directory _test-setup && \
+	$(MAKE) --no-print-directory _test-kind && \
+	$(MAKE) --no-print-directory _test-infra && \
+	$(MAKE) --no-print-directory _test-deploy && \
+	$(MAKE) --no-print-directory _test-verify && \
 	echo "" && \
 	echo "=======================================" && \
 	echo "=== All Test Phases Completed Successfully ===" && \


### PR DESCRIPTION
## Summary
Updated Makefile to hide internal test phase targets from `make help` output and removed the "Expected order" section for a cleaner, more focused user interface.

## Problem
Issue #107 requested making the individual test phase targets (`test-prereq`, `test-setup`, `test-kind`, `test-infra`, `test-deploy`, `test-verify`) private and removing them from the help output. These targets are implementation details that users shouldn't need to invoke directly - they should use `make test-all` instead.

## Solution
Applied the underscore prefix convention to mark targets as private and removed their help documentation:

### Target Renaming
- `test-prereq` → `_test-prereq`
- `test-setup` → `_test-setup`
- `test-kind` → `_test-kind`
- `test-infra` → `_test-infra`
- `test-deploy` → `_test-deploy`
- `test-verify` → `_test-verify`

### Help Simplification
- Removed `##` documentation comments from private targets (prevents them from appearing in help)
- Removed "Expected order for manual execution" section from help output
- Help now shows only the public API: `test`, `test-short`, `test-all`, `clean`, etc.

## Changes

**Makefile**:
- Updated `.PHONY` declaration with new private target names
- Renamed 6 test phase targets with `_` prefix
- Removed help documentation (`##`) from private targets
- Updated `test-all` target to call private targets (`_test-prereq`, etc.)
- Simplified `help` target by removing "Expected order" section

## Before/After

### Before (make help):
```
Available targets:
  help                 Display this help message
  test                 Run all tests
  test-short           Run quick tests only
  test-prereq          Run prerequisite verification tests only
  test-setup           Run repository setup tests only
  test-kind            Run Kind cluster deployment tests only
  test-infra           Run infrastructure generation tests only
  test-deploy          Run deployment monitoring tests only
  test-verify          Run cluster verification tests only
  test-all             Run all test phases sequentially
  ...

Expected order for manual execution:
  1. make test-prereq   - Prerequisites verification
  2. make test-setup    - Repository setup
  ...
```

### After (make help):
```
Available targets:
  help                 Display this help message
  test                 Run all tests
  test-short           Run quick tests only (skip long-running tests)
  test-all             Run all test phases sequentially
  clean                Clean up test resources
  ...
```

## Testing
- [x] Verified `make help` shows only public targets
- [x] Verified private targets still work: `make _test-prereq` runs successfully
- [x] Verified `test-all` target works with new private target names
- [x] All prerequisite tests pass

**Note**: Private targets can still be invoked directly if needed (e.g., `make _test-prereq`), but they won't appear in help, signaling they're internal implementation details.

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)