### PR TITLE
Fix GitHub Actions variable expansion in security workflows (fixes #208)

### DIFF
--- a/.github/workflows/security-gosec.yml
+++ b/.github/workflows/security-gosec.yml
@@ -96,10 +96,10 @@ jobs:
           cat > comment_body.md << COMMENT_EOF
 ## 🔄 Security Issues Still Present
 
-**New Detection**: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+**New Detection**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 **Date**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-**Branch**: \${{ github.ref_name }}
-**Commit**: \${{ github.sha }}
+**Branch**: ${{ github.ref_name }}
+**Commit**: ${{ github.sha }}
 **Issues Count**: $ISSUES
 
 ### Latest Findings
@@ -143,9 +143,9 @@ The **gosec** source code security scanner has detected security issues in the G
 | **🔴 HIGH** | $HIGH |
 | **🟡 MEDIUM** | $MEDIUM |
 | **🟢 LOW** | $LOW |
-| **Workflow Run** | [\${{ github.run_id }}](\${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}) |
-| **Branch** | \`\${{ github.ref_name }}\` |
-| **Commit** | \`\${{ github.sha }}\` |
+| **Workflow Run** | [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+| **Branch** | \`${{ github.ref_name }}\` |
+| **Commit** | \`${{ github.sha }}\` |
 | **Date** | $(date -u +"%Y-%m-%d %H:%M:%S UTC") |
 
 ## 📋 Security Issues Found
@@ -204,7 +204,7 @@ gosec ./...
 - [gosec Documentation](https://github.com/securego/gosec)
 - [Available Rules](https://github.com/securego/gosec#available-rules)
 - [CWE Database](https://cwe.mitre.org/)
-- [Workflow File](\${{ github.server_url }}/\${{ github.repository }}/blob/main/.github/workflows/security-gosec.yml)
+- [Workflow File](${{ github.server_url }}/${{ github.repository }}/blob/main/.github/workflows/security-gosec.yml)
 
 ## 🔔 Next Steps
 
@@ -216,7 +216,7 @@ gosec ./...
 
 ---
 
-*🤖 This issue was automatically created by the [gosec security workflow](\${{ github.server_url }}/\${{ github.repository }}/actions/workflows/security-gosec.yml)*
+*🤖 This issue was automatically created by the [gosec security workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/security-gosec.yml)*
 ISSUE_EOF
 
           # Create issue with security labels

--- a/.github/workflows/security-govulncheck.yml
+++ b/.github/workflows/security-govulncheck.yml
@@ -77,10 +77,10 @@ jobs:
           cat > comment_body.md << COMMENT_EOF
 ## 🔄 Vulnerability Still Present
 
-**New Detection**: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+**New Detection**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 **Date**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-**Branch**: \${{ github.ref_name }}
-**Commit**: \${{ github.sha }}
+**Branch**: ${{ github.ref_name }}
+**Commit**: ${{ github.sha }}
 
 ### Latest Scan Output
 
@@ -115,10 +115,10 @@ The **govulncheck** security scanner has detected vulnerabilities in Go dependen
 | **Scanner** | govulncheck (Official Go vulnerability checker) |
 | **Status** | ❌ FAILED |
 | **Vulnerabilities** | $VULN_COUNT |
-| **Workflow Run** | [\${{ github.run_id }}](\${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}) |
-| **Branch** | \`\${{ github.ref_name }}\` |
-| **Commit** | \`\${{ github.sha }}\` |
-| **Triggered By** | \${{ github.event_name }} |
+| **Workflow Run** | [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+| **Branch** | \`${{ github.ref_name }}\` |
+| **Commit** | \`${{ github.sha }}\` |
+| **Triggered By** | ${{ github.event_name }} |
 | **Date** | $(date -u +"%Y-%m-%d %H:%M:%S UTC") |
 
 ## 📋 Vulnerability Details
@@ -167,7 +167,7 @@ make test-all
 
 - [Go Vulnerability Database](https://vuln.go.dev/)
 - [govulncheck Documentation](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)
-- [Workflow File](\${{ github.server_url }}/\${{ github.repository }}/blob/main/.github/workflows/security-govulncheck.yml)
+- [Workflow File](${{ github.server_url }}/${{ github.repository }}/blob/main/.github/workflows/security-govulncheck.yml)
 
 ## 🔔 Next Steps
 
@@ -179,7 +179,7 @@ make test-all
 
 ---
 
-*🤖 This issue was automatically created by the [govulncheck security workflow](\${{ github.server_url }}/\${{ github.repository }}/actions/workflows/security-govulncheck.yml)*
+*🤖 This issue was automatically created by the [govulncheck security workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/security-govulncheck.yml)*
 ISSUE_EOF
 
           # Create issue with security labels

--- a/.github/workflows/security-nancy.yml
+++ b/.github/workflows/security-nancy.yml
@@ -91,10 +91,10 @@ jobs:
           cat > comment_body.md << COMMENT_EOF
 ## 🔄 Vulnerable Dependencies Still Present
 
-**New Detection**: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+**New Detection**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 **Date**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-**Branch**: \${{ github.ref_name }}
-**Commit**: \${{ github.sha }}
+**Branch**: ${{ github.ref_name }}
+**Commit**: ${{ github.sha }}
 
 ### Status
 
@@ -103,7 +103,7 @@ Nancy continues to detect vulnerable Go dependencies from the Sonatype OSS Index
 <details>
 <summary>View workflow logs for details</summary>
 
-Check the [workflow run](\${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}) for specific vulnerable packages and versions.
+Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for specific vulnerable packages and versions.
 
 </details>
 
@@ -126,10 +126,10 @@ The **nancy** dependency scanner has detected Go dependencies with known vulnera
 | **Scanner** | nancy (Sonatype OSS Index) |
 | **Status** | ❌ FAILED |
 | **Database** | Sonatype OSS Index |
-| **Workflow Run** | [\${{ github.run_id }}](\${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}) |
-| **Branch** | `\${{ github.ref_name }}` |
-| **Commit** | `\${{ github.sha }}` |
-| **Triggered By** | \${{ github.event_name }} |
+| **Workflow Run** | [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+| **Branch** | `${{ github.ref_name }}` |
+| **Commit** | `${{ github.sha }}` |
+| **Triggered By** | ${{ github.event_name }} |
 | **Date** | $(date -u +"%Y-%m-%d %H:%M:%S UTC") |
 
 ## 📋 Vulnerability Details
@@ -138,7 +138,7 @@ Nancy scans your Go dependencies (`go.list`) against the Sonatype OSS Index for 
 
 ### View Full Results
 
-Check the [workflow run logs](\${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}) for:
+Check the [workflow run logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for:
 - Specific vulnerable package names
 - CVE identifiers
 - Vulnerability severity ratings
@@ -154,7 +154,7 @@ The scan analyzed dependencies from `go.list`. Download the artifact from the wo
 
 Review the workflow logs to identify which packages have vulnerabilities:
 \`\`\`
-Check: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+Check: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 \`\`\`
 
 ### 2️⃣ Update Dependencies
@@ -237,7 +237,7 @@ Consider enabling GitHub Dependabot for automatic dependency updates:
 - [Sonatype OSS Index](https://ossindex.sonatype.org/)
 - [Go Vulnerability Database](https://vuln.go.dev/)
 - [Go Module Documentation](https://go.dev/ref/mod)
-- [Workflow File](\${{ github.server_url }}/\${{ github.repository }}/blob/main/.github/workflows/security-nancy.yml)
+- [Workflow File](${{ github.server_url }}/${{ github.repository }}/blob/main/.github/workflows/security-nancy.yml)
 
 ## 🔄 Comparison with govulncheck
 
@@ -260,12 +260,12 @@ Both scanners complement each other - fix vulnerabilities found by either scanne
 
 ---
 
-*🤖 This issue was automatically created by the [nancy security workflow](\${{ github.server_url }}/\${{ github.repository }}/actions/workflows/security-nancy.yml)*
+*🤖 This issue was automatically created by the [nancy security workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/security-nancy.yml)*
 ISSUE_EOF
 
           # Create issue with security labels
           gh issue create \
-            --title "🚨 [nancy] Vulnerable dependencies detected on \${{ github.ref_name }}" \
+            --title "🚨 [nancy] Vulnerable dependencies detected on ${{ github.ref_name }}" \
             --label "security" \
             --label "nancy" \
             --body-file issue_body.md || \

--- a/.github/workflows/security-trivy.yml
+++ b/.github/workflows/security-trivy.yml
@@ -125,10 +125,10 @@ jobs:
           cat > comment_body.md << COMMENT_EOF
 ## 🔄 Vulnerabilities Still Present
 
-**New Detection**: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+**New Detection**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 **Date**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-**Branch**: \${{ github.ref_name }}
-**Commit**: \${{ github.sha }}
+**Branch**: ${{ github.ref_name }}
+**Commit**: ${{ github.sha }}
 
 ### Current Vulnerability Count
 
@@ -153,7 +153,7 @@ $(cat trivy-results.txt 2>/dev/null | head -200 || echo "See workflow logs for f
 
 **Action Required**: Vulnerabilities persist. Please prioritize CRITICAL and HIGH severity issues.
 
-**Security Tab**: Check the [Security tab](\${{ github.server_url }}/\${{ github.repository }}/security/code-scanning) for detailed SARIF results.
+**Security Tab**: Check the [Security tab](${{ github.server_url }}/${{ github.repository }}/security/code-scanning) for detailed SARIF results.
 COMMENT_EOF
 
           gh issue comment $EXISTING_ISSUE --body-file comment_body.md
@@ -176,9 +176,9 @@ The **Trivy** comprehensive security scanner has detected vulnerabilities, misco
 | **🟡 MEDIUM** | $MEDIUM |
 | **🟢 LOW** | $LOW |
 | **TOTAL** | **$TOTAL** |
-| **Workflow Run** | [\${{ github.run_id }}](\${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}) |
-| **Branch** | `\${{ github.ref_name }}` |
-| **Commit** | `\${{ github.sha }}` |
+| **Workflow Run** | [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+| **Branch** | `${{ github.ref_name }}` |
+| **Commit** | `${{ github.sha }}` |
 | **Date** | $(date -u +"%Y-%m-%d %H:%M:%S UTC") |
 
 ## 📊 Severity Breakdown
@@ -194,7 +194,7 @@ LOW:      $LOW issues     - 📝 Low priority
 
 ### View in GitHub Security Tab
 
-🔒 **SARIF Results**: [View in Security Tab](\${{ github.server_url }}/\${{ github.repository }}/security/code-scanning)
+🔒 **SARIF Results**: [View in Security Tab](${{ github.server_url }}/${{ github.repository }}/security/code-scanning)
 
 The SARIF output has been uploaded to GitHub's Security tab for detailed analysis.
 
@@ -281,8 +281,8 @@ docker run --rm -v $(pwd):/scan aquasec/trivy fs /scan
 - [Trivy Documentation](https://aquasecurity.github.io/trivy/)
 - [Trivy GitHub](https://github.com/aquasecurity/trivy)
 - [Security Best Practices](https://aquasecurity.github.io/trivy/latest/docs/best-practices/)
-- [GitHub Security Tab](\${{ github.server_url }}/\${{ github.repository }}/security)
-- [Workflow File](\${{ github.server_url }}/\${{ github.repository }}/blob/main/.github/workflows/security-trivy.yml)
+- [GitHub Security Tab](${{ github.server_url }}/${{ github.repository }}/security)
+- [Workflow File](${{ github.server_url }}/${{ github.repository }}/blob/main/.github/workflows/security-trivy.yml)
 
 ## 🔔 Next Steps
 
@@ -296,12 +296,12 @@ docker run --rm -v $(pwd):/scan aquasec/trivy fs /scan
 
 ---
 
-*🤖 This issue was automatically created by the [Trivy security workflow](\${{ github.server_url }}/\${{ github.repository }}/actions/workflows/security-trivy.yml)*
+*🤖 This issue was automatically created by the [Trivy security workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/security-trivy.yml)*
 ISSUE_EOF
 
           # Create issue with security labels
           gh issue create \
-            --title "🚨 [Trivy] $TOTAL vulnerabilities detected on \${{ github.ref_name }}" \
+            --title "🚨 [Trivy] $TOTAL vulnerabilities detected on ${{ github.ref_name }}" \
             --label "security" \
             --label "trivy" \
             --body-file issue_body.md || \


### PR DESCRIPTION
## Problem

After merging PR #210, the security workflows are still failing because GitHub Actions variables are not being expanded properly in issue creation.

**Root Cause**: The previous fix incorrectly escaped GitHub Actions variables with backslash (`\${{ github.run_id }}`), which prevented GitHub Actions from expanding them during YAML processing. This resulted in issues showing literal placeholder text instead of actual values.

## Previous Fixes (Incorrect)

- **PR #209**: Fixed only govulncheck workflow with incorrect escaping
- **PR #210**: Fixed all 4 workflows but with incorrect escaping

Both PRs used `\${{ }}` which prevented GitHub Actions expansion.

## This Fix (Correct)

Removed the incorrect backslash escaping from all GitHub Actions variables in 4 security workflows:

- `.github/workflows/security-govulncheck.yml` (18 changes)
- `.github/workflows/security-gosec.yml` (16 changes)
- `.github/workflows/security-trivy.yml` (24 changes)
- `.github/workflows/security-nancy.yml` (26 changes)

## Understanding the Expansion Order

GitHub Actions processes variables in two stages:

1. **YAML Processing** (first): `${{ github.run_id }}` → `"123456"`
2. **Shell Execution** (second): `$VULN_COUNT` → actual count, `$(date)` → timestamp

**Wrong Approach** (PR #210):
```yaml
cat > file.md << ISSUE_EOF
Run: \${{ github.run_id }}  # ❌ Backslash prevents GitHub expansion
ISSUE_EOF
```
Result: Issues show literal `${{ github.run_id }}`

**Correct Approach** (This PR):
```yaml
cat > file.md << ISSUE_EOF
Run: ${{ github.run_id }}   # ✅ GitHub expands BEFORE shell sees it
Count: $VULN_COUNT          # ✅ Shell expands during heredoc
Date: $(date)               # ✅ Shell executes during heredoc
ISSUE_EOF
```
Result: Issues show actual run IDs, counts, and timestamps

## Changes Made

Used sed to remove backslash escaping from GitHub Actions variables:
```bash
sed -i '' 's/\\${{ github/${{ github/g' .github/workflows/security-*.yml
```

This changes:
- `\${{ github.run_id }}` → `${{ github.run_id }}` ✅
- `\${{ github.repository }}` → `${{ github.repository }}` ✅
- `\${{ github.ref_name }}` → `${{ github.ref_name }}` ✅
- `\${{ github.sha }}` → `${{ github.sha }}` ✅

While keeping:
- Markdown backticks escaped: `\`\`\`` ✅
- Shell variables unescaped: `$VULN_COUNT` ✅
- Command substitutions unescaped: `$(date)` ✅

## Testing

After merge, the next security workflow run will verify that:
- Issues show actual workflow run IDs (e.g., "123456")
- Issues show actual timestamps (e.g., "2025-12-11 23:30:00 UTC")
- Issues show actual vulnerability counts (e.g., "3")
- All GitHub Actions variables properly expand

## Related

- Fixes #208
- Supersedes PR #209 (govulncheck only, incorrect fix)
- Corrects PR #210 (all workflows, incorrect escaping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)