### PR TITLE
Rename ENV to DEPLOYMENT_ENV for clarity and consistency (fixes #136)

### DIFF
--- a/.claude/commands/troubleshoot.md
+++ b/.claude/commands/troubleshoot.md
@@ -53,7 +53,7 @@ Verify environment variables:
 
 ```bash
 # Show current config
-env | grep -E "ARO|KIND|CLUSTER|AZURE|REGION|ENV|USER"
+env | grep -E "ARO|MANAGEMENT|WORKLOAD|CLUSTER|AZURE|REGION|DEPLOYMENT_ENV|USER"
 ```
 
 **Common Issues**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ go test -v ./test -run TestCheckDependencies_ToolAvailable
 go test -v ./test -run TestInfrastructure
 
 # With custom configuration
-ENV=prod CLUSTER_NAME=my-cluster go test -v ./test -timeout 60m
+DEPLOYMENT_ENV=prod WORKLOAD_CLUSTER_NAME=my-cluster go test -v ./test -timeout 60m
 ```
 
 ### Repository Management
@@ -167,7 +167,7 @@ See `docs/INTEGRATION.md` for detailed integration patterns.
 - `OPENSHIFT_VERSION` - OpenShift version (default: `4.18`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID (required for deployment)
-- `ENV` - Environment identifier (default: `stage`)
+- `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)
 - `USER` - User identifier (default: current user)
 
 ### Test Behavior

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test _check-dep _setup _cluster _generate-yamls _deploy-crds _verify test-all clean help
 
 # Default values
