### PR TITLE
Restore accidentally removed Verify tests (fixes #182)

### DIFF
--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -148,6 +148,93 @@ func TestDeployment_ApplyAROClusterYAML(t *testing.T) {
 	t.Logf("Successfully applied %s", file)
 }
 
+// TestDeployment_VerifyCredentialsYAML verifies credentials.yaml exists and is valid
+func TestDeployment_VerifyCredentialsYAML(t *testing.T) {
+	t.Log("Verifying credentials.yaml")
+
+	config := NewTestConfig()
+	outputDir := filepath.Join(config.RepoDir, config.GetOutputDirName())
+
+	if !DirExists(outputDir) {
+		t.Skipf("Output directory does not exist: %s", outputDir)
+	}
+
+	filePath := filepath.Join(outputDir, "credentials.yaml")
+	if !FileExists(filePath) {
+		t.Errorf("credentials.yaml not found")
+		return
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("Failed to stat credentials.yaml: %v", err)
+	}
+
+	if info.Size() == 0 {
+		t.Errorf("credentials.yaml is empty")
+	} else {
+		t.Logf("credentials.yaml is valid (size: %d bytes)", info.Size())
+	}
+}
+
+// TestDeployment_VerifyInfrastructureSecretsYAML verifies is.yaml exists and is valid
+func TestDeployment_VerifyInfrastructureSecretsYAML(t *testing.T) {
+	t.Log("Verifying is.yaml (infrastructure secrets)")
+
+	config := NewTestConfig()
+	outputDir := filepath.Join(config.RepoDir, config.GetOutputDirName())
+
+	if !DirExists(outputDir) {
+		t.Skipf("Output directory does not exist: %s", outputDir)
+	}
+
+	filePath := filepath.Join(outputDir, "is.yaml")
+	if !FileExists(filePath) {
+		t.Errorf("is.yaml not found")
+		return
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("Failed to stat is.yaml: %v", err)
+	}
+
+	if info.Size() == 0 {
+		t.Errorf("is.yaml is empty")
+	} else {
+		t.Logf("is.yaml is valid (size: %d bytes)", info.Size())
+	}
+}
+
+// TestDeployment_VerifyAROClusterYAML verifies aro.yaml exists and is valid
+func TestDeployment_VerifyAROClusterYAML(t *testing.T) {
+	t.Log("Verifying aro.yaml (ARO cluster configuration)")
+
+	config := NewTestConfig()
+	outputDir := filepath.Join(config.RepoDir, config.GetOutputDirName())
+
+	if !DirExists(outputDir) {
+		t.Skipf("Output directory does not exist: %s", outputDir)
+	}
+
+	filePath := filepath.Join(outputDir, "aro.yaml")
+	if !FileExists(filePath) {
+		t.Errorf("aro.yaml not found")
+		return
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("Failed to stat aro.yaml: %v", err)
+	}
+
+	if info.Size() == 0 {
+		t.Errorf("aro.yaml is empty")
+	} else {
+		t.Logf("aro.yaml is valid (size: %d bytes)", info.Size())
+	}
+}
+
 // TestDeployment_MonitorCluster tests monitoring the ARO cluster deployment
 func TestDeployment_MonitorCluster(t *testing.T) {
 


### PR DESCRIPTION
## Summary

Restored the three Verify tests that were accidentally removed in PR #181 to the TestDeployment phase where they belong.

## Problem

Issue #182 identified that three Verify tests were accidentally removed during the refactoring in PR #181:
- `TestInfrastructure_VerifyCredentialsYAML`
- `TestInfrastructure_VerifyInfrastructureSecretsYAML`
- `TestInfrastructure_VerifyAROClusterYAML`

These tests should have been moved to the TestDeployment phase along with the Apply tests, but were omitted from the refactoring.

## Solution

Restored all three Verify tests as `TestDeployment_Verify*YAML` functions in the deployment phase (test/05_deploy_crs_test.go), placing them in the logical sequence after Apply tests and before Monitor tests.

## Changes

### test/05_deploy_crs_test.go

**Added 3 Verify tests** (87 lines):
- ✅ `TestDeployment_VerifyCredentialsYAML` - verifies credentials.yaml exists and has valid content
- ✅ `TestDeployment_VerifyInfrastructureSecretsYAML` - verifies is.yaml exists and has valid content  
- ✅ `TestDeployment_VerifyAROClusterYAML` - verifies aro.yaml exists and has valid content

**Implementation details**:
- Adapted from original `TestInfrastructure_Verify*` versions (commit 1eaa07b)
- Removed dependency on deleted `verifyYAMLFileExists` helper function
- Inlined file existence checking and validation logic
- Follow same patterns as Apply tests (config, outputDir, proper error handling)
- Positioned after Apply tests (lines 151-236) for logical test flow

**Each test**:
1. Checks if output directory exists (skip if not)
2. Verifies the specific YAML file exists
3. Validates file size is not empty
4. Logs file size for debugging

## Testing

```bash
# Test all three restored tests
$ go test -v ./test -run TestDeployment_VerifyCredentialsYAML
✅ PASS - credentials.yaml is valid (size: 896 bytes)

$ go test -v ./test -run TestDeployment_VerifyInfrastructureSecretsYAML
✅ PASS - is.yaml is valid (size: 32070 bytes)

$ go test -v ./test -run TestDeployment_VerifyAROClusterYAML
✅ PASS - aro.yaml is valid (size: 6112 bytes)

# Code formatting
$ go fmt ./...
✅ All files formatted
```

**Sample output**:
```
=== RUN   TestDeployment_VerifyCredentialsYAML
    05_deploy_crs_test.go:153: Verifying credentials.yaml
    05_deploy_crs_test.go:176: credentials.yaml is valid (size: 896 bytes)
--- PASS: TestDeployment_VerifyCredentialsYAML (0.00s)
```

## Benefits

1. **Restores Missing Functionality**: Tests that verify generated YAML files are now back in the test suite
2. **Correct Placement**: Tests are in the deployment phase where they logically belong
3. **Granular Validation**: Each YAML file has its own dedicated verify test for clear failure reporting
4. **Maintains Test Flow**: Positioned correctly in the sequential test execution (Apply → Verify → Monitor)

## Code Quality

- ✅ All tests compile successfully
- ✅ Tests are idempotent and can run sequentially
- ✅ Follows repository patterns from CLAUDE.md
- ✅ Uses centralized configuration via `NewTestConfig()`
- ✅ Proper error handling with `t.Errorf()` for non-fatal, `t.Fatalf()` for fatal errors
- ✅ Code formatted with `go fmt`

## Historical Context

**Original location**: test/04_generate_yamls_test.go (as `TestInfrastructure_Verify*`)  
**Removed in**: PR #181 (commit e6f1f35)  
**Should have been**: Moved to test/05_deploy_crs_test.go along with Apply tests  
**Restored as**: `TestDeployment_Verify*YAML` in the deployment phase

Fixes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)