### PR TITLE
feat: make ASO controller wait timeout configurable (fixes #292)

### DIFF
--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -381,15 +381,19 @@ func TestKindCluster_ASOCredentialsConfigured(t *testing.T) {
 	t.Log("ASO credentials are properly configured")
 }
 
-// TestKindCluster_ASOControllerReady waits for Azure Service Operator controller to be ready
+// TestKindCluster_ASOControllerReady waits for Azure Service Operator controller to be ready.
+// The timeout is configurable via the ASO_CONTROLLER_TIMEOUT environment variable (default: 10m).
+// ASO may require a longer timeout due to its CRD initialization sequence which can involve
+// multiple pod restarts.
 func TestKindCluster_ASOControllerReady(t *testing.T) {
-	PrintTestHeader(t, "TestKindCluster_ASOControllerReady",
-		"Wait for Azure Service Operator controller manager to become available (timeout: 10m)")
-
 	config := NewTestConfig()
+
+	PrintTestHeader(t, "TestKindCluster_ASOControllerReady",
+		fmt.Sprintf("Wait for Azure Service Operator controller manager to become available (timeout: %v)", config.ASOControllerTimeout))
+
 	context := fmt.Sprintf("kind-%s", config.ManagementClusterName)
 
-	timeout := 10 * time.Minute
+	timeout := config.ASOControllerTimeout
 	pollInterval := 10 * time.Second
 	startTime := time.Now()
 


### PR DESCRIPTION
## Summary

Makes the ASO (Azure Service Operator) controller manager wait timeout configurable via the `ASO_CONTROLLER_TIMEOUT` environment variable, allowing users to increase the timeout for environments where ASO initialization takes longer than the default 10 minutes.

## Problem

The ASO controller wait timeout was hardcoded to 10 minutes in `test/03_cluster_test.go`. During initial deployment, the ASO controller can take longer than this due to its CRD initialization sequence:
1. Scans for existing CRDs
2. Applies missing CRDs
3. Releases leadership lease and restarts to pick up new CRDs

This can result in multiple pod restarts (observed 6 restarts in some cases), causing the test to timeout even though the controller would eventually become ready.

See issue #292 for full details.

## Solution

Add a new `ASO_CONTROLLER_TIMEOUT` environment variable that follows the same pattern as the existing `DEPLOYMENT_TIMEOUT` variable:

- Add `DefaultASOControllerTimeout` constant (10m) for backwards compatibility
- Add `ASOControllerTimeout` field to `TestConfig` struct
- Add `parseASOControllerTimeout()` function with validation and warning for invalid values
- Update `TestKindCluster_ASOControllerReady` to use the configurable timeout
- Update test header to display the actual timeout value

## Changes

- `test/config.go`:
  - Add `DefaultASOControllerTimeout` constant (10 minutes)
  - Add `ASOControllerTimeout` field to `TestConfig`
  - Add `parseASOControllerTimeout()` function
  - Initialize `ASOControllerTimeout` in `NewTestConfig()`

- `test/03_cluster_test.go`:
  - Update `TestKindCluster_ASOControllerReady` to use `config.ASOControllerTimeout`
  - Update function comment to document the environment variable
  - Update test header to show the actual timeout value

## Usage

```bash
# Use default 10 minute timeout
make test-all

# Use custom 20 minute timeout for slower environments
ASO_CONTROLLER_TIMEOUT=20m make test-all
```

## Testing

- [x] All check dependency tests pass
- [x] Custom timeout value (e.g., `ASO_CONTROLLER_TIMEOUT=20m`) is correctly parsed and displayed
- [x] Invalid timeout values show warning message and fall back to default
- [x] Code formatted with `go fmt`

Fixes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)