### PR TITLE
Ensure JUnit XML results are saved even when tests fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,10 @@ _check-dep: check-gotestsum
 	@echo "=== Running Check Dependencies Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@set -e; \
-	EXIT_CODE=0; \
+	@EXIT_CODE=0; \
 	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-check-dep.xml -- $(TEST_VERBOSITY) ./test -run TestCheckDependencies || EXIT_CODE=$$?; \
-	$(MAKE) --no-print-directory _copy-latest-results; \
+	mkdir -p $(LATEST_RESULTS_DIR); \
+	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \
 	echo "Test results saved to: $(RESULTS_DIR)/junit-check-dep.xml"; \
 	echo "Latest results copied to: $(LATEST_RESULTS_DIR)/"; \
@@ -87,10 +87,10 @@ _setup: check-gotestsum
 	@echo "=== Running Repository Setup Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@set -e; \
-	EXIT_CODE=0; \
+	@EXIT_CODE=0; \
 	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-setup.xml -- $(TEST_VERBOSITY) ./test -run TestSetup || EXIT_CODE=$$?; \
-	$(MAKE) --no-print-directory _copy-latest-results; \
+	mkdir -p $(LATEST_RESULTS_DIR); \
+	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \
 	echo "Test results saved to: $(RESULTS_DIR)/junit-setup.xml"; \
 	echo "Latest results copied to: $(LATEST_RESULTS_DIR)/"; \
@@ -107,10 +107,10 @@ _cluster: check-gotestsum
 	@echo "=== Running Cluster Deployment Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@set -e; \
-	EXIT_CODE=0; \
+	@EXIT_CODE=0; \
 	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-cluster.xml -- $(TEST_VERBOSITY) ./test -run TestKindCluster -timeout $(CLUSTER_TIMEOUT) || EXIT_CODE=$$?; \
-	$(MAKE) --no-print-directory _copy-latest-results; \
+	mkdir -p $(LATEST_RESULTS_DIR); \
+	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \
 	echo "Test results saved to: $(RESULTS_DIR)/junit-cluster.xml"; \
 	echo "Latest results copied to: $(LATEST_RESULTS_DIR)/"; \
@@ -127,10 +127,10 @@ _generate-yamls: check-gotestsum
 	@echo "=== Running YAML Generation Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@set -e; \
-	EXIT_CODE=0; \
+	@EXIT_CODE=0; \
 	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-generate-yamls.xml -- $(TEST_VERBOSITY) ./test -run TestInfrastructure -timeout $(GENERATE_YAMLS_TIMEOUT) || EXIT_CODE=$$?; \
-	$(MAKE) --no-print-directory _copy-latest-results; \
+	mkdir -p $(LATEST_RESULTS_DIR); \
+	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \
 	echo "Test results saved to: $(RESULTS_DIR)/junit-generate-yamls.xml"; \
 	echo "Latest results copied to: $(LATEST_RESULTS_DIR)/"; \
@@ -147,10 +147,10 @@ _deploy-crs: check-gotestsum
 	@echo "=== Running CR Deployment Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@set -e; \
-	EXIT_CODE=0; \
+	@EXIT_CODE=0; \
 	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-crs.xml -- $(TEST_VERBOSITY) ./test -run TestDeployment -timeout $(DEPLOY_CRS_TIMEOUT) || EXIT_CODE=$$?; \
-	$(MAKE) --no-print-directory _copy-latest-results; \
+	mkdir -p $(LATEST_RESULTS_DIR); \
+	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \
 	echo "Test results saved to: $(RESULTS_DIR)/junit-deploy-crs.xml"; \
 	echo "Latest results copied to: $(LATEST_RESULTS_DIR)/"; \
@@ -167,10 +167,10 @@ _verify: check-gotestsum
 	@echo "=== Running Cluster Verification Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
-	@set -e; \
-	EXIT_CODE=0; \
+	@EXIT_CODE=0; \
 	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-verify.xml -- $(TEST_VERBOSITY) ./test -run TestVerification -timeout $(VERIFY_TIMEOUT) || EXIT_CODE=$$?; \
-	$(MAKE) --no-print-directory _copy-latest-results; \
+	mkdir -p $(LATEST_RESULTS_DIR); \
+	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \
 	echo "Test results saved to: $(RESULTS_DIR)/junit-verify.xml"; \
 	echo "Latest results copied to: $(LATEST_RESULTS_DIR)/"; \


### PR DESCRIPTION
## Summary

Fixes an issue where JUnit XML test results were not being saved to `results/latest/` when tests failed, making it difficult to diagnose test failures in CI/CD pipelines.

### Problem

When running test targets (e.g., `make _cluster`), if the tests failed:
- The Makefile would exit immediately after `gotestsum` returned a non-zero exit code
- The `_copy-latest-results` target never executed
- Status messages were not displayed
- JUnit XML files were created but not copied to the `results/latest/` directory
- CI/CD systems couldn't access the test results for failed test runs

### Solution

Modified all test targets (`_check-dep`, `_setup`, `_cluster`, `_generate-yamls`, `_deploy-crs`, `_verify`) to:
1. **Capture exit codes**: Use `|| EXIT_CODE=$$?` to capture the gotestsum exit code without immediate exit
2. **Always run cleanup**: Copy results to `results/latest/` regardless of test success/failure
3. **Display status**: Show appropriate success (✅) or failure (❌) messages
4. **Preserve exit status**: Exit with the original error code to maintain proper error signaling for Make and CI/CD

### Benefits

- JUnit XML files are now always available in `results/latest/` even when tests fail
- Better CI/CD integration - test reporting tools can always find the results
- Clearer user feedback with explicit success/failure indicators
- Maintains proper exit codes for scripting and automation

## Test Plan

- [x] Verified Makefile syntax is valid (`make help`)
- [x] Ran successful test (`make test`) - results copied correctly
- [x] Verified `results/latest/` directory contains JUnit XML files
- [x] Code review to ensure all test targets follow the same pattern

## Related Issues

Addresses the general issue of JUnit XML output not being available when tests fail, particularly noted with `make _cluster`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)