### PR TITLE
Update namespaces check to remove kubeadm namespaces (fixes #146)

### DIFF
--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -106,8 +106,6 @@ func TestKindCluster_CAPIComponents(t *testing.T) {
 	expectedNamespaces := []string{
 		"capi-system",
 		"capz-system",
-		"capi-kubeadm-bootstrap-system",
-		"capi-kubeadm-control-plane-system",
 	}
 
 	for _, ns := range expectedNamespaces {


### PR DESCRIPTION
## Summary
Removed unnecessary kubeadm namespace checks from the CAPI components verification in the cluster deployment tests.

## Problem
Issue #146 identified that the namespace check in `test/03_cluster_test.go` was validating namespaces that aren't relevant for ARO-CAPZ deployments:
- `capi-kubeadm-bootstrap-system`
- `capi-kubeadm-control-plane-system`

These namespaces are only needed when using the kubeadm bootstrap and control plane providers, but ARO-CAPZ uses Azure Service Operator (ASO) instead.

## Solution
Removed the two unnecessary namespace entries from the `expectedNamespaces` array, keeping only the namespaces that are actually required:
- `capi-system` - Core Cluster API components
- `capz-system` - Azure provider components

## Changes

### Code Changes
- **test/03_cluster_test.go** (lines 106-109):
  - Removed `capi-kubeadm-bootstrap-system` from expectedNamespaces
  - Removed `capi-kubeadm-control-plane-system` from expectedNamespaces
  - Kept only `capi-system` and `capz-system` which are the required namespaces for ARO-CAPZ

## Testing
- ✅ All dependency tests pass (`make test`)
- ✅ Code formatted with `go fmt`
- ✅ Namespace check logic remains functional with reduced set

## Files Changed
1 file changed, 2 deletions(-)
- test/03_cluster_test.go (updated)

Fixes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)