### PR TITLE
feat: show AROControlPlane conditions during deployment (fixes #229)

### DIFF
--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -299,6 +299,14 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 			}
 		}
 
+		// Fetch and display AROControlPlane conditions for better visibility
+		conditionsOutput, condErr := RunCommandQuiet(t, "kubectl", "--context", context, "get",
+			"arocontrolplane", "-A", "-o", "jsonpath={.items[0].status.conditions}")
+		if condErr == nil && strings.TrimSpace(conditionsOutput) != "" {
+			PrintToTTY("[%d] 📋 AROControlPlane conditions:\n", iteration)
+			PrintToTTY("%s", FormatAROControlPlaneConditions(conditionsOutput))
+		}
+
 		// Report progress using helper function
 		ReportProgress(t, iteration, elapsed, remaining, timeout)
 


### PR DESCRIPTION
## Summary

Display detailed AROControlPlane conditions during the control plane provisioning wait loop, providing users with better visibility into deployment progress.

## Problem

As reported in #229, during the control plane provisioning wait loop, users only see whether the control plane is ready (`true`/`false`), but have no visibility into what's actually happening. The AROControlPlane resource contains detailed condition information (ResourceGroupReady, VNetReady, HcpClusterReady, etc.) that would be valuable to display.

## Solution

Added functionality to fetch and display AROControlPlane conditions on each polling iteration during `TestDeployment_WaitForControlPlane`. The conditions are formatted with visual indicators:
- ✅ for `True` status (complete)
- 🔄 for `False` status (in progress)
- ⏳ for unknown status

## Example Output

During deployment, users will now see:
```
[1] 📊 Control plane ready status: false
[1] 📋 AROControlPlane conditions:
  🔄 Ready: False (Reconciling)
  ✅ ResourceGroupReady: True
  ✅ VNetReady: True
  ✅ SubnetsReady: True
  ✅ VaultReady: True
  ✅ UserIdentitiesReady: True
  ✅ RoleAssignmentReady: True
  ✅ NetworkSecurityGroupsReady: True
  🔄 HcpClusterReady: False (Reconciling)
```

## Changes

### test/helpers.go
- Added `AROControlPlaneCondition` struct for JSON parsing
- Added `FormatAROControlPlaneConditions(jsonData string) string` - formats conditions with visual indicators
- Added `RunCommandQuiet(t, name, args...) (string, error)` - executes commands without TTY output (for use in loops)

### test/05_deploy_crs_test.go
- Updated `TestDeployment_WaitForControlPlane` to fetch and display conditions on each iteration

### test/helpers_test.go
- Added 9 comprehensive test cases for `FormatAROControlPlaneConditions`

## Testing

- [x] All new tests pass (`TestFormatAROControlPlaneConditions`)
- [x] All existing tests pass (`make test`)
- [x] Code compiles successfully (`go build ./test`)
- [x] Code formatted (`go fmt ./...`)

Fixes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)