### PR TITLE
feat: add -failfast flag to cluster tests (fixes #250)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ _cluster: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-cluster.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestKindCluster -timeout $(CLUSTER_TIMEOUT) || EXIT_CODE=$$?; \
+	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-cluster.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestKindCluster -timeout $(CLUSTER_TIMEOUT) -failfast || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \


### PR DESCRIPTION
## Summary

Adds the `-failfast` flag to the cluster test phase to stop execution immediately when a test fails, preventing long waits when critical prerequisite tests fail.

## Problem

When `TestKindCluster_ASOCredentialsConfigured` fails (due to missing Azure credentials), subsequent cluster tests like `ASOControllerReady` and `WebhooksReady` continue running and wait 10+ minutes before timing out. This wastes 15+ minutes when the issue is a simple credentials problem.

**Before this fix:**
```
TestKindCluster_ASOCredentialsConfigured  ❌ FAIL (credentials missing)
TestKindCluster_ASOControllerReady        ⏳ Still runs, waits 10 minutes, then fails
TestKindCluster_WebhooksReady             ⏳ Still runs, waits 5 minutes, then fails
--- make test-all stops here (after 15+ minutes wasted)
```

## Solution

Added `-failfast` flag to the `go test` command in the `_cluster` Makefile target. This flag causes Go to stop running tests in a package immediately when one test fails.

**After this fix:**
```
TestKindCluster_ASOCredentialsConfigured  ❌ FAIL (credentials missing)
--- make test-all stops immediately
```

## Changes

- `Makefile`: Added `-failfast` flag to the `_cluster` target's gotestsum command

## Testing

- [x] `make test` passes
- [x] Code review verified the change is minimal and correct

Fixes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)