### PR TITLE
Disable Go test caching for all test phases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ _check-dep: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-check-dep.xml -- $(TEST_VERBOSITY) ./test -run TestCheckDependencies || EXIT_CODE=$$?; \
+	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-check-dep.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestCheckDependencies || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \
@@ -88,7 +88,7 @@ _setup: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-setup.xml -- $(TEST_VERBOSITY) ./test -run TestSetup || EXIT_CODE=$$?; \
+	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-setup.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestSetup || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \
@@ -108,7 +108,7 @@ _cluster: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-cluster.xml -- $(TEST_VERBOSITY) ./test -run TestKindCluster -timeout $(CLUSTER_TIMEOUT) || EXIT_CODE=$$?; \
+	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-cluster.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestKindCluster -timeout $(CLUSTER_TIMEOUT) || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \
@@ -128,7 +128,7 @@ _generate-yamls: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-generate-yamls.xml -- $(TEST_VERBOSITY) ./test -run TestInfrastructure -timeout $(GENERATE_YAMLS_TIMEOUT) || EXIT_CODE=$$?; \
+	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-generate-yamls.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestInfrastructure -timeout $(GENERATE_YAMLS_TIMEOUT) || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \
@@ -148,7 +148,7 @@ _deploy-crs: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-crs.xml -- $(TEST_VERBOSITY) ./test -run TestDeployment -timeout $(DEPLOY_CRS_TIMEOUT) || EXIT_CODE=$$?; \
+	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-crs.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestDeployment -timeout $(DEPLOY_CRS_TIMEOUT) || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \
@@ -168,7 +168,7 @@ _verify: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-verify.xml -- $(TEST_VERBOSITY) ./test -run TestVerification -timeout $(VERIFY_TIMEOUT) || EXIT_CODE=$$?; \
+	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-verify.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestVerification -timeout $(VERIFY_TIMEOUT) || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \


### PR DESCRIPTION
## Summary

Added `-count=1` flag to all test targets in the Makefile to disable Go's test result caching. This fixes a critical bug where tests with side effects (cloning repositories, creating clusters) would use cached results instead of re-executing after `make clean`.

## Problem

Go caches test results by default for performance. However, this causes serious issues for integration tests with side effects:

### Failure Scenario
```bash
# First run - everything works
make _setup          # Clones repo to /tmp/cluster-api-installer-aro
make _generate-yamls # Works fine

# Clean up
make clean           # Deletes /tmp/cluster-api-installer-aro

# Second run - FAILS
make _setup          # Shows "PASS test (cached)" - DOESN'T ACTUALLY CLONE!
make _generate-yamls # SKIP: Repository not cloned yet ❌
```

### Root Cause
1. First `make _setup` runs → clones repo → tests pass → Go caches result
2. `make clean` deletes the repository directory
3. Second `make _setup` runs → Go sees cached pass → **doesn't re-run tests**
4. Repository never gets cloned again
5. All subsequent tests fail with "Repository not cloned yet"

This breaks the fundamental assumption that running `make _setup` will ensure the repository exists.

## Solution

Added `-count=1` flag to all test commands in these targets:
- `_check-dep` - Check dependencies
- `_setup` - Repository setup (CRITICAL for repo cloning)
- `_cluster` - Cluster deployment
- `_generate-yamls` - YAML generation
- `_deploy-crs` - CR deployment
- `_verify` - Cluster verification

### What `-count=1` Does
The `-count=1` flag tells Go to run each test exactly once, effectively disabling the test result cache. This is the standard practice for integration tests with side effects.

## Changes

**Makefile** - Modified 6 test targets:
```diff
-$(GOTESTSUM) ... -- $(TEST_VERBOSITY) ./test -run TestSetup || EXIT_CODE=$$?; \
+$(GOTESTSUM) ... -- $(TEST_VERBOSITY) ./test -count=1 -run TestSetup || EXIT_CODE=$$?; \
```

Same change applied to:
- Line 71: `_check-dep`
- Line 91: `_setup` ⭐ Most critical
- Line 111: `_cluster`
- Line 131: `_generate-yamls`
- Line 151: `_deploy-crs`
- Line 171: `_verify`

## Impact

### ✅ Benefits
- **Tests always execute** - No more cached results masking missing prerequisites
- **Idempotent workflows** - `make clean && make _setup` works reliably
- **CI/CD reliability** - Fresh environments always get fresh test runs
- **Developer experience** - No confusion about why setup "passed" but repo doesn't exist

### ⚠️ Trade-offs
- **Slightly slower** - Tests re-run every time (but this is correct behavior!)
- **Negligible impact** - Most test time is cluster creation, not test execution
- **Acceptable cost** - Correctness > speed for integration tests

## Testing

### Before Fix
```bash
$ make clean  # Delete repo
$ make _setup
=== Running Repository Setup Tests ===
PASS test (cached)  # ❌ Repo NOT cloned!
$ ls /tmp/cluster-api-installer-aro
ls: cannot access: No such file or directory  # ❌
```

### After Fix
```bash
$ make clean  # Delete repo
$ make _setup
=== Running Repository Setup Tests ===
PASS test.TestSetup_CloneRepository (0.93s)  # ✅ Actually runs!
$ ls /tmp/cluster-api-installer-aro
charts  config  doc  scripts  ...  # ✅ Repo exists!
```

## References

- **Go test caching documentation**: https://pkg.go.dev/cmd/go#hdr-Testing_flags
- **Best practice**: Integration tests with side effects should always use `-count=1`
- **Common pattern**: See kubernetes/kubernetes, docker/docker, and other large Go projects

## Checklist

- [x] Identified root cause (Go test caching)
- [x] Applied fix to all test targets
- [x] Tested fix (repo clones after clean)
- [x] Verified no performance regression (negligible impact)
- [x] Documented problem and solution

🤖 Generated with [Claude Code](https://claude.com/claude-code)