### PR TITLE
fix: add PrintToTTY for YAML generation command visibility (fixes #219)

### DIFF
--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -48,6 +48,8 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 	}
 
 	// Run the generation script
+	PrintToTTY("\n=== Generating infrastructure resources ===\n")
+	PrintToTTY("Running infrastructure generation script: %s %s\n", genScriptPath, config.GetOutputDirName())
 	t.Log("Running infrastructure generation script...")
 	output, err := RunCommand(t, "bash", genScriptPath, config.GetOutputDirName())
 	if err != nil {
@@ -57,6 +59,7 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 	}
 
 	// Don't log full output as it may contain Azure resource IDs and other sensitive information
+	PrintToTTY("✅ Infrastructure generation completed successfully\n")
 	t.Log("Infrastructure generation completed successfully")
 
 	// Verify generated files exist


### PR DESCRIPTION
## Summary

Adds immediate visibility of the command being executed during YAML generation in the TestInfrastructure tests.

## Problem

The `TestInfrastructure_GenerateResources` test was only using `t.Log()` which buffers output, making it difficult to see what command was being executed during YAML file generation. This was reported in #219.

## Solution

Added `PrintToTTY()` calls to provide immediate visibility of:
- When infrastructure generation starts
- The exact command being executed (script path and output directory)  
- When generation completes successfully

This matches the pattern used in `05_deploy_crs_test.go` for consistent user experience across all tests.

## Changes

- Added `PrintToTTY` header before running generation script
- Added `PrintToTTY` to show the command being executed
- Added `PrintToTTY` for successful completion message

## Testing

- [x] All check dependencies tests pass
- [x] Code formatted with `go fmt`

Fixes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)