### PR TITLE
Add real-time output to long-running tests

### DIFF
--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -17,22 +17,36 @@ func TestKindCluster_KindClusterReady(t *testing.T) {
 	config := NewTestConfig()
 
 	if !DirExists(config.RepoDir) {
+		fmt.Fprintf(os.Stderr, "⚠️  Repository not cloned yet at %s\n", config.RepoDir)
+		os.Stderr.Sync() // Force immediate output
 		t.Skipf("Repository not cloned yet at %s", config.RepoDir)
 	}
 
 	// Check if cluster already exists
+	fmt.Fprintf(os.Stderr, "\n=== Checking for existing Kind cluster ===\n")
+	os.Stderr.Sync() // Force immediate output
 	t.Log("Checking for existing Kind cluster")
 	output, _ := RunCommand(t, "kind", "get", "clusters")
 	clusterExists := strings.Contains(output, config.ManagementClusterName)
 
 	if !clusterExists {
+		fmt.Fprintf(os.Stderr, "Kind cluster '%s' not found - will deploy new cluster\n", config.ManagementClusterName)
+		os.Stderr.Sync() // Force immediate output
+
 		// Deploy Kind cluster using the script
 		scriptPath := filepath.Join(config.RepoDir, "scripts", "deploy-charts-kind-capz.sh")
 		if !FileExists(scriptPath) {
+			fmt.Fprintf(os.Stderr, "❌ Deployment script not found: %s\n", scriptPath)
+			os.Stderr.Sync() // Force immediate output
 			t.Errorf("Deployment script not found: %s", scriptPath)
 			return
 		}
 
+		fmt.Fprintf(os.Stderr, "\n=== Deploying Kind cluster '%s' ===\n", config.ManagementClusterName)
+		fmt.Fprintf(os.Stderr, "This will: create Kind cluster, install cert-manager, deploy CAPI/CAPZ/ASO controllers\n")
+		fmt.Fprintf(os.Stderr, "Expected duration: 5-10 minutes\n")
+		fmt.Fprintf(os.Stderr, "Output streaming below...\n\n")
+		os.Stderr.Sync() // Force immediate output
 		t.Logf("Deploying Kind cluster '%s' using script", config.ManagementClusterName)
 
 		// Set environment variable for the script (deploy-charts-kind-capz.sh expects KIND_CLUSTER_NAME)
@@ -58,17 +72,25 @@ func TestKindCluster_KindClusterReady(t *testing.T) {
 		output, err = RunCommandWithStreaming(t, "bash", scriptPath)
 		if err != nil {
 			// On error, show output for debugging (may contain sensitive info, but needed for troubleshooting)
+			fmt.Fprintf(os.Stderr, "\n❌ Failed to deploy Kind cluster: %v\n", err)
+			os.Stderr.Sync() // Force immediate output
 			t.Errorf("Failed to deploy Kind cluster: %v\nOutput: %s", err, output)
 			return
 		}
 
 		// Don't log full script output as it may contain sensitive Azure configuration
+		fmt.Fprintf(os.Stderr, "\n✅ Kind cluster deployment script completed successfully\n\n")
+		os.Stderr.Sync() // Force immediate output
 		t.Log("Kind cluster deployment script completed successfully")
 	} else {
+		fmt.Fprintf(os.Stderr, "✅ Kind cluster '%s' already exists\n\n", config.ManagementClusterName)
+		os.Stderr.Sync() // Force immediate output
 		t.Logf("Kind cluster '%s' already exists", config.ManagementClusterName)
 	}
 
 	// Verify cluster is accessible via kubectl
+	fmt.Fprintf(os.Stderr, "=== Verifying cluster accessibility ===\n")
+	os.Stderr.Sync() // Force immediate output
 	t.Log("Verifying cluster accessibility...")
 
 	// Set kubeconfig context
@@ -76,10 +98,15 @@ func TestKindCluster_KindClusterReady(t *testing.T) {
 
 	output, err := RunCommand(t, "kubectl", "--context", fmt.Sprintf("kind-%s", config.ManagementClusterName), "get", "nodes")
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "❌ Failed to access Kind cluster nodes: %v\nOutput: %s\n\n", err, output)
+		os.Stderr.Sync() // Force immediate output
 		t.Errorf("Failed to access Kind cluster nodes: %v\nOutput: %s", err, output)
 		return
 	}
 
+	fmt.Fprintf(os.Stderr, "✅ Kind cluster nodes:\n%s\n\n", output)
+	fmt.Fprintf(os.Stderr, "✅ Kind cluster is ready\n\n")
+	os.Stderr.Sync() // Force immediate output
 	t.Logf("Kind cluster nodes:\n%s", output)
 	t.Log("Kind cluster is ready")
 }
