### PR TITLE
Fix GitHub Actions workflow failure by skipping Azure login test in CI (fixes #126)

### DIFF
--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -39,6 +39,12 @@ func TestCheckDependencies_ToolAvailable(t *testing.T) {
 
 // TestCheckDependencies_AzureCLILogin_IsLoggedIn checks if Azure CLI is logged in
 func TestCheckDependencies_AzureCLILogin_IsLoggedIn(t *testing.T) {
+	// Skip in CI environments where Azure login is not available
+	if os.Getenv("CI") == "true" || os.Getenv("GITHUB_ACTIONS") == "true" {
+		t.Skip("Skipping Azure CLI login check in CI environment")
+		return
+	}
+
 	output, err := RunCommand(t, "az", "account", "show")
 	if err != nil {
 		t.Errorf("Azure CLI not logged in. Please run 'az login': %v", err)


### PR DESCRIPTION
## Summary
Fixes the check-dependencies GitHub Actions workflow failure by making the Azure CLI login test skip gracefully in CI environments.

## Problem
The `check-dependencies` workflow was failing on every run because the `TestCheckDependencies_AzureCLILogin_IsLoggedIn` test expects Azure credentials to be available. GitHub Actions CI runners are not logged into Azure, causing this test to fail with:

```
Azure CLI not logged in. Please run 'az login': exit status 1
```

This resulted in:
- All check-dependencies workflow runs failing (red badge)
- False negative test results
- Confusion about actual test suite health

Issue: #126
Workflow: https://github.com/RadekCap/CAPZTests/actions/workflows/check-dependencies.yml

## Solution
Modified the Azure CLI login test to detect CI environments and skip gracefully when running in GitHub Actions. The test now checks for standard CI environment variables (`CI=true` or `GITHUB_ACTIONS=true`) and skips with a clear message.

This approach:
- ✅ Allows workflow to pass in CI
- ✅ Still validates Azure login in local development
- ✅ Provides clear feedback about why test is skipped
- ✅ Follows existing pattern (see TestCheckDependencies_DockerCredentialHelper)

## Changes

### test/01_check_dependencies_test.go
**Lines 42-46**: Added CI environment detection
```go
// Skip in CI environments where Azure login is not available
if os.Getenv("CI") == "true" || os.Getenv("GITHUB_ACTIONS") == "true" {
    t.Skip("Skipping Azure CLI login check in CI environment")
    return
}
```

## Behavior Changes

### Before
- **CI (GitHub Actions)**: ❌ FAIL - "Azure CLI not logged in"
- **Local (logged in)**: ✅ PASS - Shows account info
- **Local (not logged in)**: ❌ FAIL - "Please run 'az login'"

### After
- **CI (GitHub Actions)**: ⏭️ SKIP - "Skipping Azure CLI login check in CI environment"
- **Local (logged in)**: ✅ PASS - Shows account info
- **Local (not logged in)**: ❌ FAIL - "Please run 'az login'"

## Testing

### Local Testing (without CI env)
```bash
$ make test
PASS test.TestCheckDependencies_AzureCLILogin_IsLoggedIn (7.56s)
DONE 15 tests in 8.870s
```

### CI Simulation
```bash
$ CI=true go test -v ./test -run TestCheckDependencies_AzureCLILogin_IsLoggedIn
--- SKIP: TestCheckDependencies_AzureCLILogin_IsLoggedIn (0.00s)
    01_check_dependencies_test.go:44: Skipping Azure CLI login check in CI environment
PASS
```

## Why This Approach?

1. **Follows existing patterns**: The `TestCheckDependencies_DockerCredentialHelper` test already uses environment-based skipping (checks for macOS vs other platforms)

2. **Standard CI detection**: Using `CI` and `GITHUB_ACTIONS` environment variables is the standard way to detect CI environments across different platforms

3. **Preserves local validation**: Developers still get validation that they're logged into Azure when running tests locally

4. **Clear messaging**: Skip message clearly explains why the test was skipped

## Alternative Approaches Considered

1. **Remove the test entirely**: ❌ Loses validation in local development
2. **Make test non-failing**: ❌ Doesn't provide clear feedback
3. **Use -short flag**: ❌ Would require workflow changes and affect other tests
4. **CI-specific workflow file**: ❌ Creates maintenance burden

## Impact

After merge:
- ✅ check-dependencies workflow will pass
- ✅ Workflow badge will show green/passing status
- ✅ CI test summary will show 14 passed, 1 skipped
- ✅ Local developers still get Azure login validation
- ✅ No changes needed to workflow files

## Verification

Once merged and the workflow runs on main branch:
- Check workflow run: https://github.com/RadekCap/CAPZTests/actions/workflows/check-dependencies.yml
- Workflow should show: ✅ passing
- Test summary should show: 14 passed, 1 skipped
- Azure login test should show: ⏭️ SKIP with message

Fixes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)