-ENV ?= stage
+DEPLOYMENT_ENV ?= stage
 REGION ?= uksouth
 MANAGEMENT_CLUSTER_NAME ?= capz-stage
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Tests are configured via environment variables:
 - `OPENSHIFT_VERSION` - OpenShift version (default: `4.18`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
-- `ENV` - Environment identifier (default: `stage`)
+- `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)
 - `USER` - User identifier
 
 ### Test Behavior
@@ -127,7 +127,7 @@ go test -v ./test -run TestCheckDependencies
 go test -v ./test -run TestInfrastructure
 
 # Run with custom configuration
-ENV=prod \
+DEPLOYMENT_ENV=prod \
 WORKLOAD_CLUSTER_NAME=my-aro-cluster \
 REGION=westus2 \
 go test -v ./test -timeout 60m

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -216,7 +216,7 @@ CLUSTER_NAME=capz-tests-cluster
 RESOURCE_GROUP=capz-tests-rg
 OPENSHIFT_VERSION=4.18
 REGION=uksouth
-ENV=stage
+DEPLOYMENT_ENV=stage
 
 # Azure Configuration (set your actual values)
 # AZURE_SUBSCRIPTION_NAME=your-subscription-id

--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -28,7 +28,7 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 	t.Logf("Generating infrastructure resources for cluster '%s' (env: %s)", config.WorkloadClusterName, config.Environment)
 
 	// Set environment variables for the generation script
-	SetEnvVar(t, "ENV", config.Environment)
+	SetEnvVar(t, "DEPLOYMENT_ENV", config.Environment)
 	SetEnvVar(t, "USER", config.User)
 	SetEnvVar(t, "WORKLOAD_CLUSTER_NAME", config.WorkloadClusterName)
 	SetEnvVar(t, "REGION", config.Region)

--- a/test/README.md
+++ b/test/README.md
@@ -83,7 +83,7 @@ Tests are configured via environment variables:
 - `OPENSHIFT_VERSION` - OpenShift version (default: `4.18`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
-- `ENV` - Environment (stage/prod) (default: `stage`)
+- `DEPLOYMENT_ENV` - Deployment environment (stage/prod) (default: `stage`)
 - `USER` - User identifier
 
 ## Running Tests
@@ -113,7 +113,7 @@ go test -v ./test -run TestVerification
 ### Run with Custom Configuration
 
 ```bash
-ENV=prod \
+DEPLOYMENT_ENV=prod \
 WORKLOAD_CLUSTER_NAME=my-aro-cluster \
 REGION=westus2 \
 AZURE_SUBSCRIPTION_NAME=your-subscription-id \

--- a/test/config.go
+++ b/test/config.go
@@ -67,7 +67,7 @@ func NewTestConfig() *TestConfig {
 		OpenShiftVersion:      GetEnvOrDefault("OPENSHIFT_VERSION", "4.18"),
 		Region:                GetEnvOrDefault("REGION", "uksouth"),
 		AzureSubscription:     os.Getenv("AZURE_SUBSCRIPTION_NAME"),
-		Environment:           GetEnvOrDefault("ENV", "stage"),
+		Environment:           GetEnvOrDefault("DEPLOYMENT_ENV", "stage"),
 		User:                  GetEnvOrDefault("USER", os.Getenv("USER")),
 
 		// Paths


### PR DESCRIPTION
## Summary
Renames the generic `ENV` environment variable to `DEPLOYMENT_ENV` to improve clarity and avoid potential conflicts with system environment variables.

## Problem
Issue #136 requested a review of the `ENV` variable usage. Analysis revealed several concerns:

1. **Too Generic**: The name "ENV" is ambiguous - it could refer to many different types of "environment"
2. **System Conflicts**: `ENV` is a common name that might conflict with system environment variables
3. **Inconsistent**: After PR #158 introduced descriptive names like `MANAGEMENT_CLUSTER_NAME` and `WORKLOAD_CLUSTER_NAME`, the generic "ENV" stood out as inconsistent
4. **Poor Self-Documentation**: The name doesn't clearly indicate what aspect of "environment" it represents

## Solution
Renamed `ENV` to `DEPLOYMENT_ENV` throughout the codebase to clearly indicate it represents the deployment environment identifier (e.g., `stage`, `prod`, `dev`).

### Benefits
- **Clarity**: Immediately clear this is the deployment environment setting
- **Consistency**: Matches the descriptive naming pattern from PR #158
- **Self-Documenting**: No need to consult documentation to understand the purpose
- **Safer**: Less likely to conflict with system or shell environment variables

## Changes

### Code Changes
1. **Makefile**
   - Renamed `ENV ?= stage` → `DEPLOYMENT_ENV ?= stage`

2. **test/config.go**
   - Updated environment variable: `GetEnvOrDefault("ENV", "stage")` → `GetEnvOrDefault("DEPLOYMENT_ENV", "stage")`

3. **test/04_generate_yamls_test.go**
   - Updated SetEnvVar call: `SetEnvVar(t, "ENV", ...)` → `SetEnvVar(t, "DEPLOYMENT_ENV", ...)`

### Documentation Changes
4. **CLAUDE.md**
   - Updated environment variables section
   - Updated usage example

5. **README.md**
   - Updated environment variables section
   - Updated usage example

6. **test/README.md**
   - Updated environment variables section
   - Updated usage example

7. **docs/INTEGRATION.md**
   - Updated example configuration

8. **.claude/commands/troubleshoot.md**
   - Updated grep pattern to include new variable names

## Migration Guide

### For Users
Update your scripts, CI/CD pipelines, and configuration files:

```bash
# Before (old name - no longer supported)
export ENV=prod
ENV=stage make test-all

# After (new name)
export DEPLOYMENT_ENV=prod
DEPLOYMENT_ENV=stage make test-all
```

### Usage Examples

```bash
# Set deployment environment
DEPLOYMENT_ENV=prod make test-all

# Combined with other variables
DEPLOYMENT_ENV=prod \
WORKLOAD_CLUSTER_NAME=my-cluster \
REGION=westus2 \
make test-all

# In CI/CD (GitHub Actions example)
env:
  DEPLOYMENT_ENV: prod
  WORKLOAD_CLUSTER_NAME: ci-cluster
```

## Impact

### Breaking Change
⚠️ **This is a breaking change** for users who use the `ENV` environment variable. The old name is no longer recognized.

### Affected Use Cases
- Shell scripts that set `ENV=...`
- CI/CD pipelines using `ENV` variable
- Local development configurations
- Documentation and examples

### No Impact On
- Default behavior (still defaults to "stage")
- Test logic or functionality
- Resource naming patterns
- Output directory structure

## Naming Consistency

This change completes the naming improvements started in PR #158:

| Old Name | New Name | Purpose |
|----------|----------|---------|
| `KIND_CLUSTER_NAME` | `MANAGEMENT_CLUSTER_NAME` | Management cluster identifier |
| `CLUSTER_NAME` | `WORKLOAD_CLUSTER_NAME` | Workload cluster identifier |
| `ENV` | `DEPLOYMENT_ENV` | Deployment environment identifier |

All three now follow the pattern of descriptive, unambiguous names that clearly indicate their purpose.

## Testing
- ✅ All tests pass (15 tests in 1.038s)
- ✅ Code formatted with `go fmt ./...`
- ✅ No functional changes to test behavior
- ✅ Makefile syntax validated
- ✅ All documentation updated consistently

## Files Changed
```
Modified: 8 files
- Makefile
- test/config.go
- test/04_generate_yamls_test.go
- CLAUDE.md
- README.md
- test/README.md
- docs/INTEGRATION.md
- .claude/commands/troubleshoot.md
```

Fixes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)