### PR TITLE
fix: verification tests now find kubeconfig without env var (fixes #298)

### DIFF
--- a/test/06_verification_test.go
+++ b/test/06_verification_test.go
@@ -9,6 +9,14 @@ import (
 	"testing"
 )
 
+// getKubeconfigPath returns the path where the workload cluster kubeconfig is stored.
+// This is calculated deterministically from the config, allowing tests to find the
+// kubeconfig without relying on environment variables that may be cleaned up.
+func getKubeconfigPath(config *TestConfig) string {
+	provisionedClusterName := config.GetProvisionedClusterName()
+	return filepath.Join(os.TempDir(), fmt.Sprintf("%s-kubeconfig.yaml", provisionedClusterName))
+}
+
 // TestVerification_RetrieveKubeconfig tests retrieving the cluster kubeconfig
 func TestVerification_RetrieveKubeconfig(t *testing.T) {
 
@@ -18,8 +26,8 @@ func TestVerification_RetrieveKubeconfig(t *testing.T) {
 	// Use the provisioned cluster name from aro.yaml
 	provisionedClusterName := config.GetProvisionedClusterName()
 
-	// Kubeconfig output path
-	kubeconfigPath := filepath.Join(os.TempDir(), fmt.Sprintf("%s-kubeconfig.yaml", provisionedClusterName))
+	// Kubeconfig output path - use helper for consistency
+	kubeconfigPath := getKubeconfigPath(config)
 
 	t.Logf("Retrieving kubeconfig for cluster '%s'", provisionedClusterName)
 
@@ -93,13 +101,11 @@ func TestVerification_RetrieveKubeconfig(t *testing.T) {
 // TestVerification_ClusterNodes verifies cluster nodes are available
 func TestVerification_ClusterNodes(t *testing.T) {
 
-	kubeconfigPath := os.Getenv("ARO_CLUSTER_KUBECONFIG")
-	if kubeconfigPath == "" {
-		t.Skip("Kubeconfig not available, run TestVerification_RetrieveKubeconfig first")
-	}
+	config := NewTestConfig()
+	kubeconfigPath := getKubeconfigPath(config)
 
 	if !FileExists(kubeconfigPath) {
-		t.Skipf("Kubeconfig file not found at %s", kubeconfigPath)
+		t.Skipf("Kubeconfig not available at %s, run TestVerification_RetrieveKubeconfig first", kubeconfigPath)
 	}
 
 	t.Log("Checking cluster nodes...")
@@ -127,13 +133,11 @@ func TestVerification_ClusterNodes(t *testing.T) {
 // TestVerification_ClusterVersion verifies the OpenShift cluster version
 func TestVerification_ClusterVersion(t *testing.T) {
 
-	kubeconfigPath := os.Getenv("ARO_CLUSTER_KUBECONFIG")
-	if kubeconfigPath == "" {
-		t.Skip("Kubeconfig not available, run TestVerification_RetrieveKubeconfig first")
-	}
+	config := NewTestConfig()
+	kubeconfigPath := getKubeconfigPath(config)
 
 	if !FileExists(kubeconfigPath) {
-		t.Skipf("Kubeconfig file not found at %s", kubeconfigPath)
+		t.Skipf("Kubeconfig not available at %s, run TestVerification_RetrieveKubeconfig first", kubeconfigPath)
 	}
 
 	t.Log("Checking OpenShift cluster version...")
@@ -152,13 +156,11 @@ func TestVerification_ClusterVersion(t *testing.T) {
 // TestVerification_ClusterOperators checks cluster operators status
 func TestVerification_ClusterOperators(t *testing.T) {
 
-	kubeconfigPath := os.Getenv("ARO_CLUSTER_KUBECONFIG")
-	if kubeconfigPath == "" {
-		t.Skip("Kubeconfig not available, run TestVerification_RetrieveKubeconfig first")
-	}
+	config := NewTestConfig()
+	kubeconfigPath := getKubeconfigPath(config)
 
 	if !FileExists(kubeconfigPath) {
-		t.Skipf("Kubeconfig file not found at %s", kubeconfigPath)
+		t.Skipf("Kubeconfig not available at %s, run TestVerification_RetrieveKubeconfig first", kubeconfigPath)
 	}
 
 	t.Log("Checking cluster operators...")
@@ -177,13 +179,11 @@ func TestVerification_ClusterOperators(t *testing.T) {
 // TestVerification_ClusterHealth performs basic health checks
 func TestVerification_ClusterHealth(t *testing.T) {
 
-	kubeconfigPath := os.Getenv("ARO_CLUSTER_KUBECONFIG")
-	if kubeconfigPath == "" {
-		t.Skip("Kubeconfig not available, run TestVerification_RetrieveKubeconfig first")
-	}
+	config := NewTestConfig()
+	kubeconfigPath := getKubeconfigPath(config)
 
 	if !FileExists(kubeconfigPath) {
-		t.Skipf("Kubeconfig file not found at %s", kubeconfigPath)
+		t.Skipf("Kubeconfig not available at %s, run TestVerification_RetrieveKubeconfig first", kubeconfigPath)
 	}
 
 	SetEnvVar(t, "KUBECONFIG", kubeconfigPath)


### PR DESCRIPTION
## Summary
Fixes verification tests that were skipping due to environment variable cleanup.

## Problem
As reported in #298, the `SetEnvVar` helper uses `t.Cleanup()` which restores environment variables after each test. This caused:

1. `TestVerification_RetrieveKubeconfig` sets `ARO_CLUSTER_KUBECONFIG`
2. Test completes → `t.Cleanup()` unsets the variable
3. Subsequent tests check `os.Getenv("ARO_CLUSTER_KUBECONFIG")` → empty
4. Tests skip with "Kubeconfig not available"

## Solution
Added `getKubeconfigPath(config)` helper that calculates the kubeconfig path deterministically from `TestConfig`. Each verification test now calculates the path itself instead of relying on an environment variable.

```go
func getKubeconfigPath(config *TestConfig) string {
    provisionedClusterName := config.GetProvisionedClusterName()
    return filepath.Join(os.TempDir(), fmt.Sprintf("%s-kubeconfig.yaml", provisionedClusterName))
}
```

## Changes
- `test/06_verification_test.go`: Added helper function and updated all 5 tests

## Testing
Before fix:
```
PASS test.TestVerification_RetrieveKubeconfig (0.04s)
SKIP test.TestVerification_ClusterNodes (0.00s)
SKIP test.TestVerification_ClusterVersion (0.00s)
SKIP test.TestVerification_ClusterOperators (0.00s)
SKIP test.TestVerification_ClusterHealth (0.00s)
```

After fix:
```
PASS test.TestVerification_RetrieveKubeconfig (0.04s)
PASS test.TestVerification_ClusterNodes (0.42s)
PASS test.TestVerification_ClusterVersion (0.27s)
PASS test.TestVerification_ClusterOperators (0.24s)
PASS test.TestVerification_ClusterHealth (0.35s)
```

- [x] All 5 verification tests pass
- [x] Tested against existing ARO HCP infrastructure
- [x] Code formatted

Fixes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)