### PR TITLE
Revert AZ_COMMAND env var for Python venv support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,13 +179,6 @@ These environment variables are validated in the Check Dependencies phase. If mi
   export AZURE_SUBSCRIPTION_NAME=$(az account show --query name -o tsv)
   ```
 
-### Azure CLI Configuration
-- `AZ_COMMAND` - Custom path to az CLI executable or wrapper script
-  - Default: `az` (uses system PATH)
-  - Use when system Python is incompatible with Azure CLI (e.g., Fedora 43 with Python 3.14)
-  - Example: `export AZ_COMMAND="$HOME/.az-venv/bin/az"`
-  - See README.md for venv setup instructions
-
 ### Repository Configuration
 - `ARO_REPO_URL` - cluster-api-installer URL (default: RadekCap/cluster-api-installer)
 - `ARO_REPO_BRANCH` - Branch to use (default: `ARO-ASO`)

--- a/README.md
+++ b/README.md
@@ -54,33 +54,6 @@ Target usage of this test suite will be:
 - Access to Azure subscription for ARO deployment
 - Authenticated via `az login`
 
-### Azure CLI with Python Virtual Environment
-
-If your system Python is incompatible with Azure CLI (e.g., Fedora 43 with Python 3.14), you can run Azure CLI from a virtual environment:
-
-1. **Install a compatible Python version and create venv:**
-   ```bash
-   # Fedora
-   sudo dnf install python3.12
-   python3.12 -m venv ~/.az-venv
-   ~/.az-venv/bin/pip install azure-cli
-
-   # Ubuntu/Debian
-   sudo apt install python3.12 python3.12-venv
-   python3.12 -m venv ~/.az-venv
-   ~/.az-venv/bin/pip install azure-cli
-   ```
-
-2. **Configure tests to use the venv:**
-   ```bash
-   export AZ_COMMAND="$HOME/.az-venv/bin/az"
-   ```
-
-3. **Run tests as usual:**
-   ```bash
-   make test
-   ```
-
 ## Configuration
 
 Tests are configured via environment variables:

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -11,10 +11,10 @@ import (
 
 // TestCheckDependencies_ToolAvailable verifies all required tools are installed
 func TestCheckDependencies_ToolAvailable(t *testing.T) {
-	// Note: "az" is checked separately via AzCommandExists() to support custom az paths
 	requiredTools := []string{
 		"docker",
 		"kind",
+		"az",
 		"oc",
 		"helm",
 		"git",
@@ -36,20 +36,6 @@ func TestCheckDependencies_ToolAvailable(t *testing.T) {
 			}
 		})
 	}
-
-	// Check az CLI separately to support AZ_COMMAND env var for venv usage
-	t.Run("az", func(t *testing.T) {
-		if !AzCommandExists() {
-			t.Errorf("Azure CLI is not available. Either 'az' must be in PATH or AZ_COMMAND env var must be set to a valid az executable")
-		} else {
-			azCmd := GetAzCommand()
-			if azCmd != "az" {
-				t.Logf("Using custom az command: %s", azCmd)
-			} else {
-				t.Logf("Tool 'az' is available")
-			}
-		}
-	})
 }
 
 // TestCheckDependencies_DockerDaemonRunning verifies the Docker daemon is running and accessible.
@@ -113,7 +99,7 @@ func TestCheckDependencies_AzureCLILogin_IsLoggedIn(t *testing.T) {
 		return
 	}
 
-	_, err := RunAzCommand(t, "account", "show")
+	_, err := RunCommand(t, "az", "account", "show")
 	if err != nil {
 		t.Errorf("Azure CLI not logged in. Please run 'az login': %v", err)
 		return
@@ -145,7 +131,7 @@ func TestCheckDependencies_AzureEnvironment(t *testing.T) {
 		}
 
 		// Try to extract from Azure CLI
-		output, err := RunAzCommandQuiet(t, "account", "show", "--query", "tenantId", "-o", "tsv")
+		output, err := RunCommandQuiet(t, "az", "account", "show", "--query", "tenantId", "-o", "tsv")
 		if err != nil {
 			missingVars = append(missingVars, "AZURE_TENANT_ID")
 			t.Errorf("AZURE_TENANT_ID is not set and could not be extracted from Azure CLI.\n\n"+
@@ -184,7 +170,7 @@ func TestCheckDependencies_AzureEnvironment(t *testing.T) {
 		}
 
 		// Try to extract subscription ID from Azure CLI
-		output, err := RunAzCommandQuiet(t, "account", "show", "--query", "id", "-o", "tsv")
+		output, err := RunCommandQuiet(t, "az", "account", "show", "--query", "id", "-o", "tsv")
 		if err != nil {
 			missingVars = append(missingVars, "AZURE_SUBSCRIPTION_ID or AZURE_SUBSCRIPTION_NAME")
 			t.Errorf("Neither AZURE_SUBSCRIPTION_ID nor AZURE_SUBSCRIPTION_NAME is set, "+


### PR DESCRIPTION
## Summary

Reverts the `AZ_COMMAND` environment variable feature introduced in #257.

This feature was intended to support running Azure CLI from a Python virtual environment when the system Python (e.g., 3.14 on Fedora 43) is incompatible with Azure CLI. However, it added complexity without being fully set up.

## Changes

- Remove `AZ_COMMAND` documentation from CLAUDE.md and README.md
- Remove `GetAzCommand()`, `AzCommandExists()`, `RunAzCommand()`, `RunAzCommandQuiet()` helper functions
- Revert `01_check_dependencies_test.go` to use direct `az` command checks

## Reverts

This reverts commit 391a7fbb49b9e9750a6faa67340341c28f68b1ed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)