### PR TITLE
Rename _kind to _cluster in Makefile and documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ make test-all
 # Individual test phases (internal use - called by test-all)
 make _check-dep      # Check dependencies
 make _setup          # Repository setup
-make _kind           # Kind cluster deployment
+make _cluster        # Cluster deployment
 make _infra          # Infrastructure generation
 make _deploy         # Deployment monitoring
 make _verify         # Cluster verification

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test _check-dep _setup _kind _infra _deploy _verify test-all clean help
+.PHONY: test _check-dep _setup _cluster _infra _deploy _verify test-all clean help
 
 # Default values
 CLUSTER_NAME ?= test-cluster
@@ -56,14 +56,14 @@ _setup: check-gotestsum
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-setup.xml"
 
-_kind: check-gotestsum
+_cluster: check-gotestsum
 	@mkdir -p $(RESULTS_DIR)
-	@echo "=== Running Kind Cluster Deployment Tests ==="
+	@echo "=== Running Cluster Deployment Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-kind.xml -- $(TEST_VERBOSITY) ./test -run TestKindCluster -timeout 30m
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-cluster.xml -- $(TEST_VERBOSITY) ./test -run TestKindCluster -timeout 30m
 	@echo ""
-	@echo "Test results saved to: $(RESULTS_DIR)/junit-kind.xml"
+	@echo "Test results saved to: $(RESULTS_DIR)/junit-cluster.xml"
 
 _infra: check-gotestsum
 	@mkdir -p $(RESULTS_DIR)
@@ -102,7 +102,7 @@ test-all: ## Run all test phases sequentially
 	@echo ""
 	@$(MAKE) --no-print-directory _check-dep && \
 	$(MAKE) --no-print-directory _setup && \
-	$(MAKE) --no-print-directory _kind && \
+	$(MAKE) --no-print-directory _cluster && \
 	$(MAKE) --no-print-directory _infra && \
 	$(MAKE) --no-print-directory _deploy && \
 	$(MAKE) --no-print-directory _verify && \

--- a/TEST_COVERAGE.md
+++ b/TEST_COVERAGE.md
@@ -234,23 +234,18 @@ go test -v ./test -run TestCheckDependencies
 Run individual test phases for targeted validation.
 
 ```bash
-# Check dependencies only
+# Check dependencies only (fast, no Azure resources)
 make test
 
-# Validate repository setup
-make test-setup
+# Run all test phases sequentially
+make test-all
 
-# Test Kind cluster deployment
-make test-kind
-
-# Test infrastructure generation
-make test-infra
-
-# Monitor deployment
-make test-deploy
-
-# Verify deployed cluster
-make test-verify
+# Run specific test phase using Go test directly
+go test -v ./test -run TestSetup
+go test -v ./test -run TestKindCluster
+go test -v ./test -run TestInfrastructure
+go test -v ./test -run TestDeployment
+go test -v ./test -run TestVerification
 ```
 
 ---

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -273,19 +273,18 @@ git commit -m "Update vendored installer scripts"
 ## Testing the Integration
 
 ```bash
-# Verify repository is accessible
-make test-setup
-
-# Run full test suite
+# Run check dependencies tests (fast, no Azure resources)
 make test
 
-# Or step by step
-make test
-make test-setup
-make test-kind
-make test-infra
-make test-deploy
-make test-verify
+# Run full test suite (all phases sequentially)
+make test-all
+
+# Or run specific test phases using Go test directly
+go test -v ./test -run TestSetup
+go test -v ./test -run TestKindCluster
+go test -v ./test -run TestInfrastructure
+go test -v ./test -run TestDeployment
+go test -v ./test -run TestVerification
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

Rename the internal make target from `_kind` to `_cluster` to better reflect that it deploys the management cluster (which happens to use Kind as the implementation).

## Changes Made

### Makefile
- Renamed target from `_kind:` to `_cluster:`
- Updated `.PHONY` declaration
- Changed output file from `junit-kind.xml` to `junit-cluster.xml`
- Updated `test-all` target to call `_cluster` instead of `_kind`
- Updated echo message from "Kind Cluster Deployment Tests" to "Cluster Deployment Tests"

### Documentation
- **CLAUDE.md**: Updated internal target reference from `make _kind` to `make _cluster`
- **TEST_COVERAGE.md**: Updated phase-specific testing examples to use current public targets (`make test`, `make test-all`) and Go test commands
- **docs/INTEGRATION.md**: Updated testing examples to reflect current architecture

## Testing

✅ All check dependencies tests pass:
```
DONE 15 tests in 0.000s
```

## Rationale

The target name `_cluster` better describes what the target does - it deploys the management cluster. While the implementation uses Kind (Kubernetes in Docker), the target name should focus on the logical purpose rather than the implementation detail.

This change improves consistency with the overall test architecture where targets are named by their purpose (setup, infra, deploy, verify) rather than their implementation tools.

## Migration Guide

No migration needed for users - this is an internal target. Public interface remains:
- `make test` - Run check dependencies tests
- `make test-all` - Run all test phases sequentially

🤖 Generated with [Claude Code](https://claude.com/claude-code)