### PR TITLE
feat: add AZ_COMMAND env var for Python venv support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,13 @@ These environment variables are validated in the Check Dependencies phase. If mi
   export AZURE_SUBSCRIPTION_NAME=$(az account show --query name -o tsv)
   ```
 
+### Azure CLI Configuration
+- `AZ_COMMAND` - Custom path to az CLI executable or wrapper script
+  - Default: `az` (uses system PATH)
+  - Use when system Python is incompatible with Azure CLI (e.g., Fedora 43 with Python 3.14)
+  - Example: `export AZ_COMMAND="$HOME/.az-venv/bin/az"`
+  - See README.md for venv setup instructions
+
 ### Repository Configuration
 - `ARO_REPO_URL` - cluster-api-installer URL (default: RadekCap/cluster-api-installer)
 - `ARO_REPO_BRANCH` - Branch to use (default: `ARO-ASO`)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,33 @@ Target usage of this test suite will be:
 - Access to Azure subscription for ARO deployment
 - Authenticated via `az login`
 
+### Azure CLI with Python Virtual Environment
+
+If your system Python is incompatible with Azure CLI (e.g., Fedora 43 with Python 3.14), you can run Azure CLI from a virtual environment:
+
+1. **Install a compatible Python version and create venv:**
+   ```bash
+   # Fedora
+   sudo dnf install python3.12
+   python3.12 -m venv ~/.az-venv
+   ~/.az-venv/bin/pip install azure-cli
+
+   # Ubuntu/Debian
+   sudo apt install python3.12 python3.12-venv
+   python3.12 -m venv ~/.az-venv
+   ~/.az-venv/bin/pip install azure-cli
+   ```
+
+2. **Configure tests to use the venv:**
+   ```bash
+   export AZ_COMMAND="$HOME/.az-venv/bin/az"
+   ```
+
+3. **Run tests as usual:**
+   ```bash
+   make test
+   ```
+
 ## Configuration
 
 Tests are configured via environment variables:

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -11,10 +11,10 @@ import (
 
 // TestCheckDependencies_ToolAvailable verifies all required tools are installed
 func TestCheckDependencies_ToolAvailable(t *testing.T) {
+	// Note: "az" is checked separately via AzCommandExists() to support custom az paths
 	requiredTools := []string{
 		"docker",
 		"kind",
-		"az",
 		"oc",
 		"helm",
 		"git",
@@ -36,6 +36,20 @@ func TestCheckDependencies_ToolAvailable(t *testing.T) {
 			}
 		})
 	}
+
+	// Check az CLI separately to support AZ_COMMAND env var for venv usage
+	t.Run("az", func(t *testing.T) {
+		if !AzCommandExists() {
+			t.Errorf("Azure CLI is not available. Either 'az' must be in PATH or AZ_COMMAND env var must be set to a valid az executable")
+		} else {
+			azCmd := GetAzCommand()
+			if azCmd != "az" {
+				t.Logf("Using custom az command: %s", azCmd)
+			} else {
+				t.Logf("Tool 'az' is available")
+			}
+		}
+	})
 }
 
 // TestCheckDependencies_DockerDaemonRunning verifies the Docker daemon is running and accessible.
@@ -99,7 +113,7 @@ func TestCheckDependencies_AzureCLILogin_IsLoggedIn(t *testing.T) {
 		return
 	}
 
-	_, err := RunCommand(t, "az", "account", "show")
+	_, err := RunAzCommand(t, "account", "show")
 	if err != nil {
 		t.Errorf("Azure CLI not logged in. Please run 'az login': %v", err)
 		return
@@ -131,7 +145,7 @@ func TestCheckDependencies_AzureEnvironment(t *testing.T) {
 		}
 
 		// Try to extract from Azure CLI
-		output, err := RunCommandQuiet(t, "az", "account", "show", "--query", "tenantId", "-o", "tsv")
+		output, err := RunAzCommandQuiet(t, "account", "show", "--query", "tenantId", "-o", "tsv")
 		if err != nil {
 			missingVars = append(missingVars, "AZURE_TENANT_ID")
 			t.Errorf("AZURE_TENANT_ID is not set and could not be extracted from Azure CLI.\n\n"+
@@ -170,7 +184,7 @@ func TestCheckDependencies_AzureEnvironment(t *testing.T) {
 		}
 
 		// Try to extract subscription ID from Azure CLI
-		output, err := RunCommandQuiet(t, "az", "account", "show", "--query", "id", "-o", "tsv")
+		output, err := RunAzCommandQuiet(t, "account", "show", "--query", "id", "-o", "tsv")
 		if err != nil {
 			missingVars = append(missingVars, "AZURE_SUBSCRIPTION_ID or AZURE_SUBSCRIPTION_NAME")
 			t.Errorf("Neither AZURE_SUBSCRIPTION_ID nor AZURE_SUBSCRIPTION_NAME is set, "+

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -233,6 +233,49 @@ func GetEnvOrDefault(key, defaultValue string) string {
 	return defaultValue
 }
 
+// GetAzCommand returns the az CLI command path.
+// Returns AZ_COMMAND env var if set, otherwise "az".
+// This allows using az CLI from a Python virtual environment with
+// a compatible Python version (e.g., when system Python 3.14 is incompatible).
+func GetAzCommand() string {
+	return GetEnvOrDefault("AZ_COMMAND", "az")
+}
+
+// AzCommandExists checks if the configured az CLI is available.
+// Uses AZ_COMMAND env var if set, otherwise checks for 'az' in PATH.
+func AzCommandExists() bool {
+	azCmd := GetAzCommand()
+	// If it's an absolute path, check if file exists and is executable
+	if strings.HasPrefix(azCmd, "/") {
+		info, err := os.Stat(azCmd)
+		if err != nil {
+			return false
+		}
+		// Check if it's executable (has any execute bit set)
+		return info.Mode().Perm()&0111 != 0
+	}
+	// Otherwise use PATH lookup
+	_, err := exec.LookPath(azCmd)
+	return err == nil
+}
+
+// RunAzCommand executes an az CLI command using the configured az command path.
+// Uses AZ_COMMAND env var if set, otherwise uses system 'az'.
+// This allows running az from a Python venv with compatible Python version.
+func RunAzCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	azCmd := GetAzCommand()
+	return RunCommand(t, azCmd, args...)
+}
+
+// RunAzCommandQuiet executes an az CLI command without TTY output.
+// Uses AZ_COMMAND env var if set, otherwise uses system 'az'.
+func RunAzCommandQuiet(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	azCmd := GetAzCommand()
+	return RunCommandQuiet(t, azCmd, args...)
+}
+
 // PrintTestHeader prints a clear test identification header to both terminal and test log.
 // This helps users understand which test is running and what it does.
 func PrintTestHeader(t *testing.T, testName, description string) {
@@ -465,7 +508,7 @@ func EnsureAzureCredentialsSet(t *testing.T) error {
 
 	// Check and set AZURE_TENANT_ID
 	if os.Getenv("AZURE_TENANT_ID") == "" {
-		output, err := RunCommandQuiet(t, "az", "account", "show", "--query", "tenantId", "-o", "tsv")
+		output, err := RunAzCommandQuiet(t, "account", "show", "--query", "tenantId", "-o", "tsv")
 		if err != nil {
 			return fmt.Errorf("AZURE_TENANT_ID not set and could not extract from Azure CLI: %w", err)
 		}
@@ -481,7 +524,7 @@ func EnsureAzureCredentialsSet(t *testing.T) error {
 
 	// Check and set AZURE_SUBSCRIPTION_ID (if neither ID nor NAME is set)
 	if os.Getenv("AZURE_SUBSCRIPTION_ID") == "" && os.Getenv("AZURE_SUBSCRIPTION_NAME") == "" {
-		output, err := RunCommandQuiet(t, "az", "account", "show", "--query", "id", "-o", "tsv")
+		output, err := RunAzCommandQuiet(t, "account", "show", "--query", "id", "-o", "tsv")
 		if err != nil {
 			return fmt.Errorf("AZURE_SUBSCRIPTION_ID not set and could not extract from Azure CLI: %w", err)
 		}


### PR DESCRIPTION
## Summary

Adds `AZ_COMMAND` environment variable support to run Azure CLI from a custom path, enabling use of az CLI from a Python virtual environment with a compatible Python version.

## Problem

Fedora 43 ships with Python 3.14 which is incompatible with Azure CLI. Users need a way to run `az` commands through a Python venv with an older Python version (e.g., 3.12).

## Solution

Added new helper functions that respect the `AZ_COMMAND` environment variable:

- `GetAzCommand()` - Returns configured az CLI path (defaults to `az`)
- `AzCommandExists()` - Checks if the configured az CLI is available
- `RunAzCommand()` - Runs az commands using configured path
- `RunAzCommandQuiet()` - Same but without TTY output

All existing `az` command calls now use these helpers.

## Usage

```bash
# Create venv with compatible Python
python3.12 -m venv ~/.az-venv
~/.az-venv/bin/pip install azure-cli

# Configure tests to use venv
export AZ_COMMAND="$HOME/.az-venv/bin/az"

# Run tests as usual
make test
```

## Changes

| File | Change |
|------|--------|
| `test/helpers.go` | Add az CLI helper functions |
| `test/helpers.go` | Update `EnsureAzureCredentialsSet()` to use new helpers |
| `test/01_check_dependencies_test.go` | Update all az command calls to use new helpers |
| `CLAUDE.md` | Document `AZ_COMMAND` env var |
| `README.md` | Add venv setup instructions |

## Testing

- [x] `go build ./...` compiles
- [x] `make test` passes (19 tests, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)