### PR TITLE
Extract timeout values into configurable variables (fixes #134)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,13 @@ endif
 # Set to -v for verbose output (default), or empty string for quiet output
 TEST_VERBOSITY ?= -v
 
+# Test timeout configuration
+# Individual phase timeouts (format: Go duration like 30m, 1h, etc.)
+CLUSTER_TIMEOUT ?= 30m
+GENERATE_YAMLS_TIMEOUT ?= 20m
+DEPLOY_CRDS_TIMEOUT ?= 40m
+VERIFY_TIMEOUT ?= 20m
+
 # Results directory configuration
 # Create unique results directory for each test run using timestamp
 TIMESTAMP := $(shell date +%Y%m%d_%H%M%S)
@@ -84,7 +91,7 @@ _cluster: check-gotestsum
 	@echo "=== Running Cluster Deployment Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-cluster.xml -- $(TEST_VERBOSITY) ./test -run TestKindCluster -timeout 30m
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-cluster.xml -- $(TEST_VERBOSITY) ./test -run TestKindCluster -timeout $(CLUSTER_TIMEOUT)
 	@$(MAKE) --no-print-directory _copy-latest-results
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-cluster.xml"
@@ -97,7 +104,7 @@ _generate-yamls: check-gotestsum
 	@echo "=== Running YAML Generation Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-generate-yamls.xml -- $(TEST_VERBOSITY) ./test -run TestInfrastructure -timeout 20m
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-generate-yamls.xml -- $(TEST_VERBOSITY) ./test -run TestInfrastructure -timeout $(GENERATE_YAMLS_TIMEOUT)
 	@$(MAKE) --no-print-directory _copy-latest-results
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-generate-yamls.xml"
@@ -110,7 +117,7 @@ _deploy-crds: check-gotestsum
 	@echo "=== Running CRD Deployment Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-crds.xml -- $(TEST_VERBOSITY) ./test -run TestDeployment -timeout 40m
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-crds.xml -- $(TEST_VERBOSITY) ./test -run TestDeployment -timeout $(DEPLOY_CRDS_TIMEOUT)
 	@$(MAKE) --no-print-directory _copy-latest-results
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-deploy-crds.xml"
@@ -123,7 +130,7 @@ _verify: check-gotestsum
 	@echo "=== Running Cluster Verification Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-verify.xml -- $(TEST_VERBOSITY) ./test -run TestVerification -timeout 20m
+	@$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-verify.xml -- $(TEST_VERBOSITY) ./test -run TestVerification -timeout $(VERIFY_TIMEOUT)
 	@$(MAKE) --no-print-directory _copy-latest-results
 	@echo ""
 	@echo "Test results saved to: $(RESULTS_DIR)/junit-verify.xml"


### PR DESCRIPTION
## Summary
Extracts hardcoded timeout values from Makefile test targets into configurable variables that can be overridden via environment variables.

## Problem
Issue #134 identified that there are four hardcoded timeout values in the Makefile:
- `_cluster` target: 30m
- `_generate-yamls` target: 20m
- `_deploy-crds` target: 40m
- `_verify` target: 20m

These hardcoded values prevent users from customizing timeouts for different environments or longer-running deployments.

## Solution
Extracted all four timeout values into configuration variables at the top of the Makefile:
- `CLUSTER_TIMEOUT` (default: 30m)
- `GENERATE_YAMLS_TIMEOUT` (default: 20m)
- `DEPLOY_CRDS_TIMEOUT` (default: 40m)
- `VERIFY_TIMEOUT` (default: 20m)

These variables use the `?=` operator, allowing users to override them via environment variables while maintaining backward compatibility with the original default values.

## Changes
- Added timeout configuration section in Makefile (lines 21-26)
- Updated `_cluster` target to use `$(CLUSTER_TIMEOUT)`
- Updated `_generate-yamls` target to use `$(GENERATE_YAMLS_TIMEOUT)`
- Updated `_deploy-crds` target to use `$(DEPLOY_CRDS_TIMEOUT)`
- Updated `_verify` target to use `$(VERIFY_TIMEOUT)`

## Usage Examples

Users can now customize timeouts per test phase:

```bash
# Use default timeouts
make _cluster

# Override specific phase timeout
CLUSTER_TIMEOUT=45m make _cluster

# Override multiple timeouts
CLUSTER_TIMEOUT=45m DEPLOY_CRDS_TIMEOUT=1h make test-all
```

## Testing
- ✅ `make test` passed (15 tests in 2.005s)
- ✅ Code formatted with `make fmt`
- ✅ Makefile syntax validated
- ✅ Default behavior unchanged (backward compatible)

## Backward Compatibility
This change is fully backward compatible. All default timeout values remain the same, so existing workflows and CI/CD pipelines will continue to work without modification.

Fixes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)