### PR TITLE
fix: print generated file paths to TTY output (fixes #219)

### DIFF
--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -68,6 +68,7 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 		return
 	}
 
+	PrintToTTY("Output directory created: %s\n", outputDir)
 	t.Logf("Output directory created: %s", outputDir)
 
 	// Log paths of all generated files
@@ -81,14 +82,18 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 		if FileExists(filePath) {
 			info, err := os.Stat(filePath)
 			if err != nil {
+				PrintToTTY("  ⚠️  Generated file: %s (unable to stat: %v)\n", filePath, err)
 				t.Logf("Generated file: %s (unable to stat: %v)", filePath, err)
 			} else {
+				PrintToTTY("  ✅ Generated file: %s (%d bytes)\n", filePath, info.Size())
 				t.Logf("Generated file: %s (size: %d bytes)", filePath, info.Size())
 			}
 		} else {
+			PrintToTTY("  ❌ Expected generated file not found: %s\n", filePath)
 			t.Errorf("Expected generated file not found: %s", filePath)
 		}
 	}
+	PrintToTTY("\n")
 }
 
 // TestInfrastructure_VerifyCredentialsYAML verifies credentials.yaml exists and is valid


### PR DESCRIPTION
## Summary

Adds PrintToTTY calls for the generated file messages so they appear immediately during `make` runs.

## Problem

The generated file paths were only shown in verbose test output (`go test -v`), not during normal `make` runs.

## Solution

Added `PrintToTTY` calls for:
- Output directory created message
- Each generated file with size and status icon (✅/⚠️/❌)

## Example Output

```
=== Generating infrastructure resources ===
Running infrastructure generation script: /tmp/.../aro-hcp-gen.sh capz-tests-cluster-stage
✅ Infrastructure generation completed successfully
Output directory created: /tmp/cluster-api-installer-aro/capz-tests-cluster-stage
  ✅ Generated file: .../credentials.yaml (896 bytes)
  ✅ Generated file: .../is.yaml (32070 bytes)
  ✅ Generated file: .../aro.yaml (6112 bytes)
```

## Testing

- [x] Test passes with expected TTY output

Fixes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)