### PR TITLE
fix: change default USER to 'rcap' for domain prefix (fixes #260)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ These environment variables are validated in the Check Dependencies phase. If mi
 - `OPENSHIFT_VERSION` - OpenShift version (default: `4.18`)
 - `REGION` - Azure region (default: `uksouth`)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)
-- `USER` - User identifier (default: current user)
+- `USER` - User identifier for domain prefix (default: `rcap`)
 
 ### Test Behavior
 - `DEPLOYMENT_TIMEOUT` - Control plane deployment timeout (default: `45m`, format: Go duration like `1h`, `45m`)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -170,7 +170,7 @@ See `docs/INTEGRATION.md` for detailed integration patterns.
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID (required for deployment)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)
-- `USER` - User identifier (default: current user)
+- `USER` - User identifier for domain prefix (default: `rcap`)
 
 ### Test Behavior
 - `DEPLOYMENT_TIMEOUT` - Control plane deployment timeout (default: `45m`, format: Go duration like `1h`, `45m`)

--- a/test/config.go
+++ b/test/config.go
@@ -77,7 +77,7 @@ func NewTestConfig() *TestConfig {
 		Region:                GetEnvOrDefault("REGION", "uksouth"),
 		AzureSubscription:     os.Getenv("AZURE_SUBSCRIPTION_NAME"),
 		Environment:           GetEnvOrDefault("DEPLOYMENT_ENV", "stage"),
-		User:                  GetEnvOrDefault("USER", os.Getenv("USER")),
+		User:                  GetEnvOrDefault("USER", "rcap"),
 
 		// Paths
 		ClusterctlBinPath: GetEnvOrDefault("CLUSTERCTL_BIN", "./bin/clusterctl"),


### PR DESCRIPTION
## Summary

Change the default USER value from system username to `rcap` to ensure the domain prefix stays within the 15 character Azure limit by default.

## Problem

The domain prefix for ARO clusters is derived from `${USER}-${DEPLOYMENT_ENV}`. When USER defaults to the system username (e.g., `radoslavcap`), the domain prefix can exceed the 15 character Azure limit:
- `radoslavcap-stage` = 17 chars (exceeds limit)

See issue #260 for details.

## Solution

Change the default USER from `os.Getenv("USER")` to a short static default `rcap`:
- `rcap-stage` = 10 chars (within limit)

Users can still override via the USER environment variable if needed.

## Changes

- `test/config.go` - Changed USER default from `os.Getenv("USER")` to `"rcap"`
- `CLAUDE.md` - Updated documentation to reflect new default
- `GEMINI.md` - Updated documentation to reflect new default

## Testing

- [x] All tests pass (`make test`)
- [x] Code formatted with `go fmt`

Fixes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)