### PR TITLE
Simplify repository structure validation to only check required scripts (fixes #139)

### DIFF
--- a/test/02_setup_test.go
+++ b/test/02_setup_test.go
@@ -37,7 +37,7 @@ func TestSetup_CloneRepository(t *testing.T) {
 	t.Logf("Repository cloned successfully to %s", config.RepoDir)
 }
 
-// TestSetup_VerifyRepositoryStructure verifies the cloned repository has expected structure
+// TestSetup_VerifyRepositoryStructure verifies the cloned repository has required scripts
 func TestSetup_VerifyRepositoryStructure(t *testing.T) {
 	config := NewTestConfig()
 
@@ -45,20 +45,18 @@ func TestSetup_VerifyRepositoryStructure(t *testing.T) {
 		t.Skipf("Repository not cloned yet at %s", config.RepoDir)
 	}
 
-	// Check for expected directories and files
-	expectedPaths := []string{
-		"scripts",
-		"doc/aro-hcp-scripts",
-		"doc/ARO-capz.md",
-		"doc/aro-hcp-scripts/aro-hcp-gen.sh",
+	// Check for scripts actually used by tests
+	requiredScripts := []string{
+		"scripts/deploy-charts-kind-capz.sh", // Used by TestKindCluster_Deploy (03_cluster_test.go)
+		"doc/aro-hcp-scripts/aro-hcp-gen.sh", // Used by TestInfrastructure_GenerateResources (04_generate_yamls_test.go)
 	}
 
-	for _, expectedPath := range expectedPaths {
-		fullPath := filepath.Join(config.RepoDir, expectedPath)
-		if !FileExists(fullPath) && !DirExists(fullPath) {
-			t.Errorf("Expected path does not exist: %s", fullPath)
+	for _, requiredScript := range requiredScripts {
+		fullPath := filepath.Join(config.RepoDir, requiredScript)
+		if !FileExists(fullPath) {
+			t.Errorf("Required script does not exist: %s", fullPath)
 		} else {
-			t.Logf("Found expected path: %s", expectedPath)
+			t.Logf("Found required script: %s", requiredScript)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Simplifies `TestSetup_VerifyRepositoryStructure` to only validate the two shell scripts that are actually used by the test suite, removing unnecessary checks for directories and documentation files.

## Problem
Issue #139 questioned whether all paths being validated were necessary:

```go
expectedPaths := []string{
    "scripts",                    // Directory
    "doc/aro-hcp-scripts",        // Directory  
    "doc/ARO-capz.md",            // Documentation
    "doc/aro-hcp-scripts/aro-hcp-gen.sh",  // Script
}
```

Analysis revealed that only the shell scripts are actually used by tests, while other paths were validated unnecessarily.

## Solution
Simplified the test to only check for the two scripts that are actually executed:

### Before (4 paths)
- ❌ `scripts/` - Directory (redundant with script check)
- ❌ `doc/aro-hcp-scripts/` - Directory (redundant with script check)
- ❌ `doc/ARO-capz.md` - Documentation file (never used by tests)
- ✅ `doc/aro-hcp-scripts/aro-hcp-gen.sh` - Script (used by tests)

### After (2 paths)
- ✅ `scripts/deploy-charts-kind-capz.sh` - Used by `TestKindCluster_Deploy` (03_cluster_test.go)
- ✅ `doc/aro-hcp-scripts/aro-hcp-gen.sh` - Used by `TestInfrastructure_GenerateResources` (04_generate_yamls_test.go)

## Detailed Analysis

### What Tests Actually Use

1. **`scripts/deploy-charts-kind-capz.sh`** ✅
   ```go
   // test/03_cluster_test.go:30
   scriptPath := filepath.Join(config.RepoDir, "scripts", "deploy-charts-kind-capz.sh")
   ```
   - **Purpose**: Deploys Kind management cluster with CAPZ components
   - **Critical**: Yes - required for cluster deployment phase

2. **`doc/aro-hcp-scripts/aro-hcp-gen.sh`** ✅
   ```go
   // test/04_generate_yamls_test.go:19
   genScriptPath := filepath.Join(config.RepoDir, config.GenScriptPath)
   // config.GenScriptPath defaults to "./doc/aro-hcp-scripts/aro-hcp-gen.sh"
   ```
   - **Purpose**: Generates ARO infrastructure YAML resources
   - **Critical**: Yes - required for infrastructure generation phase

### What Tests Don't Use

3. **`doc/ARO-capz.md`** ❌
   - Only referenced in documentation hyperlinks (TEST_COVERAGE.md, test/README.md)
   - Tests never read or execute this file
   - Removing it from validation doesn't affect test functionality
   - Creates unnecessary coupling to documentation structure

4. **Directory checks** ❌
   - Checking for `scripts/` directory is redundant when checking `scripts/deploy-charts-kind-capz.sh`
   - Checking for `doc/aro-hcp-scripts/` directory is redundant when checking the script within it
   - File existence implies parent directory existence

## Changes

### Code Changes
**test/02_setup_test.go**:
```go
// Before
expectedPaths := []string{
    "scripts",
    "doc/aro-hcp-scripts", 
    "doc/ARO-capz.md",
    "doc/aro-hcp-scripts/aro-hcp-gen.sh",
}

// After  
requiredScripts := []string{
    "scripts/deploy-charts-kind-capz.sh",     // Used by TestKindCluster_Deploy
    "doc/aro-hcp-scripts/aro-hcp-gen.sh",     // Used by TestInfrastructure_GenerateResources
}
```

### Additional Improvements
- **Renamed variable**: `expectedPaths` → `requiredScripts` (clearer intent)
- **Updated comment**: Function comment now reflects simplified purpose
- **Added documentation**: Inline comments show which test uses each script
- **Removed hybrid logic**: No longer checks both files AND directories

## Benefits

### Clarity
- ✅ Test purpose is immediately clear: "validate required scripts exist"
- ✅ Variable names are self-documenting
- ✅ Comments link scripts to the tests that use them

### Maintainability  
- ✅ Less code to maintain (10 lines vs 12 lines)
- ✅ Fewer false positives (documentation changes won't break tests)
- ✅ Easier to understand what's actually required

### Performance
- ✅ Faster execution (2 checks instead of 4)
- ✅ Simpler validation logic

### Coupling
- ✅ Reduced coupling to repository structure
- ✅ Tests only depend on what they actually use
- ✅ Documentation can evolve independently

## Testing

### Test Execution
```bash
$ go test -v ./test -run TestSetup
=== RUN   TestSetup_CloneRepository
--- PASS: TestSetup_CloneRepository (1.91s)
=== RUN   TestSetup_VerifyRepositoryStructure
    02_setup_test.go:59: Found required script: scripts/deploy-charts-kind-capz.sh
    02_setup_test.go:59: Found required script: doc/aro-hcp-scripts/aro-hcp-gen.sh
--- PASS: TestSetup_VerifyRepositoryStructure (0.00s)
=== RUN   TestSetup_ScriptPermissions
--- PASS: TestSetup_ScriptPermissions (0.00s)
PASS
ok      github.com/rcap/CAPZTests/test  2.566s
```

- ✅ All setup tests pass (3 tests)
- ✅ All check dependencies tests pass (15 tests)
- ✅ Code formatted with `go fmt`
- ✅ No functional changes to test behavior

## Impact

### No Breaking Changes
- Same validation coverage for what actually matters
- Tests still fail if required scripts are missing
- No changes to how other tests function

### Better Test Design
This change follows the testing principle:
> "Test only what you use, use only what you test"

The old validation was checking things "just in case" rather than validating actual requirements.

## Files Changed
```
Modified: 1 file
- test/02_setup_test.go (-2 checks, clearer logic)
```

Fixes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)