### PR TITLE
Make help the default target when running 'make'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ LATEST_RESULTS_DIR := results/latest
 GOBIN := $(shell if [ -n "$$(go env GOBIN 2>/dev/null)" ]; then go env GOBIN; else echo "$$(go env GOPATH 2>/dev/null || echo "$$HOME/go")/bin"; fi)
 GOTESTSUM := $(GOBIN)/gotestsum --format='$(GOTESTSUM_FORMAT)'
 
+# Default target - show help when running 'make' with no arguments
+.DEFAULT_GOAL := help
+
 # Internal target to copy latest results
 .PHONY: _copy-latest-results
 _copy-latest-results:


### PR DESCRIPTION
## Summary
Makes the help message display by default when running `make` with no arguments, improving user experience and discoverability.

## Problem
Previously, running `make` with no arguments would execute the first target defined in the Makefile (`_copy-latest-results`), which is an internal utility target. This was unintuitive and not helpful for users trying to discover available commands.

Users had to know to type `make help` to see available targets, which is not discoverable.

## Solution
Added `.DEFAULT_GOAL := help` to the Makefile to explicitly set the default target to `help`.

This is a common Makefile convention that makes the tool more user-friendly and follows best practices.

## Changes
- Added `.DEFAULT_GOAL := help` directive (line 39)
- Added explanatory comment for clarity

## Impact
**Before:**
```bash
$ make
# Would execute _copy-latest-results (confusing)
```

**After:**
```bash
$ make
# Displays help message showing all available targets
```

## Testing
- ✅ Running `make` now displays help message
- ✅ All existing targets still work (`make test`, `make test-all`, etc.)
- ✅ No functional changes to any targets

## Benefits
- Better user experience for new users
- Improved discoverability of available commands
- Follows common Makefile conventions
- No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)