### PR TITLE
fix: extract CAPZ_USER and DEPLOYMENT_ENV defaults to constants (fixes #294)

### DIFF
--- a/test/config.go
+++ b/test/config.go
@@ -10,6 +10,15 @@ import (
 const (
 	// DefaultDeploymentTimeout is the default timeout for control plane deployment
 	DefaultDeploymentTimeout = 45 * time.Minute
+
+	// DefaultCAPZUser is the default user identifier for CAPZ resources.
+	// Used in ClusterNamePrefix (for resource group naming) and User field.
+	// Extracted to a constant to ensure consistency across all usages.
+	DefaultCAPZUser = "rcap"
+
+	// DefaultDeploymentEnv is the default deployment environment identifier.
+	// Used in ClusterNamePrefix and Environment field.
+	DefaultDeploymentEnv = "stage"
 )
 
 var (
@@ -72,12 +81,12 @@ func NewTestConfig() *TestConfig {
 		// Cluster defaults
 		ManagementClusterName: GetEnvOrDefault("MANAGEMENT_CLUSTER_NAME", "capz-tests-stage"),
 		WorkloadClusterName:   GetEnvOrDefault("WORKLOAD_CLUSTER_NAME", "capz-tests-cluster"),
-		ClusterNamePrefix:     GetEnvOrDefault("CS_CLUSTER_NAME", fmt.Sprintf("%s-%s", GetEnvOrDefault("CAPZ_USER", "rcap"), GetEnvOrDefault("DEPLOYMENT_ENV", "stage"))),
+		ClusterNamePrefix:     GetEnvOrDefault("CS_CLUSTER_NAME", fmt.Sprintf("%s-%s", GetEnvOrDefault("CAPZ_USER", DefaultCAPZUser), GetEnvOrDefault("DEPLOYMENT_ENV", DefaultDeploymentEnv))),
 		OpenShiftVersion:      GetEnvOrDefault("OPENSHIFT_VERSION", "4.21"),
 		Region:                GetEnvOrDefault("REGION", "uksouth"),
 		AzureSubscription:     os.Getenv("AZURE_SUBSCRIPTION_NAME"),
-		Environment:           GetEnvOrDefault("DEPLOYMENT_ENV", "stage"),
-		User:                  GetEnvOrDefault("CAPZ_USER", "rcap"),
+		Environment:           GetEnvOrDefault("DEPLOYMENT_ENV", DefaultDeploymentEnv),
+		User:                  GetEnvOrDefault("CAPZ_USER", DefaultCAPZUser),
 
 		// Paths
 		ClusterctlBinPath: GetEnvOrDefault("CLUSTERCTL_BIN", "./bin/clusterctl"),


### PR DESCRIPTION
## Summary
Extracts default values for `CAPZ_USER` and `DEPLOYMENT_ENV` to named constants to prevent inconsistent defaults.

## Problem
As reported in #294, the default values for `CAPZ_USER` were duplicated as string literals in multiple places within `test/config.go`. This made it easy to accidentally introduce mismatches where one location had a different default than another.

## Solution
- Added `DefaultCAPZUser` constant (`"rcap"`) for the CAPZ_USER default value
- Added `DefaultDeploymentEnv` constant (`"stage"`) for the DEPLOYMENT_ENV default value
- Updated all usages to reference these constants instead of hardcoded strings

This ensures that if the default needs to change, it only needs to be updated in one place.

## Changes
- `test/config.go`: Added two new constants and updated three field initializations to use them

## Testing
- [x] All check dependencies tests pass (26 tests, 1 skipped)
- [x] Code builds successfully
- [x] Code formatted with `go fmt`

Fixes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)