### PR TITLE
feat: add non-interactive mode for make clean (fixes #263)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,15 +109,24 @@ make update-submodule
 
 # Clean up test resources (interactive - prompts before deleting each resource)
 make clean
+
+# Clean up ALL test resources without prompting (non-interactive)
+make clean-all
+# OR use the FORCE variable:
+FORCE=1 make clean
 ```
 
-The `make clean` command is interactive and will prompt you to confirm deletion of:
+The `make clean` command is interactive by default and will prompt you to confirm deletion of:
 - Kind cluster
 - Cluster-api-installer repository clone
 - Kubeconfig files
 - Results directory
 
 This prevents accidental deletion and allows selective cleanup.
+
+For non-interactive cleanup (useful for CI/CD, scripted workflows, or quick resets):
+- Use `make clean-all` to delete all resources without prompts
+- Or use `FORCE=1 make clean` to skip all confirmation prompts
 
 ### Code Quality
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ The JUnit XML files can be:
 The `results/` directory is excluded from git (via `.gitignore`) and can be cleaned up with:
 
 ```bash
-make clean  # Interactive cleanup - prompts for confirmation before deleting each resource
+make clean      # Interactive cleanup - prompts for confirmation before deleting each resource
+make clean-all  # Non-interactive - deletes ALL resources without prompting
+FORCE=1 make clean  # Same as clean-all
 ```
 
 The `make clean` command will interactively ask you to confirm deletion of:
@@ -230,6 +232,10 @@ The `make clean` command will interactively ask you to confirm deletion of:
 - Results directory
 
 This allows you to selectively clean up resources while preserving anything you want to keep.
+
+For automated workflows (CI/CD, scripts) or quick full resets, use:
+- `make clean-all` - deletes all resources without prompting
+- `FORCE=1 make clean` - equivalent to `make clean-all`
 
 ## Integration with cluster-api-installer
 


### PR DESCRIPTION
## Summary

Implements non-interactive cleanup mode as requested in #263:
- New `make clean-all` target that deletes all resources without prompts
- `FORCE=1 make clean` environment variable option for the same behavior

## Problem

Currently `make clean` prompts for confirmation before deleting each resource, which is tedious when you want to clean up everything at once. This is particularly inconvenient for:
- CI/CD pipelines
- Scripted cleanup workflows
- Quick full resets during development

## Solution

Added two equivalent ways to perform non-interactive cleanup:

```bash
# Option 1: New dedicated target
make clean-all

# Option 2: Environment variable
FORCE=1 make clean
```

Both options delete all resources (Kind cluster, cluster-api-installer directory, kubeconfig files, results directory) without prompting for confirmation.

The interactive mode remains the default for `make clean` to prevent accidental deletion.

## Changes

- **Makefile**: Added `clean-all` target with non-interactive cleanup logic
- **Makefile**: Modified `clean` target to delegate to `clean-all` when `FORCE=1`
- **Makefile**: Updated `.PHONY` declaration to include `clean-all`
- **CLAUDE.md**: Updated Repository Management section with new cleanup options
- **README.md**: Updated Cleanup section with new cleanup options

## Testing

- [x] `make help` shows both `clean` and `clean-all` targets with descriptions
- [x] `make clean-all` deletes all resources without prompting
- [x] `FORCE=1 make clean` correctly delegates to `clean-all`
- [x] All existing tests pass (`make test` - 20 tests passed)
- [x] Code formatted with `make fmt`

Fixes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)