### PR TITLE
feat: update default OpenShift version to 4.21 (fixes #256)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ These environment variables are validated in the Check Dependencies phase. If mi
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - ARO workload cluster name (default: `capz-tests-cluster`)
 - `RESOURCE_GROUP` - Azure resource group
-- `OPENSHIFT_VERSION` - OpenShift version (default: `4.18`)
+- `OPENSHIFT_VERSION` - OpenShift version (default: `4.21`)
 - `REGION` - Azure region (default: `uksouth`)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)
 - `CAPZ_USER` - User identifier for domain prefix (default: `rcap`). Must be short enough that `${CAPZ_USER}-${DEPLOYMENT_ENV}` does not exceed 15 characters.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -166,7 +166,7 @@ See `docs/INTEGRATION.md` for detailed integration patterns.
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - ARO workload cluster name (default: `capz-tests-cluster`)
 - `RESOURCE_GROUP` - Azure resource group
-- `OPENSHIFT_VERSION` - OpenShift version (default: `4.18`)
+- `OPENSHIFT_VERSION` - OpenShift version (default: `4.21`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID (required for deployment)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Tests are configured via environment variables:
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - ARO workload cluster name (default: `capz-tests-cluster`)
 - `RESOURCE_GROUP` - Azure resource group
-- `OPENSHIFT_VERSION` - OpenShift version (default: `4.18`)
+- `OPENSHIFT_VERSION` - OpenShift version (default: `4.21`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -217,7 +217,7 @@ MANAGEMENT_CLUSTER_NAME=capz-tests-stage  # For running tests
 KIND_CLUSTER_NAME=capz-tests-stage        # For direct script usage (advanced)
 CLUSTER_NAME=capz-tests-cluster
 RESOURCE_GROUP=capz-tests-rg
-OPENSHIFT_VERSION=4.18
+OPENSHIFT_VERSION=4.21
 REGION=uksouth
 DEPLOYMENT_ENV=stage
 

--- a/test/README.md
+++ b/test/README.md
@@ -82,7 +82,7 @@ Tests are configured via environment variables:
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - ARO workload cluster name (default: `capz-tests-cluster`)
 - `RESOURCE_GROUP` - Azure resource group
-- `OPENSHIFT_VERSION` - OpenShift version (default: `4.18`)
+- `OPENSHIFT_VERSION` - OpenShift version (default: `4.21`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `DEPLOYMENT_ENV` - Deployment environment (stage/prod) (default: `stage`)

--- a/test/config.go
+++ b/test/config.go
@@ -73,7 +73,7 @@ func NewTestConfig() *TestConfig {
 		ManagementClusterName: GetEnvOrDefault("MANAGEMENT_CLUSTER_NAME", "capz-tests-stage"),
 		WorkloadClusterName:   GetEnvOrDefault("WORKLOAD_CLUSTER_NAME", "capz-tests-cluster"),
 		ResourceGroup:         GetEnvOrDefault("RESOURCE_GROUP", "capz-tests-rg"),
-		OpenShiftVersion:      GetEnvOrDefault("OPENSHIFT_VERSION", "4.18"),
+		OpenShiftVersion:      GetEnvOrDefault("OPENSHIFT_VERSION", "4.21"),
 		Region:                GetEnvOrDefault("REGION", "uksouth"),
 		AzureSubscription:     os.Getenv("AZURE_SUBSCRIPTION_NAME"),
 		Environment:           GetEnvOrDefault("DEPLOYMENT_ENV", "stage"),


### PR DESCRIPTION
## Summary

Update the default OpenShift version for testing from 4.18 to 4.21.

## Problem

The test suite was configured to use OpenShift 4.18 as the default version, which is outdated. As referenced in issue #256, we need to update to the latest supported version.

## Solution

Updated the default `OPENSHIFT_VERSION` from `4.18` to `4.21` in the configuration and all related documentation.

## Changes

- `test/config.go` - Updated default OpenShift version in `NewTestConfig()`
- `CLAUDE.md` - Updated documentation for environment variable
- `GEMINI.md` - Updated documentation for environment variable  
- `README.md` - Updated documentation for environment variable
- `test/README.md` - Updated documentation for environment variable
- `docs/INTEGRATION.md` - Updated example environment variable value

## Testing

- [x] All check dependencies tests pass (20 tests)
- [x] Code formatted with `go fmt`

## Notes

- Users can still override with `OPENSHIFT_VERSION` environment variable
- Ensure cluster-api-installer supports OpenShift 4.21 before merging

Fixes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)