### PR TITLE
fix: patch ASO credentials secret after Kind deployment

### DIFF
--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -86,6 +86,17 @@ func TestKindCluster_KindClusterReady(t *testing.T) {
 		// Don't log full script output as it may contain sensitive Azure configuration
 		PrintToTTY("\n✅ Kind cluster deployment script completed successfully\n\n")
 		t.Log("Kind cluster deployment script completed successfully")
+
+		// Patch the ASO credentials secret with actual Azure credentials
+		// The helm chart creates the secret with empty values, so we need to populate it
+		PrintToTTY("=== Patching ASO credentials secret ===\n")
+		context := fmt.Sprintf("kind-%s", config.ManagementClusterName)
+		if err := PatchASOCredentialsSecret(t, context); err != nil {
+			PrintToTTY("❌ Failed to patch ASO credentials: %v\n", err)
+			t.Errorf("Failed to patch ASO credentials secret: %v", err)
+			return
+		}
+		PrintToTTY("✅ ASO credentials secret patched successfully\n\n")
 	} else {
 		PrintToTTY("✅ Kind cluster '%s' already exists\n\n", config.ManagementClusterName)
 		t.Logf("Kind cluster '%s' already exists", config.ManagementClusterName)


### PR DESCRIPTION
## Summary

Fixes the ASO credentials validation failure by patching the `aso-controller-settings` secret with actual Azure credentials after Kind cluster deployment.

## Root Cause

The `cluster-api-installer` helm chart creates the `aso-controller-settings` secret with **hardcoded empty strings**:

```yaml
# charts/cluster-api-provider-azure/templates/v1_secret_aso-controller-settings.yaml
stringData:
  AZURE_TENANT_ID: ""
  AZURE_SUBSCRIPTION_ID: ""
```

The chart does NOT use Helm templating to inject environment variables. Setting `AZURE_TENANT_ID` and `AZURE_SUBSCRIPTION_ID` before deployment has **no effect** - the secret is always created with empty values.

## Solution

After the deployment script completes successfully, patch the secret with actual Azure credentials extracted from Azure CLI:

```go
PatchASOCredentialsSecret(t, context)  // Patches the secret with AZURE_TENANT_ID and AZURE_SUBSCRIPTION_ID
```

## Changes

- `test/helpers.go`: Added `PatchASOCredentialsSecret()` helper function
- `test/03_cluster_test.go`: Call the helper after deployment script completes

## Testing

- [x] `go build ./...` compiles
- [x] `make test` passes

## Note

This is a workaround for the upstream helm chart issue. A proper fix would be to update the `cluster-api-installer` chart to use Helm templating for credentials injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)