### PR TITLE
chore: disable Cluster Preparation workflow

### DIFF
--- a/.github/workflows/test-kind-cluster.yml
+++ b/.github/workflows/test-kind-cluster.yml
@@ -1,11 +1,14 @@
 name: Cluster Preparation
 
+# DISABLED: This workflow is temporarily disabled due to failures.
+# It can still be triggered manually via workflow_dispatch.
+# To re-enable, uncomment the push and pull_request triggers below.
 on:
-  push:
-    branches: [ "**" ]
-  pull_request:
-    branches: [ "**" ]
   workflow_dispatch:
+  # push:
+  #   branches: [ "**" ]
+  # pull_request:
+  #   branches: [ "**" ]
 
 jobs:
   test-kind:


### PR DESCRIPTION
## Summary
- Temporarily disables the Cluster Preparation GitHub Actions workflow due to failures
- Removes automatic triggers (`push` and `pull_request`)
- Keeps `workflow_dispatch` for manual execution when needed

## Changes
- `.github/workflows/test-kind-cluster.yml`: Commented out automatic triggers

## Test Plan
- [x] Workflow file is valid YAML
- [ ] No automatic workflow runs on push/PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)