### PR TITLE
fix: auto-extract Azure credentials before Kind deployment

### DIFF
--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -30,6 +30,17 @@ func TestKindCluster_KindClusterReady(t *testing.T) {
 	if !clusterExists {
 		PrintToTTY("Kind cluster '%s' not found - will deploy new cluster\n", config.ManagementClusterName)
 
+		// Ensure Azure credentials are available for the deployment script
+		// The script needs AZURE_TENANT_ID and AZURE_SUBSCRIPTION_ID to configure ASO
+		PrintToTTY("\n=== Ensuring Azure credentials are available ===\n")
+		if err := EnsureAzureCredentialsSet(t); err != nil {
+			PrintToTTY("❌ Failed to ensure Azure credentials: %v\n", err)
+			PrintToTTY("Please ensure you are logged into Azure CLI: az login\n\n")
+			t.Fatalf("Azure credentials required for deployment: %v", err)
+			return
+		}
+		PrintToTTY("✅ Azure credentials available\n")
+
 		// Deploy Kind cluster using the script
 		scriptPath := filepath.Join(config.RepoDir, "scripts", "deploy-charts-kind-capz.sh")
 		if !FileExists(scriptPath) {


### PR DESCRIPTION
## Summary

Fixes the issue where the ASO credentials test fails even though the user is logged into Azure CLI, because the deployment script didn't receive the Azure environment variables.

## Problem

When running `make test-all`:
1. The `_check-dep` phase auto-extracts Azure credentials using `os.Setenv()` and passes
2. The `_cluster` phase runs as a **separate make target** (new process)
3. Environment variables set in the previous phase don't persist across process boundaries
4. The deployment script runs **without** `AZURE_TENANT_ID` and `AZURE_SUBSCRIPTION_ID`
5. The `aso-controller-settings` secret is created with **empty values**
6. `TestKindCluster_ASOCredentialsConfigured` correctly detects the empty secret and fails

**Symptoms:**
```
❌ AZURE_TENANT_ID: MISSING or EMPTY
❌ AZURE_SUBSCRIPTION_ID: MISSING or EMPTY
```

Even though `az account show` works fine.

## Solution

Added `EnsureAzureCredentialsSet()` helper that is called in `TestKindCluster_KindClusterReady` **before** running the deployment script. This ensures Azure credentials are extracted from Azure CLI and set as environment variables within the same process that runs the deployment script.

## Changes

- `test/helpers.go`: Added `EnsureAzureCredentialsSet()` helper function
- `test/03_cluster_test.go`: Call the helper before running deployment script

## Testing

- [x] `go build ./...` compiles successfully
- [x] `make test` passes
- [x] Code follows existing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)