@@ -91,6 +118,8 @@ func TestKindCluster_CAPINamespacesExists(t *testing.T) {
 
 	config := NewTestConfig()
 
+	fmt.Fprintf(os.Stderr, "\n=== Checking for CAPI namespaces ===\n")
+	os.Stderr.Sync() // Force immediate output
 	t.Log("Checking for CAPI namespaces...")
 
 	context := fmt.Sprintf("kind-%s", config.ManagementClusterName)
@@ -102,22 +131,39 @@ func TestKindCluster_CAPINamespacesExists(t *testing.T) {
 	}
 
 	for _, ns := range expectedNamespaces {
+		fmt.Fprintf(os.Stderr, "Checking namespace: %s...\n", ns)
+		os.Stderr.Sync() // Force immediate output
+
 		_, err := RunCommand(t, "kubectl", "--context", context, "get", "namespace", ns)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "⚠️  Namespace '%s' may not exist yet (this might be expected): %v\n", ns, err)
+			os.Stderr.Sync() // Force immediate output
 			t.Logf("Namespace '%s' may not exist yet (this might be expected): %v", ns, err)
 		} else {
+			fmt.Fprintf(os.Stderr, "✅ Found namespace: %s\n", ns)
+			os.Stderr.Sync() // Force immediate output
 			t.Logf("Found namespace: %s", ns)
 		}
 	}
 
 	// Wait a bit for controllers to be ready
+	fmt.Fprintf(os.Stderr, "\nWaiting 5 seconds for controllers to initialize...\n")
+	os.Stderr.Sync() // Force immediate output
 	time.Sleep(5 * time.Second)
 
 	// Check for CAPI pods
+	fmt.Fprintf(os.Stderr, "\n=== Checking for CAPI pods ===\n")
+	fmt.Fprintf(os.Stderr, "Running: kubectl get pods -A --selector=cluster.x-k8s.io/provider\n")
+	os.Stderr.Sync() // Force immediate output
+
 	output, err := RunCommand(t, "kubectl", "--context", context, "get", "pods", "-A", "--selector=cluster.x-k8s.io/provider")
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  CAPI pods check failed: %v\nOutput: %s\n\n", err, output)
+		os.Stderr.Sync() // Force immediate output
 		t.Logf("CAPI pods check: %v\nOutput: %s", err, output)
 	} else {
+		fmt.Fprintf(os.Stderr, "✅ CAPI pods found:\n%s\n\n", output)
+		os.Stderr.Sync() // Force immediate output
 		t.Logf("CAPI pods:\n%s", output)
 	}
 }
@@ -130,18 +176,29 @@ func TestKindCluster_CAPIControllerReady(t *testing.T) {
 	config := NewTestConfig()
 	context := fmt.Sprintf("kind-%s", config.ManagementClusterName)
 
+	fmt.Fprintf(os.Stderr, "\n=== Waiting for CAPI controller manager ===\n")
+	fmt.Fprintf(os.Stderr, "Namespace: capi-system\n")
+	fmt.Fprintf(os.Stderr, "Deployment: capi-controller-manager\n")
+	fmt.Fprintf(os.Stderr, "Timeout: 10m\n")
+	fmt.Fprintf(os.Stderr, "Running: kubectl wait deployment/capi-controller-manager --for condition=Available\n\n")
+	os.Stderr.Sync() // Force immediate output
+
 	// Wait for CAPI controller manager deployment to be available
 	// kubectl -n capi-system wait deployment/capi-controller-manager --for condition=Available --timeout=10m
-	output, err := RunCommand(t, "kubectl", "--context", context, "-n", "capi-system",
+	output, err := RunCommandWithStreaming(t, "kubectl", "--context", context, "-n", "capi-system",
 		"wait", "deployment/capi-controller-manager",
 		"--for", "condition=Available",
 		"--timeout=10m")
 
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "\n❌ CAPI controller manager deployment is not available: %v\n\n", err)
+		os.Stderr.Sync() // Force immediate output
 		t.Errorf("CAPI controller manager deployment is not available: %v\nOutput: %s", err, output)
 		return
 	}
 
+	fmt.Fprintf(os.Stderr, "\n✅ CAPI controller manager deployment is available\n\n")
+	os.Stderr.Sync() // Force immediate output
 	t.Log("CAPI controller manager deployment is available")
 }
 
@@ -153,18 +210,29 @@ func TestKindCluster_CAPZControllerReady(t *testing.T) {
 	config := NewTestConfig()
 	context := fmt.Sprintf("kind-%s", config.ManagementClusterName)
 
+	fmt.Fprintf(os.Stderr, "\n=== Waiting for CAPZ controller manager ===\n")
+	fmt.Fprintf(os.Stderr, "Namespace: capz-system\n")
+	fmt.Fprintf(os.Stderr, "Deployment: capz-controller-manager\n")
+	fmt.Fprintf(os.Stderr, "Timeout: 10m\n")
+	fmt.Fprintf(os.Stderr, "Running: kubectl wait deployment/capz-controller-manager --for condition=Available\n\n")
+	os.Stderr.Sync() // Force immediate output
+
 	// Wait for CAPZ controller manager deployment to be available
 	// kubectl -n capz-system wait deployment/capz-controller-manager --for condition=Available --timeout=10m
-	output, err := RunCommand(t, "kubectl", "--context", context, "-n", "capz-system",
+	output, err := RunCommandWithStreaming(t, "kubectl", "--context", context, "-n", "capz-system",
 		"wait", "deployment/capz-controller-manager",
 		"--for", "condition=Available",
 		"--timeout=10m")
 
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "\n❌ CAPZ controller manager deployment is not available: %v\n\n", err)
+		os.Stderr.Sync() // Force immediate output
 		t.Errorf("CAPZ controller manager deployment is not available: %v\nOutput: %s", err, output)
 		return
 	}
 
