### PR TITLE
fix: replace USER with CAPZ_USER to avoid system variable conflict (fixes #262)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ These environment variables are validated in the Check Dependencies phase. If mi
 - `OPENSHIFT_VERSION` - OpenShift version (default: `4.18`)
 - `REGION` - Azure region (default: `uksouth`)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)
-- `USER` - User identifier for domain prefix (default: `rcap`)
+- `CAPZ_USER` - User identifier for domain prefix (default: `rcap`). Must be short enough that `${CAPZ_USER}-${DEPLOYMENT_ENV}` does not exceed 15 characters.
 
 ### Test Behavior
 - `DEPLOYMENT_TIMEOUT` - Control plane deployment timeout (default: `45m`, format: Go duration like `1h`, `45m`)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -170,7 +170,7 @@ See `docs/INTEGRATION.md` for detailed integration patterns.
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID (required for deployment)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)
-- `USER` - User identifier for domain prefix (default: `rcap`)
+- `CAPZ_USER` - User identifier for domain prefix (default: `rcap`). Must be short enough that `${CAPZ_USER}-${DEPLOYMENT_ENV}` does not exceed 15 characters.
 
 ### Test Behavior
 - `DEPLOYMENT_TIMEOUT` - Control plane deployment timeout (default: `45m`, format: Go duration like `1h`, `45m`)

--- a/test/config.go
+++ b/test/config.go
@@ -77,7 +77,7 @@ func NewTestConfig() *TestConfig {
 		Region:                GetEnvOrDefault("REGION", "uksouth"),
 		AzureSubscription:     os.Getenv("AZURE_SUBSCRIPTION_NAME"),
 		Environment:           GetEnvOrDefault("DEPLOYMENT_ENV", "stage"),
-		User:                  GetEnvOrDefault("USER", "rcap"),
+		User:                  GetEnvOrDefault("CAPZ_USER", "rcap"),
 
 		// Paths
 		ClusterctlBinPath: GetEnvOrDefault("CLUSTERCTL_BIN", "./bin/clusterctl"),

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -586,22 +586,22 @@ func PatchASOCredentialsSecret(t *testing.T, kubeContext string) error {
 const MaxDomainPrefixLength = 15
 
 // GetDomainPrefix returns the domain prefix that will be used for the ARO cluster.
-// The domain prefix is derived from USER and DEPLOYMENT_ENV environment variables
-// in the format "${USER}-${DEPLOYMENT_ENV}".
+// The domain prefix is derived from CAPZ_USER and DEPLOYMENT_ENV environment variables
+// in the format "${CAPZ_USER}-${DEPLOYMENT_ENV}".
 func GetDomainPrefix(user, environment string) string {
 	return fmt.Sprintf("%s-%s", user, environment)
 }
 
 // ValidateDomainPrefix checks if the domain prefix length is within the allowed limit.
 // Returns an error with a descriptive message if the prefix exceeds MaxDomainPrefixLength (15 chars).
-// The domain prefix is derived from USER and DEPLOYMENT_ENV in the format "${USER}-${DEPLOYMENT_ENV}".
+// The domain prefix is derived from CAPZ_USER and DEPLOYMENT_ENV in the format "${CAPZ_USER}-${DEPLOYMENT_ENV}".
 func ValidateDomainPrefix(user, environment string) error {
 	prefix := GetDomainPrefix(user, environment)
 	if len(prefix) > MaxDomainPrefixLength {
 		return fmt.Errorf(
 			"domain prefix '%s' (%d chars) exceeds maximum length of %d characters\n"+
-				"  USER='%s' (%d chars) + '-' + DEPLOYMENT_ENV='%s' (%d chars) = %d chars\n"+
-				"  Suggestion: Use shorter values for USER or DEPLOYMENT_ENV environment variables",
+				"  CAPZ_USER='%s' (%d chars) + '-' + DEPLOYMENT_ENV='%s' (%d chars) = %d chars\n"+
+				"  Suggestion: Use shorter values for CAPZ_USER or DEPLOYMENT_ENV environment variables",
 			prefix, len(prefix), MaxDomainPrefixLength,
 			user, len(user), environment, len(environment), len(prefix))
 	}


### PR DESCRIPTION
## Summary

Replace the `USER` environment variable with `CAPZ_USER` to avoid conflict with the standard Unix system variable.

## Problem

The `USER` environment variable is a **standard Unix/Linux variable** always set to the current system username. This means:
- The default value `rcap` was **never used** because `USER` is always set
- Users with long usernames (e.g., `radoslavcap`) always exceeded the 15 char domain prefix limit
- The fix in #260 had no effect

See issue #262 for details.

## Solution

Replace `USER` with a new environment variable `CAPZ_USER` that:
- Does not conflict with system environment variables
- Defaults to `rcap` which works within the 15 char limit
- Can be explicitly set by users who want a custom prefix

## Changes

| File | Change |
|------|--------|
| `test/config.go` | Replace `USER` with `CAPZ_USER` |
| `test/helpers.go` | Update comments and error messages |
| `CLAUDE.md` | Update documentation |
| `GEMINI.md` | Update documentation |

## Testing

- [x] All domain prefix tests pass
- [x] `make test` passes
- [x] Code formatted with `go fmt`

## Migration Note

This is a breaking change for users who explicitly set `USER` for test configuration. They should now use `CAPZ_USER` instead.

Fixes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)