### PR TITLE
Restore _deploy-crds target naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Tests are designed to run **sequentially** in a specific order, with each phase 
 2. **Setup** (`02_setup_test.go`) - Repository cloning and validation
 3. **Kind Cluster** (`03_kind_cluster_test.go`) - Management cluster deployment
 4. **Infrastructure** (`04_infrastructure_test.go`) - YAML generation
-5. **Deployment** (`05_deployment_test.go`) - Cluster deployment monitoring
+5. **Deployment** (`05_deployment_test.go`) - CRD deployment monitoring
 6. **Verification** (`06_verification_test.go`) - Final cluster validation
 
 Tests are **idempotent** - they skip steps already completed, allowing re-runs.
@@ -84,7 +84,7 @@ make _check-dep      # Check dependencies
 make _setup          # Repository setup
 make _cluster        # Cluster deployment
 make _generate-yamls # YAML generation
-make _deploy         # Deployment monitoring
+make _deploy-crds    # CRD deployment
 make _verify         # Cluster verification
 
 # Run specific test function

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test _check-dep _setup _cluster _generate-yamls _deploy _verify test-all clean help
+.PHONY: test _check-dep _setup _cluster _generate-yamls _deploy-crds _verify test-all clean help
 
 # Default values
 CLUSTER_NAME ?= test-cluster
@@ -74,14 +74,14 @@ _generate-yamls: check-gotestsum
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-generate-yamls.xml"
 
-_deploy: check-gotestsum
+_deploy-crds: check-gotestsum
 	@mkdir -p $(RESULTS_DIR)
-	@echo "=== Running Deployment Monitoring Tests ==="
+	@echo "=== Running CRD Deployment Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy.xml -- $(TEST_VERBOSITY) ./test -run TestDeployment -timeout 40m
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-crds.xml -- $(TEST_VERBOSITY) ./test -run TestDeployment -timeout 40m
 	@echo ""
-	@echo "Test results saved to: $(RESULTS_DIR)/junit-deploy.xml"
+	@echo "Test results saved to: $(RESULTS_DIR)/junit-deploy-crds.xml"
 
 _verify: check-gotestsum
 	@mkdir -p $(RESULTS_DIR)
@@ -104,7 +104,7 @@ test-all: ## Run all test phases sequentially
 	$(MAKE) --no-print-directory _setup && \
 	$(MAKE) --no-print-directory _cluster && \
 	$(MAKE) --no-print-directory _generate-yamls && \
-	$(MAKE) --no-print-directory _deploy && \
+	$(MAKE) --no-print-directory _deploy-crds && \
 	$(MAKE) --no-print-directory _verify && \
 	echo "" && \
 	echo "=======================================" && \

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ results/
     ├── junit-setup.xml            # Setup test results
     ├── junit-cluster.xml          # Cluster deployment test results
     ├── junit-generate-yamls.xml   # YAML generation test results
-    ├── junit-deploy.xml           # Deployment monitoring test results
+    ├── junit-deploy-crds.xml      # CRD deployment test results
     └── junit-verify.xml           # Verification test results
 ```
 


### PR DESCRIPTION
## Summary

Restore the `_deploy-crds` target naming that was reverted in PR #116.

This PR reverts commit 33059fd from PR #116 and restores the `_deploy-crds` naming.

## Changes Made

### Makefile
- Renamed target from `_deploy:` to `_deploy-crds:`
- Updated `.PHONY` declaration
- Changed output file from `junit-deploy.xml` to `junit-deploy-crds.xml`
- Updated `test-all` target to call `_deploy-crds` instead of `_deploy`
- Updated echo message to "Running CRD Deployment Tests"

### Documentation
- **CLAUDE.md**: 
  - Updated internal target reference to `make _deploy-crds`
  - Updated test phase description to "CRD deployment monitoring"
- **README.md**: 
  - Updated results directory structure to show `junit-deploy-crds.xml`

## Testing

✅ All check dependencies tests pass:
```
DONE 15 tests in 0.000s
```

## Related

- Reverts: commit 33059fd from PR #116
- Original change: commit 2f81c0c from PR #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)