### PR TITLE
docs: update test-docs to reflect current implementation (fixes #238)

### DIFF
--- a/docs/test-analysis/01-check-dependencies/00-Overview.md
+++ b/docs/test-analysis/01-check-dependencies/00-Overview.md
@@ -16,12 +16,15 @@ Verify all required tools are installed and properly configured before running t
 
 | # | Test | Purpose |
 |---|------|---------|
-| 1 | [01-ToolAvailable](01-ToolAvailable.md) | Check all required CLI tools are in PATH |
-| 2 | [02-AzureCLILogin](02-AzureCLILogin.md) | Verify Azure CLI is logged in |
-| 3 | [03-OpenShiftCLI](03-OpenShiftCLI.md) | Verify OpenShift CLI is functional |
-| 4 | [04-Helm](04-Helm.md) | Verify Helm is installed |
-| 5 | [05-Kind](05-Kind.md) | Verify Kind is installed |
-| 6 | [06-DockerCredentialHelper](06-DockerCredentialHelper.md) | Check Docker credential helpers (macOS only) |
+| 1 | [01-ToolAvailable](01-ToolAvailable.md) | Check all required CLI tools are in PATH (including az via AZ_COMMAND) |
+| 2 | [02-DockerDaemonRunning](02-DockerDaemonRunning.md) | Verify Docker daemon is running and accessible |
+| 3 | [03-AzureCLILogin](03-AzureCLILogin.md) | Verify Azure CLI is logged in |
+| 4 | [04-AzureEnvironment](04-AzureEnvironment.md) | Validate and auto-extract Azure environment variables |
+| 5 | [05-OpenShiftCLI](05-OpenShiftCLI.md) | Verify OpenShift CLI is functional |
+| 6 | [06-Helm](06-Helm.md) | Verify Helm is installed |
+| 7 | [07-Kind](07-Kind.md) | Verify Kind is installed |
+| 8 | [08-Clusterctl](08-Clusterctl.md) | Check if clusterctl is available (informational) |
+| 9 | [09-DockerCredentialHelper](09-DockerCredentialHelper.md) | Check Docker credential helpers (macOS only) |
 
 ---
 
@@ -35,36 +38,58 @@ Verify all required tools are installed and properly configured before running t
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │  Test 1: ToolAvailable                                           │
-│  └── Check: docker, kind, az, oc, helm, git, kubectl, go        │
+│  └── Check: docker, kind, oc, helm, git, kubectl, go            │
+│  └── Check: az (via AZ_COMMAND env var or system PATH)          │
 └─────────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│  Test 2: AzureCLILogin                                           │
+│  Test 2: DockerDaemonRunning                                     │
+│  └── Run: docker info --format {{.ServerVersion}}               │
+│  └── Skip if: using podman or in CI environment                 │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Test 3: AzureCLILogin                                           │
 │  └── Run: az account show                                        │
 └─────────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│  Test 3: OpenShiftCLI                                            │
+│  Test 4: AzureEnvironment                                        │
+│  └── Check AZURE_TENANT_ID (auto-extract from az if missing)    │
+│  └── Check AZURE_SUBSCRIPTION_ID/NAME (auto-extract if missing) │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Test 5: OpenShiftCLI                                            │
 │  └── Run: oc version --client                                    │
 └─────────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│  Test 4: Helm                                                    │
+│  Test 6: Helm                                                    │
 │  └── Run: helm version --short                                   │
 └─────────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│  Test 5: Kind                                                    │
+│  Test 7: Kind                                                    │
 │  └── Run: kind version                                           │
 └─────────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│  Test 6: DockerCredentialHelper (macOS only)                     │
+│  Test 8: Clusterctl                                              │
+│  └── Check: clusterctl in PATH                                   │
+│  └── Informational only (not required for Phase 1)              │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Test 9: DockerCredentialHelper (macOS only)                     │
 │  └── Parse ~/.docker/config.json and verify helpers exist       │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -77,9 +102,10 @@ Verify all required tools are installed and properly configured before running t
 |------|---------|-------------|
 | `docker` | Container runtime | `podman` |
 | `kind` | Kubernetes in Docker | - |
-| `az` | Azure CLI | - |
+| `az` | Azure CLI (supports AZ_COMMAND env var) | - |
 | `oc` | OpenShift CLI | - |
 | `helm` | Kubernetes package manager | - |
 | `git` | Version control | - |
 | `kubectl` | Kubernetes CLI | - |
 | `go` | Go runtime | - |
+| `clusterctl` | Cluster API CLI (optional) | Provided by cluster-api-installer |

--- a/docs/test-analysis/01-check-dependencies/01-ToolAvailable.md
+++ b/docs/test-analysis/01-check-dependencies/01-ToolAvailable.md
@@ -1,8 +1,8 @@
 # Test 1: TestCheckDependencies_ToolAvailable
 
-**Location:** `test/01_check_dependencies_test.go:12-38`
+**Location:** `test/01_check_dependencies_test.go:12-53`
 
-**Purpose:** Verify all required CLI tools are installed and available in PATH.
+**Purpose:** Verify all required CLI tools are installed and available in PATH, including Azure CLI via the AZ_COMMAND environment variable.
 
 ---
 
@@ -14,19 +14,21 @@ For each tool, the test uses `CommandExists()` helper which internally runs:
 |------|--------------|----------|
 | `docker` | `which docker` | `podman` |
 | `kind` | `which kind` | - |
-| `az` | `which az` | - |
 | `oc` | `which oc` | - |
 | `helm` | `which helm` | - |
 | `git` | `which git` | - |
 | `kubectl` | `which kubectl` | - |
 | `go` | `which go` | - |
+| `az` | `AzCommandExists()` | Uses AZ_COMMAND env var |
+
+**Note:** The `az` CLI is checked separately using `AzCommandExists()` which supports the `AZ_COMMAND` environment variable for custom az paths (e.g., when using a Python virtual environment on systems with incompatible system Python).
 
 ---
 
 ## Detailed Flow
 
 ```
-For each tool in [docker, kind, az, oc, helm, git, kubectl, go]:
+For each tool in [docker, kind, oc, helm, git, kubectl, go]:
 │
 ├─► Run subtest: t.Run(tool, ...)
 │
@@ -43,6 +45,20 @@ For each tool in [docker, kind, az, oc, helm, git, kubectl, go]:
 │            │        └─ No  → FAIL: "Required tool 'docker' is not installed"
 │            │
 │            └─ No  → FAIL: "Required tool '<tool>' is not installed"
+
+For "az" (checked separately):
+│
+├─► Run subtest: t.Run("az", ...)
+│
+├─► AzCommandExists()?
+│   │
+│   ├─ Yes → GetAzCommand() == "az"?
+│   │        │
+│   │        ├─ Yes → Log "Tool 'az' is available"
+│   │        │
+│   │        └─ No  → Log "Using custom az command: <path>"
+│   │
+│   └─ No  → FAIL: "Azure CLI is not available"
 ```
 
 ---
@@ -53,13 +69,13 @@ For each tool in [docker, kind, az, oc, helm, git, kubectl, go]:
 requiredTools := []string{
     "docker",
     "kind",
-    "az",
     "oc",
     "helm",
     "git",
     "kubectl",
     "go",
 }
+// Note: "az" is checked separately via AzCommandExists() to support custom az paths
 ```
 
 ---
@@ -69,21 +85,21 @@ requiredTools := []string{
 ```
 === RUN   TestCheckDependencies_ToolAvailable
 === RUN   TestCheckDependencies_ToolAvailable/docker
-    01_check_dependencies_test.go:34: Tool 'docker' is available
+    01_check_dependencies_test.go:35: Tool 'docker' is available
 === RUN   TestCheckDependencies_ToolAvailable/kind
-    01_check_dependencies_test.go:34: Tool 'kind' is available
-=== RUN   TestCheckDependencies_ToolAvailable/az
-    01_check_dependencies_test.go:34: Tool 'az' is available
+    01_check_dependencies_test.go:35: Tool 'kind' is available
 === RUN   TestCheckDependencies_ToolAvailable/oc
-    01_check_dependencies_test.go:34: Tool 'oc' is available
+    01_check_dependencies_test.go:35: Tool 'oc' is available
 === RUN   TestCheckDependencies_ToolAvailable/helm
-    01_check_dependencies_test.go:34: Tool 'helm' is available
+    01_check_dependencies_test.go:35: Tool 'helm' is available
 === RUN   TestCheckDependencies_ToolAvailable/git
-    01_check_dependencies_test.go:34: Tool 'git' is available
+    01_check_dependencies_test.go:35: Tool 'git' is available
 === RUN   TestCheckDependencies_ToolAvailable/kubectl
-    01_check_dependencies_test.go:34: Tool 'kubectl' is available
+    01_check_dependencies_test.go:35: Tool 'kubectl' is available
 === RUN   TestCheckDependencies_ToolAvailable/go
-    01_check_dependencies_test.go:34: Tool 'go' is available
+    01_check_dependencies_test.go:35: Tool 'go' is available
+=== RUN   TestCheckDependencies_ToolAvailable/az
+    01_check_dependencies_test.go:49: Tool 'az' is available
 --- PASS: TestCheckDependencies_ToolAvailable (0.02s)
 ```
 
@@ -94,3 +110,4 @@ requiredTools := []string{
 - Uses Go's `t.Run()` for subtests, allowing individual tool checks to pass/fail independently
 - Docker has a special fallback to podman for container runtime flexibility
 - No version requirements are checked, only presence in PATH
+- Azure CLI supports `AZ_COMMAND` environment variable for custom az paths (useful when system Python is incompatible with Azure CLI)

--- a/docs/test-analysis/01-check-dependencies/02-DockerDaemonRunning.md
+++ b/docs/test-analysis/01-check-dependencies/02-DockerDaemonRunning.md
@@ -1,0 +1,117 @@
+# Test 2: TestCheckDependencies_DockerDaemonRunning
+
+**Location:** `test/01_check_dependencies_test.go:55-106`
+
+**Purpose:** Verify the Docker daemon is running and accessible before running tests that depend on container operations.
+
+---
+
+## Command Executed
+
+| Command | Purpose |
+|---------|---------|
+| `docker info --format {{.ServerVersion}}` | Check if Docker daemon is responding |
+
+---
+
+## Detailed Flow
+
+```
+1. Check if docker is available:
+   └─ CommandExists("docker")?
+      ├─ No  → CommandExists("podman")?
+      │        ├─ Yes → SKIP: "Using podman instead of docker"
+      │        └─ No  → SKIP: "Docker not installed"
+      └─ Yes → Continue
+
+2. Check CI environment:
+   └─ CI=true OR GITHUB_ACTIONS=true?
+      └─ Yes → SKIP: "Skipping Docker daemon check in CI environment"
+      └─ No  → Continue
+
+3. Run: docker info --format {{.ServerVersion}}
+   └─ Success → Log "Docker daemon is running, server version: <version>"
+   └─ Failure → FAIL with platform-specific help message
+```
+
+---
+
+## Platform-Specific Help Messages
+
+### macOS
+```
+To start Docker on macOS, run one of:
+  open -a 'Rancher Desktop'
+  open -a 'Docker Desktop'
+  open -a Docker
+
+Then wait a few seconds for the daemon to start.
+```
+
+### Linux
+```
+To start Docker on Linux, run:
+  sudo systemctl start docker
+
+Or check if the Docker socket exists:
+  ls -la /var/run/docker.sock
+```
+
+---
+
+## Environment Variables Checked
+
+| Variable | Value | Effect |
+|----------|-------|--------|
+| `CI` | `true` | Skip test |
+| `GITHUB_ACTIONS` | `true` | Skip test |
+
+---
+
+## Example Output
+
+### Success
+```
+=== RUN   TestCheckDependencies_DockerDaemonRunning
+    01_check_dependencies_test.go:104: Docker daemon is running, server version: 24.0.7
+--- PASS: TestCheckDependencies_DockerDaemonRunning (0.15s)
+```
+
+### Skipped (CI Environment)
+```
+=== RUN   TestCheckDependencies_DockerDaemonRunning
+    01_check_dependencies_test.go:71: Skipping Docker daemon check in CI environment
+--- SKIP: TestCheckDependencies_DockerDaemonRunning (0.00s)
+```
+
+### Skipped (Using Podman)
+```
+=== RUN   TestCheckDependencies_DockerDaemonRunning
+    01_check_dependencies_test.go:62: Using podman instead of docker, skipping Docker daemon check
+--- SKIP: TestCheckDependencies_DockerDaemonRunning (0.00s)
+```
+
+### Failure (Daemon Not Running)
+```
+=== RUN   TestCheckDependencies_DockerDaemonRunning
+    01_check_dependencies_test.go:96: Docker daemon is not running or not accessible.
+
+To start Docker on macOS, run one of:
+  open -a 'Rancher Desktop'
+  open -a 'Docker Desktop'
+  open -a Docker
+
+Then wait a few seconds for the daemon to start.
+
+Error: Cannot connect to the Docker daemon at unix:///var/run/docker.sock
+--- FAIL: TestCheckDependencies_DockerDaemonRunning (0.30s)
+```
+
+---
+
+## Key Observations
+
+- This test catches Docker daemon issues early, before Kind Cluster tests fail with confusing errors
+- Provides clear, platform-specific instructions for starting the Docker daemon
+- Skipped in CI environments where Docker may not be available
+- Supports podman as an alternative container runtime

--- a/docs/test-analysis/01-check-dependencies/03-AzureCLILogin.md
+++ b/docs/test-analysis/01-check-dependencies/03-AzureCLILogin.md
@@ -1,6 +1,6 @@
-# Test 2: TestCheckDependencies_AzureCLILogin_IsLoggedIn
+# Test 3: TestCheckDependencies_AzureCLILogin_IsLoggedIn
 
-**Location:** `test/01_check_dependencies_test.go:40-56`
+**Location:** `test/01_check_dependencies_test.go:108-124`
 
 **Purpose:** Verify Azure CLI is logged in with valid credentials.
 

--- a/docs/test-analysis/01-check-dependencies/04-AzureEnvironment.md
+++ b/docs/test-analysis/01-check-dependencies/04-AzureEnvironment.md
@@ -1,0 +1,113 @@
+# Test 4: TestCheckDependencies_AzureEnvironment
+
+**Location:** `test/01_check_dependencies_test.go:126-223`
+
+**Purpose:** Validate required Azure environment variables are set, and auto-extract them from Azure CLI if not set (since login was already verified).
+
+---
+
+## Environment Variables Validated
+
+| Variable | Purpose | Auto-Extract Command |
+|----------|---------|---------------------|
+| `AZURE_TENANT_ID` | Azure tenant ID | `az account show --query tenantId -o tsv` |
+| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID | `az account show --query id -o tsv` |
+| `AZURE_SUBSCRIPTION_NAME` | Azure subscription name (alternative) | `az account show --query name -o tsv` |
+
+**Note:** Either `AZURE_SUBSCRIPTION_ID` or `AZURE_SUBSCRIPTION_NAME` must be set (or auto-extracted).
+
+---
+
+## Detailed Flow
+
+```
+1. Check CI environment:
+   └─ CI=true OR GITHUB_ACTIONS=true?
+      └─ Yes → SKIP test
+      └─ No  → Continue
+
+2. Check AZURE_TENANT_ID:
+   └─ Subtest: t.Run("AZURE_TENANT_ID", ...)
+   └─ Is AZURE_TENANT_ID set?
+      ├─ Yes → Log "AZURE_TENANT_ID is set via environment variable"
+      └─ No  → Try auto-extract from Azure CLI
+               ├─ Success → os.Setenv("AZURE_TENANT_ID", value)
+               │            Log "AZURE_TENANT_ID auto-extracted from Azure CLI"
+               └─ Failure → FAIL with remediation instructions
+
+3. Check AZURE_SUBSCRIPTION_ID/NAME:
+   └─ Subtest: t.Run("AZURE_SUBSCRIPTION", ...)
+   └─ Is AZURE_SUBSCRIPTION_ID or AZURE_SUBSCRIPTION_NAME set?
+      ├─ Yes → Log which variable is set
+      └─ No  → Try auto-extract AZURE_SUBSCRIPTION_ID from Azure CLI
+               ├─ Success → os.Setenv("AZURE_SUBSCRIPTION_ID", value)
+               │            Log "AZURE_SUBSCRIPTION_ID auto-extracted from Azure CLI"
+               └─ Failure → FAIL with remediation instructions
+```
+
+---
+
+## Example Output
+
+### Success (Variables Pre-Set)
+```
+=== RUN   TestCheckDependencies_AzureEnvironment
+=== RUN   TestCheckDependencies_AzureEnvironment/AZURE_TENANT_ID
+    01_check_dependencies_test.go:143: AZURE_TENANT_ID is set via environment variable
+=== RUN   TestCheckDependencies_AzureEnvironment/AZURE_SUBSCRIPTION
+    01_check_dependencies_test.go:177: AZURE_SUBSCRIPTION_ID is set via environment variable
+--- PASS: TestCheckDependencies_AzureEnvironment (0.00s)
+```
+
+### Success (Auto-Extracted)
+```
+=== RUN   TestCheckDependencies_AzureEnvironment
+=== RUN   TestCheckDependencies_AzureEnvironment/AZURE_TENANT_ID
+    01_check_dependencies_test.go:169: AZURE_TENANT_ID auto-extracted from Azure CLI: 12345678...cdef
+=== RUN   TestCheckDependencies_AzureEnvironment/AZURE_SUBSCRIPTION
+    01_check_dependencies_test.go:212: AZURE_SUBSCRIPTION_ID auto-extracted from Azure CLI: abcdef12...5678
+--- PASS: TestCheckDependencies_AzureEnvironment (0.80s)
+```
+
+### Skipped (CI Environment)
+```
+=== RUN   TestCheckDependencies_AzureEnvironment
+    01_check_dependencies_test.go:133: Skipping Azure environment validation in CI environment
+--- SKIP: TestCheckDependencies_AzureEnvironment (0.00s)
+```
+
+### Failure
+```
+=== RUN   TestCheckDependencies_AzureEnvironment
+=== RUN   TestCheckDependencies_AzureEnvironment/AZURE_TENANT_ID
+    01_check_dependencies_test.go:151: AZURE_TENANT_ID is not set and could not be extracted from Azure CLI.
+
+To fix this, run:
+  export AZURE_TENANT_ID=$(az account show --query tenantId -o tsv)
+
+Error: Please run 'az login' to setup account.
+--- FAIL: TestCheckDependencies_AzureEnvironment/AZURE_TENANT_ID (0.30s)
+```
+
+---
+
+## Key Observations
+
+- Provides seamless UX for users who are logged in with Azure CLI
+- Auto-sets environment variables for subsequent tests using `os.Setenv()`
+- Only logs partial values (first 8 and last 4 characters) to avoid exposing full IDs
+- Runs cleanup function that prints a summary of missing variables if validation failed
+- Skipped in CI environments where Azure env vars may not be set
+
+---
+
+## Remediation Instructions
+
+If auto-extraction fails, run these commands:
+
+```bash
+export AZURE_TENANT_ID=$(az account show --query tenantId -o tsv)
+export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+# OR
+export AZURE_SUBSCRIPTION_NAME=$(az account show --query name -o tsv)
+```

--- a/docs/test-analysis/01-check-dependencies/05-OpenShiftCLI.md
+++ b/docs/test-analysis/01-check-dependencies/05-OpenShiftCLI.md
@@ -1,6 +1,6 @@
-# Test 3: TestCheckDependencies_OpenShiftCLI_IsAvailable
+# Test 5: TestCheckDependencies_OpenShiftCLI_IsAvailable
 
-**Location:** `test/01_check_dependencies_test.go:58-67`
+**Location:** `test/01_check_dependencies_test.go:225-234`
 
 **Purpose:** Verify OpenShift CLI (oc) is functional and get its version.
 

--- a/docs/test-analysis/01-check-dependencies/06-Helm.md
+++ b/docs/test-analysis/01-check-dependencies/06-Helm.md
@@ -1,6 +1,6 @@
-# Test 4: TestCheckDependencies_Helm_IsAvailable
+# Test 6: TestCheckDependencies_Helm_IsAvailable
 
-**Location:** `test/01_check_dependencies_test.go:69-78`
+**Location:** `test/01_check_dependencies_test.go:236-245`
 
 **Purpose:** Verify Helm is installed and functional.
 

--- a/docs/test-analysis/01-check-dependencies/07-Kind.md
+++ b/docs/test-analysis/01-check-dependencies/07-Kind.md
@@ -1,6 +1,6 @@
-# Test 5: TestCheckDependencies_Kind_IsAvailable
+# Test 7: TestCheckDependencies_Kind_IsAvailable
 
-**Location:** `test/01_check_dependencies_test.go:80-89`
+**Location:** `test/01_check_dependencies_test.go:247-256`
 
 **Purpose:** Verify Kind (Kubernetes in Docker) is installed.
 

--- a/docs/test-analysis/01-check-dependencies/08-Clusterctl.md
+++ b/docs/test-analysis/01-check-dependencies/08-Clusterctl.md
@@ -1,0 +1,104 @@
+# Test 8: TestCheckDependencies_Clusterctl_IsAvailable
+
+**Location:** `test/01_check_dependencies_test.go:258-297`
+
+**Purpose:** Check if clusterctl is available in PATH. This is an informational check that warns users but does not fail if clusterctl is missing.
+
+---
+
+## Command Executed
+
+| Command | Purpose |
+|---------|---------|
+| `clusterctl version` | Get clusterctl version (if available) |
+
+---
+
+## Detailed Flow
+
+```
+1. Check if clusterctl is in PATH:
+   └─ CommandExists("clusterctl")?
+      │
+      ├─ Yes → Run: clusterctl version
+      │        └─► Success?
+      │            ├─ Yes → Log version
+      │            └─ No  → Log "found but version check failed"
+      │
+      └─ No  → Log informational message with install instructions
+               (Does NOT fail the test)
+```
+
+---
+
+## Platform-Specific Install Instructions
+
+### macOS
+```
+To install clusterctl on macOS:
+  brew install clusterctl
+
+Or manually:
+  curl -L https://github.com/kubernetes-sigs/cluster-api/releases/latest/download/clusterctl-darwin-arm64 -o /usr/local/bin/clusterctl
+  chmod +x /usr/local/bin/clusterctl
+```
+
+### Linux
+```
+To install clusterctl on Linux:
+  curl -L https://github.com/kubernetes-sigs/cluster-api/releases/latest/download/clusterctl-linux-amd64 -o /usr/local/bin/clusterctl
+  chmod +x /usr/local/bin/clusterctl
+```
+
+---
+
+## Example Output
+
+### Success (Found in PATH)
+```
+=== RUN   TestCheckDependencies_Clusterctl_IsAvailable
+    01_check_dependencies_test.go:268: clusterctl version: clusterctl version: &version.Info{Major:"1", Minor:"6", GitVersion:"v1.6.0", ...}
+--- PASS: TestCheckDependencies_Clusterctl_IsAvailable (0.05s)
+```
+
+### Not Found (Informational Only)
+```
+=== RUN   TestCheckDependencies_Clusterctl_IsAvailable
+    01_check_dependencies_test.go:291: clusterctl not found in system PATH.
+
+clusterctl is required for cluster monitoring (TestDeployment_MonitorCluster) and
+kubeconfig retrieval (TestVerification_GetKubeconfig).
+
+It will be looked for in cluster-api-installer's bin directory during test execution.
+If not available there either, those tests will be skipped.
+
+To install clusterctl on macOS:
+  brew install clusterctl
+
+Or manually:
+  curl -L https://github.com/kubernetes-sigs/cluster-api/releases/latest/download/clusterctl-darwin-arm64 -o /usr/local/bin/clusterctl
+  chmod +x /usr/local/bin/clusterctl
+--- PASS: TestCheckDependencies_Clusterctl_IsAvailable (0.00s)
+```
+
+---
+
+## Key Observations
+
+- This test is **informational only** - it does not fail if clusterctl is missing
+- clusterctl is used in later phases:
+  - `TestDeployment_MonitorCluster` for `clusterctl describe cluster`
+  - `TestVerification_RetrieveKubeconfig` for `clusterctl get kubeconfig`
+- If not in system PATH, tests will look for it in `cluster-api-installer/bin/` directory
+- If not available anywhere, dependent tests will be skipped with a clear message
+
+---
+
+## When Is clusterctl Actually Required?
+
+| Test | Phase | Uses clusterctl for |
+|------|-------|---------------------|
+| `TestDeployment_MonitorCluster` | 5 | `clusterctl describe cluster` |
+| `TestVerification_RetrieveKubeconfig` | 6 | `clusterctl get kubeconfig` (fallback method) |
+
+Both tests have fallback methods or will skip gracefully if clusterctl is unavailable.

--- a/docs/test-analysis/01-check-dependencies/09-DockerCredentialHelper.md
+++ b/docs/test-analysis/01-check-dependencies/09-DockerCredentialHelper.md
@@ -1,6 +1,6 @@
-# Test 6: TestCheckDependencies_DockerCredentialHelper
+# Test 9: TestCheckDependencies_DockerCredentialHelper
 
-**Location:** `test/01_check_dependencies_test.go:91-175`
+**Location:** `test/01_check_dependencies_test.go:299-384`
 
 **Purpose:** Check that Docker credential helpers configured in `~/.docker/config.json` are available in PATH. Only runs on macOS.
 

--- a/docs/test-analysis/03-cluster/00-Overview.md
+++ b/docs/test-analysis/03-cluster/00-Overview.md
@@ -18,7 +18,9 @@ Deploy a Kind cluster with CAPI, CAPZ, and ASO controllers, then verify all cont
 | 2 | [02-CAPINamespacesExists](02-CAPINamespacesExists.md) | `TestKindCluster_CAPINamespacesExists` | Verify CAPI namespaces exist |
 | 3 | [03-CAPIControllerReady](03-CAPIControllerReady.md) | `TestKindCluster_CAPIControllerReady` | Wait for CAPI controller (10m timeout) |
 | 4 | [04-CAPZControllerReady](04-CAPZControllerReady.md) | `TestKindCluster_CAPZControllerReady` | Wait for CAPZ controller (10m timeout) |
-| 5 | [05-ASOControllerReady](05-ASOControllerReady.md) | `TestKindCluster_ASOControllerReady` | Wait for ASO controller (10m timeout) |
+| 5 | [05-ASOCredentialsConfigured](05-ASOCredentialsConfigured.md) | `TestKindCluster_ASOCredentialsConfigured` | Validate ASO credentials (currently skipped) |
+| 6 | [06-ASOControllerReady](06-ASOControllerReady.md) | `TestKindCluster_ASOControllerReady` | Wait for ASO controller (10m timeout) |
+| 7 | [07-WebhooksReady](07-WebhooksReady.md) | `TestKindCluster_WebhooksReady` | Wait for CAPI/CAPZ/ASO/MCE webhooks (5m timeout) |
 
 ---
 
@@ -33,12 +35,12 @@ Deploy a Kind cluster with CAPI, CAPZ, and ASO controllers, then verify all cont
 ┌─────────────────────────────────────────────────────────────────┐
 │  Test 1: KindClusterReady                                        │
 │  ├── Check if cluster exists (kind get clusters)                 │
-│  ├── If not: run deploy-charts-kind-capz.sh                      │
+│  ├── If not: ensure Azure credentials, run deploy-charts-kind-capz│
 │  │   ├── Create Kind cluster                                     │
 │  │   ├── Install cert-manager                                    │
 │  │   ├── Deploy CAPI charts                                      │
 │  │   ├── Deploy CAPZ charts                                      │
-│  │   └── Wait for controllers                                    │
+│  │   └── Patch ASO credentials secret                            │
 │  └── Verify: kubectl get nodes                                   │
 └─────────────────────────────────────────────────────────────────┘
                               │
@@ -64,9 +66,23 @@ Deploy a Kind cluster with CAPI, CAPZ, and ASO controllers, then verify all cont
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│  Test 5: ASOControllerReady                                      │
+│  Test 5: ASOCredentialsConfigured (SKIPPED)                      │
+│  └── Validates aso-controller-settings secret                    │
+│  └── Currently skipped: requires service principal               │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Test 6: ASOControllerReady                                      │
 │  └── Poll until azureserviceoperator-controller-manager          │
 │      Available=True                                              │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Test 7: WebhooksReady                                           │
+│  └── Check CAPI, CAPZ, ASO, MCE webhooks are responsive         │
+│  └── Uses curl from ephemeral pod to test HTTPS connectivity    │
 └─────────────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/test-analysis/03-cluster/05-ASOCredentialsConfigured.md
+++ b/docs/test-analysis/03-cluster/05-ASOCredentialsConfigured.md
@@ -1,0 +1,101 @@
+# Test 5: TestKindCluster_ASOCredentialsConfigured
+
+**Location:** `test/03_cluster_test.go:284-382`
+
+**Purpose:** Validate that ASO controller has Azure credentials configured correctly. Currently **SKIPPED** because it requires service principal credentials.
+
+---
+
+## Current Status
+
+**SKIPPED**: This test is currently skipped with the message:
+```
+Skipped: ASO credentials check requires service principal (AZURE_CLIENT_ID/SECRET) - not yet configured
+```
+
+---
+
+## When Enabled, This Test Validates:
+
+| Secret Field | Required | Purpose |
+|--------------|----------|---------|
+| `AZURE_TENANT_ID` | Yes | Azure tenant identifier |
+| `AZURE_SUBSCRIPTION_ID` | Yes | Azure subscription identifier |
+| `AZURE_CLIENT_ID` | Yes (one of) | Service principal client ID |
+| `AZURE_CLIENT_SECRET` | Yes (one of) | Service principal client secret |
+
+---
+
+## Detailed Flow (When Enabled)
+
+```
+1. Check if aso-controller-settings secret exists:
+   └─ kubectl get secret aso-controller-settings -n capz-system
+      ├─ Success → Continue
+      └─ Failure → FAIL: "Secret not found"
+
+2. Check required credential fields:
+   └─ For each field in [AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID]:
+      └─ kubectl get secret ... -o jsonpath={.data.<field>}
+         ├─ Non-empty → Log "configured"
+         └─ Empty     → Add to missing list
+
+3. Check authentication method:
+   └─ For each field in [AZURE_CLIENT_ID, AZURE_CLIENT_SECRET]:
+      └─ kubectl get secret ... -o jsonpath={.data.<field>}
+         ├─ Non-empty → Auth configured = true
+         └─ Empty     → Continue
+
+4. Report results:
+   └─ Any missing?
+      ├─ Yes → FAIL with remediation steps
+      └─ No  → PASS
+```
+
+---
+
+## Why Is This Test Skipped?
+
+ASO in Kind clusters requires service principal credentials (`AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET`), which are:
+
+1. Not always available in development environments
+2. Require Azure AD application registration
+3. May have security implications for local testing
+
+**TODO:** Re-enable when service principal setup is documented or made optional.
+
+---
+
+## Remediation (If Test Were Enabled and Failing)
+
+```bash
+# Ensure Azure CLI is logged in
+az login
+
+# Set environment variables
+export AZURE_TENANT_ID=$(az account show --query tenantId -o tsv)
+export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+
+# For service principal auth (required for ASO):
+export AZURE_CLIENT_ID=<your-service-principal-client-id>
+export AZURE_CLIENT_SECRET=<your-service-principal-client-secret>
+
+# Re-run the deployment script
+```
+
+---
+
+## Example Output
+
+### Current (Skipped)
+```
+=== RUN   TestKindCluster_ASOCredentialsConfigured
+    03_cluster_test.go:292: Skipped: ASO credentials check requires service principal (AZURE_CLIENT_ID/SECRET) - not yet configured
+--- SKIP: TestKindCluster_ASOCredentialsConfigured (0.00s)
+```
+
+---
+
+## Related Tests
+
+This test runs **BEFORE** `TestKindCluster_ASOControllerReady` to provide fast failure and clear error messages if credentials are missing, rather than waiting 10 minutes for ASO to timeout.

--- a/docs/test-analysis/03-cluster/06-ASOControllerReady.md
+++ b/docs/test-analysis/03-cluster/06-ASOControllerReady.md
@@ -1,6 +1,6 @@
-# Test 5: TestKindCluster_ASOControllerReady
+# Test 6: TestKindCluster_ASOControllerReady
 
-**Location:** `test/03_cluster_test.go:262-315`
+**Location:** `test/03_cluster_test.go:384-437`
 
 **Purpose:** Wait for Azure Service Operator controller manager to become available (timeout: 10m).
 
@@ -110,6 +110,6 @@ In the context of CAPZ, ASO is used to provision Azure infrastructure (VNets, su
 |------|-----------|------------|---------|
 | Test 3 | `capi-system` | `capi-controller-manager` | Core Cluster API |
 | Test 4 | `capz-system` | `capz-controller-manager` | Azure provider for CAPI |
-| Test 5 | `capz-system` | `azureserviceoperator-controller-manager` | Azure resource management |
+| Test 6 | `capz-system` | `azureserviceoperator-controller-manager` | Azure resource management |
 
 All three tests use identical polling logic with 10m timeout and 10s intervals.

--- a/docs/test-analysis/03-cluster/07-WebhooksReady.md
+++ b/docs/test-analysis/03-cluster/07-WebhooksReady.md
@@ -1,0 +1,143 @@
+# Test 7: TestKindCluster_WebhooksReady
+
+**Location:** `test/03_cluster_test.go:439-535`
+
+**Purpose:** Wait for all admission webhooks (CAPI, CAPZ, ASO, MCE) to be responsive and accepting connections.
+
+---
+
+## Configuration
+
+| Parameter | Value |
+|-----------|-------|
+| Timeout per webhook | 5 minutes |
+| Poll interval | 5 seconds |
+| Test method | HTTPS connectivity from ephemeral pod |
+
+---
+
+## Webhooks Checked
+
+| Webhook | Namespace | Service | Port |
+|---------|-----------|---------|------|
+| CAPI | `capi-system` | `capi-webhook-service` | 443 |
+| CAPZ | `capz-system` | `capz-webhook-service` | 443 |
+| ASO | `capz-system` | `azureserviceoperator-webhook-service` | 443 |
+| MCE | `capi-system` | `mce-capi-webhook-config-service` | 9443 |
+
+---
+
+## Detailed Flow
+
+```
+For each webhook:
+│
+├─► Configuration:
+│   └── Timeout: 5 minutes, Poll interval: 5 seconds
+│
+├─► Loop until timeout:
+│   │
+│   ├─► Check if endpoint has addresses:
+│   │   └─ kubectl get endpoints <service> -n <namespace>
+│   │      -o jsonpath={.subsets[0].addresses[0].ip}
+│   │      ├─ Empty → Wait and retry
+│   │      └─ Has IP → Continue
+│   │
+│   ├─► Test HTTPS connectivity:
+│   │   └─ kubectl run webhook-test-<timestamp> --rm -i
+│   │      --restart=Never --image=curlimages/curl:latest
+│   │      -- curl -k -s -o /dev/null -w '%{http_code}'
+│   │         --connect-timeout 3 --max-time 5
+│   │         https://<service>.<namespace>.svc:<port>/
+│   │      │
+│   │      └─► HTTP code returned?
+│   │          ├─ Non-000 → Webhook responsive, PASS
+│   │          └─ 000     → Connection failed, retry
+│   │
+│   └─► Report progress, sleep, repeat
+│
+└─► Timeout → FAIL
+```
+
+---
+
+## Why Check HTTP Codes?
+
+Any HTTP response (even 400, 404, 405) indicates the webhook server is listening:
+
+| HTTP Code | Meaning |
+|-----------|---------|
+| 000 | Connection failed (server not ready) |
+| 400/404/405 | Server is up, just rejecting our test request |
+| 200 | Server responding normally |
+
+The test considers any non-000 response as success because we're only testing connectivity, not actual webhook functionality.
+
+---
+
+## Example Output
+
+```
+=== Checking webhook readiness ===
+Webhooks to verify: 4
+Timeout per webhook: 5m0s | Poll interval: 5s
+
+--- Checking CAPI webhook ---
+Service: capi-webhook-service.capi-system.svc:443
+[1] Waiting for CAPI endpoint to have addresses...
+[2] Waiting for CAPI endpoint to have addresses...
+[3] 📊 CAPI endpoint IP: 10.244.0.15
+[3] ✅ CAPI webhook is responsive (HTTP 404) - took 15s
+
+--- Checking CAPZ webhook ---
+Service: capz-webhook-service.capz-system.svc:443
+[1] 📊 CAPZ endpoint IP: 10.244.0.18
+[1] ✅ CAPZ webhook is responsive (HTTP 404) - took 2s
+
+--- Checking ASO webhook ---
+Service: azureserviceoperator-webhook-service.capz-system.svc:443
+[1] 📊 ASO endpoint IP: 10.244.0.21
+[1] ✅ ASO webhook is responsive (HTTP 400) - took 3s
+
+--- Checking MCE webhook ---
+Service: mce-capi-webhook-config-service.capi-system.svc:9443
+[1] 📊 MCE endpoint IP: 10.244.0.16
+[1] ✅ MCE webhook is responsive (HTTP 404) - took 2s
+
+=== Webhook readiness check complete ===
+```
+
+---
+
+## Why This Test Matters
+
+Webhooks are critical for Kubernetes admission control. If webhooks are not ready:
+
+1. Resource creation will fail with timeout errors
+2. CR deployment (Phase 5) will fail with cryptic webhook errors
+3. Debugging becomes difficult without knowing webhook state
+
+This test ensures all webhooks are responsive before proceeding to CR deployment.
+
+---
+
+## Technical Details
+
+### Ephemeral Pod Approach
+
+The test uses an ephemeral `curlimages/curl` pod to test HTTPS connectivity because:
+1. Can't reach cluster services from outside the cluster
+2. Self-signed certificates require `-k` flag (insecure)
+3. Pod gets automatic cleanup with `--rm` flag
+4. Unique pod name (`webhook-test-<timestamp>`) avoids conflicts
+
+### Service DNS
+
+Kubernetes service DNS format:
+```
+<service>.<namespace>.svc:<port>
+```
+
+Examples:
+- `capi-webhook-service.capi-system.svc:443`
+- `mce-capi-webhook-config-service.capi-system.svc:9443`


### PR DESCRIPTION
## Summary

Updated test-analysis documentation to match the actual test implementation. The docs were outdated and missing documentation for several tests that have been added over time.

## Problem

The test-analysis documentation in `docs/test-analysis/` was out of sync with the actual test implementation:
- Phase 1 documented 6 tests but implementation has 9 tests
- Phase 3 documented 5 tests but implementation has 7 tests
- Several new tests were missing documentation entirely
- Test numbering was incorrect

## Solution

Updated all test-analysis documentation to reflect the current implementation:

### Phase 1 Changes (01-check-dependencies)
| Test | Change |
|------|--------|
| `DockerDaemonRunning` | Added new doc (02) |
| `ToolAvailable` | Updated to reflect separate az CLI check via AZ_COMMAND |
| `AzureEnvironment` | Added new doc (04) |
| `Clusterctl` | Added new doc (08) |
| All tests | Renumbered to correct order |

### Phase 3 Changes (03-cluster)
| Test | Change |
|------|--------|
| `ASOCredentialsConfigured` | Added new doc (05, currently skipped) |
| `WebhooksReady` | Added new doc (07) |
| `ASOControllerReady` | Renumbered from 05 to 06 |
| Flow diagram | Updated to include ASO credentials patching and webhooks |

### README.md Changes
- Updated phase overview table with correct test counts
- Updated complete flow diagram to reflect current implementation
- Updated directory structure to show new file organization
- Changed total from 30 to 35 tests

## Changes

- `docs/test-analysis/README.md` - Updated test counts and directory structure
- `docs/test-analysis/01-check-dependencies/` - Added 3 new test docs, renumbered existing
- `docs/test-analysis/03-cluster/` - Added 2 new test docs, renumbered existing

## Testing

- [x] `make test` passes (check dependencies tests)
- [x] All documentation files have correct internal links
- [x] Test counts match actual implementation

Fixes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)