### PR TITLE
fix: use provisioned cluster name from aro.yaml (fixes #228)

### DIFF
--- a/test/06_verification_test.go
+++ b/test/06_verification_test.go
@@ -15,13 +15,16 @@ func TestVerification_RetrieveKubeconfig(t *testing.T) {
 	config := NewTestConfig()
 	context := fmt.Sprintf("kind-%s", config.ManagementClusterName)
 
-	// Kubeconfig output path
-	kubeconfigPath := filepath.Join(os.TempDir(), fmt.Sprintf("%s-kubeconfig.yaml", config.WorkloadClusterName))
+	// Use the provisioned cluster name from aro.yaml
+	provisionedClusterName := config.GetProvisionedClusterName()
 
-	t.Logf("Retrieving kubeconfig for cluster '%s'", config.WorkloadClusterName)
+	// Kubeconfig output path
+	kubeconfigPath := filepath.Join(os.TempDir(), fmt.Sprintf("%s-kubeconfig.yaml", provisionedClusterName))
+
+	t.Logf("Retrieving kubeconfig for cluster '%s'", provisionedClusterName)
 
 	// Method 1: Using kubectl to get secret
-	secretName := fmt.Sprintf("%s-kubeconfig", config.WorkloadClusterName)
+	secretName := fmt.Sprintf("%s-kubeconfig", provisionedClusterName)
 
 	t.Logf("Attempting Method 1: kubectl --context %s get secret %s -o jsonpath={.data.value}", context, secretName)
 	output, err := RunCommand(t, "kubectl", "--context", context, "get", "secret",
@@ -37,9 +40,9 @@ func TestVerification_RetrieveKubeconfig(t *testing.T) {
 		}
 
 		if FileExists(clusterctlPath) || CommandExists("clusterctl") {
-			t.Logf("Attempting Method 2: %s get kubeconfig %s", clusterctlPath, config.WorkloadClusterName)
+			t.Logf("Attempting Method 2: %s get kubeconfig %s", clusterctlPath, provisionedClusterName)
 
-			output, err = RunCommand(t, clusterctlPath, "get", "kubeconfig", config.WorkloadClusterName)
+			output, err = RunCommand(t, clusterctlPath, "get", "kubeconfig", provisionedClusterName)
 			if err != nil {
 				t.Errorf("Both kubeconfig retrieval methods failed: %v", err)
 				return

--- a/test/config.go
+++ b/test/config.go
@@ -110,3 +110,28 @@ func parseDeploymentTimeout() time.Duration {
 func (c *TestConfig) GetOutputDirName() string {
 	return fmt.Sprintf("%s-%s", c.WorkloadClusterName, c.Environment)
 }
+
+// GetProvisionedClusterName returns the actual cluster name from the generated aro.yaml file.
+// This is the name defined in the Cluster resource's metadata.name field, which may differ
+// from WorkloadClusterName (the local configuration). Use this when interacting with
+// the provisioned cluster via kubectl commands.
+//
+// Returns the extracted cluster name or WorkloadClusterName as fallback if aro.yaml
+// doesn't exist yet (e.g., before YAML generation phase).
+func (c *TestConfig) GetProvisionedClusterName() string {
+	aroYAMLPath := fmt.Sprintf("%s/%s/aro.yaml", c.RepoDir, c.GetOutputDirName())
+
+	name, err := ExtractClusterNameFromYAML(aroYAMLPath)
+	if err != nil {
+		// Fall back to WorkloadClusterName if aro.yaml doesn't exist or can't be parsed
+		// This allows earlier phases (before YAML generation) to still work
+		return c.WorkloadClusterName
+	}
+
+	return name
+}
+
+// GetAROYAMLPath returns the path to the generated aro.yaml file
+func (c *TestConfig) GetAROYAMLPath() string {
+	return fmt.Sprintf("%s/%s/aro.yaml", c.RepoDir, c.GetOutputDirName())
+}


### PR DESCRIPTION
## Summary

Extract and use the actual cluster name from the generated `aro.yaml` file instead of using `WORKLOAD_CLUSTER_NAME` for kubectl commands.

## Problem

As reported in #228, the deployment and verification tests were using `config.WorkloadClusterName` (e.g., `capz-tests-cluster`) to query cluster resources. However, the actual cluster name is defined in the `aro.yaml` file's `Cluster` resource under `metadata.name` (e.g., `mveber-stage`).

This caused failures like:
```
kubectl --context kind-capz-tests-stage get cluster capz-tests-cluster
⚠️  Cluster resource not found (may not be deployed yet)
```

When the actual cluster name was `mveber-stage`.

## Solution

- Added `ExtractClusterNameFromYAML()` helper function to parse multi-document YAML files and extract the cluster name from the `cluster.x-k8s.io` Cluster resource
- Added `GetProvisionedClusterName()` method to `TestConfig` that:
  - Reads the cluster name from `aro.yaml` after YAML generation
  - Falls back to `WorkloadClusterName` if `aro.yaml` doesn't exist yet (earlier phases)
- Updated all affected tests to use the provisioned cluster name

## Changes

### test/helpers.go
- Added `ExtractClusterNameFromYAML(filePath string) (string, error)` function

### test/config.go
- Added `GetProvisionedClusterName() string` method
- Added `GetAROYAMLPath() string` helper method

### test/05_deploy_crs_test.go
- Updated `TestDeployment_MonitorCluster` to use `GetProvisionedClusterName()`
- Updated `TestDeployment_CheckClusterConditions` to use `GetProvisionedClusterName()`

### test/06_verification_test.go
- Updated `TestVerification_RetrieveKubeconfig` to use `GetProvisionedClusterName()`

### test/helpers_test.go
- Added 9 comprehensive test cases for `ExtractClusterNameFromYAML`

## Testing

- [x] All helper tests pass (`TestExtractClusterNameFromYAML`)
- [x] All existing tests pass (`make test`)
- [x] Code compiles successfully (`go build ./test`)
- [x] Code formatted (`go fmt ./...`)

Fixes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)