### PR TITLE
Replace kubectl wait with polling for controller ready tests

### DIFF
--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -198,7 +198,7 @@ func TestKindCluster_CAPIControllerReady(t *testing.T) {
 			}
 		}
 
-		ReportProgress(t, os.Stderr, iteration, elapsed, remaining, timeout)
+		ReportProgress(t, iteration, elapsed, remaining, timeout)
 
 		time.Sleep(pollInterval)
 	}
@@ -253,7 +253,7 @@ func TestKindCluster_CAPZControllerReady(t *testing.T) {
 			}
 		}
 
-		ReportProgress(t, os.Stderr, iteration, elapsed, remaining, timeout)
+		ReportProgress(t, iteration, elapsed, remaining, timeout)
 
 		time.Sleep(pollInterval)
 	}
@@ -308,7 +308,7 @@ func TestKindCluster_ASOControllerReady(t *testing.T) {
 			}
 		}
 
-		ReportProgress(t, os.Stderr, iteration, elapsed, remaining, timeout)
+		ReportProgress(t, iteration, elapsed, remaining, timeout)
 
 		time.Sleep(pollInterval)
 	}

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -297,7 +297,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 		}
 
 		// Report progress using helper function
-		ReportProgress(t, os.Stderr, iteration, elapsed, remaining, timeout)
+		ReportProgress(t, iteration, elapsed, remaining, timeout)
 
 		time.Sleep(pollInterval)
 	}

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -249,7 +249,7 @@ func PrintToTTY(format string, args ...interface{}) {
 // ReportProgress prints progress information to TTY for real-time visibility
 // and to test log for test output. This helper ensures consistent progress
 // reporting across all deployment tests.
-func ReportProgress(t *testing.T, w io.Writer, iteration int, elapsed, remaining, timeout time.Duration) {
+func ReportProgress(t *testing.T, iteration int, elapsed, remaining, timeout time.Duration) {
 	t.Helper()
 	percentage := int((float64(elapsed) / float64(timeout)) * 100)
 


### PR DESCRIPTION
## Summary

- Replaced `kubectl wait` with manual polling in controller ready tests to show real-time progress  
- Added real-time output to all TestDeployment tests for consistency
- `kubectl wait` produces no output until completion (up to 10 minutes), making tests appear frozen

## Problem

Previously, tests showed output like:
```
Running (streaming): kubectl --context kind-capz-tests-stage -n capz-system wait deployment/azureserviceoperator-controller-manager --for condition=Available --timeout=10m
```

Then nothing for up to 10 minutes until completion. Even with streaming, `kubectl wait` doesn't produce output while waiting.

Additionally, TestDeployment tests had no real-time output at all - users only saw results after completion.

## Solution

**For controller ready tests**: Implemented manual polling (every 10 seconds) following the same pattern as `TestDeployment_WaitForControlPlane`:
- Check deployment Available condition status
- Display iteration count and status (True/False)
- Show progress (elapsed time, remaining time, percentage)
- Report when deployment becomes available

**For deployment tests**: Added real-time stderr output to show progress as operations happen.

## Changes

### Controller Ready Tests (Polling)
- **TestKindCluster_CAPIControllerReady**: Poll every 10s, show progress
- **TestKindCluster_CAPZControllerReady**: Poll every 10s, show progress
- **TestKindCluster_ASOControllerReady**: Poll every 10s, show progress

### Deployment Tests (Real-time Output)
- **TestDeployment_ApplyResources**: Shows progress for each file applied
- **TestDeployment_ApplyCredentialsYAML**: Real-time output with success/failure indicators
- **TestDeployment_ApplyInfrastructureSecretsYAML**: Real-time output with success/failure indicators
- **TestDeployment_ApplyAROClusterYAML**: Real-time output with success/failure indicators
- **TestDeployment_CheckClusterConditions**: Shows each condition check in real-time

### Technical Details
- Replaced `RunCommandWithStreaming` + `kubectl wait` with polling loop for controller tests
- Use `kubectl get deployment -o jsonpath={.status.conditions[?(@.type=='Available')].status}`
- Poll interval: 10 seconds (reasonable for deployment startup)
- Timeout: 10 minutes (unchanged)
- Uses `ReportProgress` helper for consistent output format
- All stderr output uses `os.Stderr.Sync()` for immediate display

## Example Output

### Controller Ready Tests

**Before:**
```
=== Waiting for CAPZ controller manager ===
Namespace: capz-system
Deployment: capz-controller-manager
Timeout: 10m
Running: kubectl wait deployment/capz-controller-manager --for condition=Available

Running (streaming): kubectl ...
[... silence for up to 10 minutes ...]
deployment.apps/capz-controller-manager condition met
```

**After:**
```
=== Waiting for CAPZ controller manager ===
Namespace: capz-system
Deployment: capz-controller-manager
Timeout: 10m0s | Poll interval: 10s

[1] Checking deployment status...
[1] 📊 Deployment Available status: False
[1] ⏳ Waiting... | Elapsed: 0s | Remaining: 10m0s | Progress: 0%
[2] Checking deployment status...
[2] 📊 Deployment Available status: False
[2] ⏳ Waiting... | Elapsed: 10s | Remaining: 9m50s | Progress: 1%
[3] Checking deployment status...
[3] 📊 Deployment Available status: True

✅ CAPZ controller manager is available! (took 20s)
```

### Deployment Tests

**Before:**
```
PASS test.TestDeployment_ApplyAROClusterYAML (0.15s)
```

**After:**
```
=== Applying aro.yaml (ARO cluster configuration) ===
✅ Successfully applied aro.yaml

PASS test.TestDeployment_ApplyAROClusterYAML (0.15s)
```

**Before:**
```
PASS test.TestDeployment_CheckClusterConditions (0.20s)
```

**After:**
```
=== Checking cluster conditions ===
Cluster: capz-tests-cluster

Fetching cluster status...
✅ Cluster has status information
✅ Cluster conditions are available

Checking InfrastructureReady condition...
📊 InfrastructureReady status: True
Checking ControlPlaneReady condition...
📊 ControlPlaneReady status: True

=== Cluster condition check complete ===

PASS test.TestDeployment_CheckClusterConditions (0.20s)
```

## Test Plan

- [x] Consistent with `TestDeployment_WaitForControlPlane` pattern
- [x] Uses `ReportProgress` helper for uniform output
- [x] Shows real-time feedback every 10 seconds for controller tests
- [x] Shows immediate output for deployment tests
- [x] Respects 10-minute timeout
- [x] Properly detects when deployment is available
- [x] All stderr output uses `os.Stderr.Sync()` for immediate display

## Benefits

✅ Users see progress every 10 seconds for controller waits instead of silent waiting  
✅ Users see immediate feedback for deployment operations  
✅ Clear indication that tests are actively running  
✅ Shows actual deployment status (True/False) at each check  
✅ Consistent output pattern across ALL tests in the suite  
✅ Same timeout behavior as before (10 minutes)  

🤖 Generated with [Claude Code](https://claude.com/claude-code)