+	fmt.Fprintf(os.Stderr, "\n✅ CAPZ controller manager deployment is available\n\n")
+	os.Stderr.Sync() // Force immediate output
 	t.Log("CAPZ controller manager deployment is available")
 }
 
@@ -176,17 +244,28 @@ func TestKindCluster_ASOControllerReady(t *testing.T) {
 	config := NewTestConfig()
 	context := fmt.Sprintf("kind-%s", config.ManagementClusterName)
 
+	fmt.Fprintf(os.Stderr, "\n=== Waiting for Azure Service Operator controller manager ===\n")
+	fmt.Fprintf(os.Stderr, "Namespace: capz-system\n")
+	fmt.Fprintf(os.Stderr, "Deployment: azureserviceoperator-controller-manager\n")
+	fmt.Fprintf(os.Stderr, "Timeout: 10m\n")
+	fmt.Fprintf(os.Stderr, "Running: kubectl wait deployment/azureserviceoperator-controller-manager --for condition=Available\n\n")
+	os.Stderr.Sync() // Force immediate output
+
 	// Wait for ASO controller manager deployment to be available
 	// kubectl -n capz-system wait deployment/azureserviceoperator-controller-manager --for condition=Available --timeout=10m
-	output, err := RunCommand(t, "kubectl", "--context", context, "-n", "capz-system",
+	output, err := RunCommandWithStreaming(t, "kubectl", "--context", context, "-n", "capz-system",
 		"wait", "deployment/azureserviceoperator-controller-manager",
 		"--for", "condition=Available",
 		"--timeout=10m")
 
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "\n❌ Azure Service Operator controller manager deployment is not available: %v\n\n", err)
+		os.Stderr.Sync() // Force immediate output
 		t.Errorf("Azure Service Operator controller manager deployment is not available: %v\nOutput: %s", err, output)
 		return
 	}
 
+	fmt.Fprintf(os.Stderr, "\n✅ Azure Service Operator controller manager deployment is available\n\n")
+	os.Stderr.Sync() // Force immediate output
 	t.Log("Azure Service Operator controller manager deployment is available")
 }


### PR DESCRIPTION
## Summary

- Modified long-running tests to display output in real-time instead of buffering until completion
- Improves user experience during operations that can take up to 30 minutes
- All output now visible immediately as tests execute

## Changes

### TestDeployment_WaitForControlPlane (test/05_deploy_crs_test.go)
- Added real-time status output before each kubectl check
- Shows control plane ready status (true/false) after each poll
- Displays progress with iteration count, elapsed time, and percentage
- All output uses `os.Stderr.Sync()` to force immediate display

### TestKindCluster tests (test/03_cluster_test.go)
- **TestKindCluster_KindClusterReady**: Added real-time output for cluster checks and verification
- **TestKindCluster_CAPINamespacesExists**: Shows namespace checks and pod discovery in real-time
- **TestKindCluster_CAPIControllerReady**: Changed from `RunCommand` to `RunCommandWithStreaming`
- **TestKindCluster_CAPZControllerReady**: Changed from `RunCommand` to `RunCommandWithStreaming`
- **TestKindCluster_ASOControllerReady**: Changed from `RunCommand` to `RunCommandWithStreaming`

### Technical Implementation
- Uses `fmt.Fprintf(os.Stderr, ...)` with `os.Stderr.Sync()` to bypass test buffering
- Switched long-running kubectl wait commands to `RunCommandWithStreaming`
- Follows same pattern as existing `TestDeployment_MonitorCluster` test

## Test Plan

- [x] Verify real-time output appears during test execution (not buffered)
- [x] Confirm all test logic remains unchanged (only output additions)
- [x] Check that `os.Stderr.Sync()` calls properly force immediate output
- [x] Validate output format is clear and informative

## Example Output

```
=== Waiting for control plane to be ready ===
Timeout: 30m0s | Poll interval: 30s

[1] Checking control plane status...
[1] 📊 Control plane ready status: false
[1] ⏳ Waiting... | Elapsed: 0s | Remaining: 30m0s | Progress: 0%
[2] Checking control plane status...
[2] 📊 Control plane ready status: false
[2] ⏳ Waiting... | Elapsed: 30s | Remaining: 29m30s | Progress: 1%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)