### PR TITLE
Reformat security badges for better readability (fixes #206)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 [![Cluster Preparation](https://github.com/RadekCap/CAPZTests/actions/workflows/test-kind-cluster.yml/badge.svg)](https://github.com/RadekCap/CAPZTests/actions/workflows/test-kind-cluster.yml)
 
 **Security Scanning:**
+
 [![govulncheck](https://github.com/RadekCap/CAPZTests/actions/workflows/security-govulncheck.yml/badge.svg)](https://github.com/RadekCap/CAPZTests/actions/workflows/security-govulncheck.yml)
 [![gosec](https://github.com/RadekCap/CAPZTests/actions/workflows/security-gosec.yml/badge.svg)](https://github.com/RadekCap/CAPZTests/actions/workflows/security-gosec.yml)
+
 [![Trivy](https://github.com/RadekCap/CAPZTests/actions/workflows/security-trivy.yml/badge.svg)](https://github.com/RadekCap/CAPZTests/actions/workflows/security-trivy.yml)
 [![nancy](https://github.com/RadekCap/CAPZTests/actions/workflows/security-nancy.yml/badge.svg)](https://github.com/RadekCap/CAPZTests/actions/workflows/security-nancy.yml)
 


### PR DESCRIPTION
## Summary

Reformatted the security scanning badges in README.md for improved visual organization and readability.

## Problem

Issue #206 requested updating the security badges from a single line format to a multi-line format with:
- One header line
- Two lines of badges (2 badges per line)

**Before**:
```markdown
**Security Scanning:**
[![govulncheck]...] [![gosec]...] [![Trivy]...] [![nancy]...]
```

All 4 badges were on a single line, making the section appear cluttered, especially on narrower displays.

## Solution

Reorganized the security badges layout to improve readability:

**After**:
```markdown
**Security Scanning:**

[![govulncheck]...] [![gosec]...]

[![Trivy]...] [![nancy]...]
```

## Changes

- **README.md** - Reformatted security badges section:
  - Added blank line after "**Security Scanning:**" header
  - Line 1: govulncheck and gosec badges
  - Line 2: Trivy and nancy badges
  - Preserved all badge functionality and links

## Visual Improvement

The new layout provides:
- ✅ Better visual separation with header on its own line
- ✅ Easier scanning with 2 badges per line instead of 4
- ✅ Improved readability on narrower displays
- ✅ Consistent spacing and organization
- ✅ Maintains all badge functionality

## Testing

- ✅ Markdown formatting verified
- ✅ All badge links preserved and functional
- ✅ No changes to badge behavior or functionality
- ✅ Visual layout matches issue requirements exactly

Fixes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)