### PR TITLE
feat: add Azure resource group cleanup to make clean targets (fixes #287)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,9 @@ make clean
 make clean-all
 # OR use the FORCE variable:
 FORCE=1 make clean
+
+# Clean up only Azure resource group (interactive)
+make clean-azure
 ```
 
 The `make clean` command is interactive by default and will prompt you to confirm deletion of:
@@ -123,12 +126,19 @@ The `make clean` command is interactive by default and will prompt you to confir
 - Cluster-api-installer repository clone
 - Kubeconfig files
 - Results directory
+- Azure resource group (`${CS_CLUSTER_NAME}-resgroup`)
 
 This prevents accidental deletion and allows selective cleanup.
 
 For non-interactive cleanup (useful for CI/CD, scripted workflows, or quick resets):
-- Use `make clean-all` to delete all resources without prompts
+- Use `make clean-all` to delete all resources without prompts (includes Azure resources)
 - Or use `FORCE=1 make clean` to skip all confirmation prompts
+
+**Azure Resource Cleanup Notes**:
+- The resource group name is derived from `${CAPZ_USER}-${DEPLOYMENT_ENV}-resgroup` (default: `rcap-stage-resgroup`)
+- Uses `az group delete --yes --no-wait` for non-blocking deletion
+- Gracefully skips Azure cleanup if Azure CLI is not installed or not authenticated
+- Checks if the resource group exists before attempting deletion
 
 ### Code Quality
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ The `results/` directory is excluded from git (via `.gitignore`) and can be clea
 make clean      # Interactive cleanup - prompts for confirmation before deleting each resource
 make clean-all  # Non-interactive - deletes ALL resources without prompting
 FORCE=1 make clean  # Same as clean-all
+make clean-azure  # Delete only Azure resource group (interactive)
 ```
 
 The `make clean` command will interactively ask you to confirm deletion of:
@@ -231,12 +232,19 @@ The `make clean` command will interactively ask you to confirm deletion of:
 - Cluster-api-installer repository clone in `/tmp`
 - Kubeconfig files in `/tmp`
 - Results directory
+- **Azure resource group** (`${CS_CLUSTER_NAME}-resgroup`, e.g., `rcap-stage-resgroup`)
 
 This allows you to selectively clean up resources while preserving anything you want to keep.
 
 For automated workflows (CI/CD, scripts) or quick full resets, use:
-- `make clean-all` - deletes all resources without prompting
+- `make clean-all` - deletes all resources without prompting (includes Azure resource group)
 - `FORCE=1 make clean` - equivalent to `make clean-all`
+
+**Azure Resource Cleanup**: The cleanup commands now include Azure resource group deletion:
+- Uses `--no-wait` for non-blocking deletion (deletion continues in background)
+- Gracefully skips if Azure CLI is not installed or not logged in
+- Checks if resource group exists before attempting deletion
+- The resource group name is derived from `${CAPZ_USER}-${DEPLOYMENT_ENV}-resgroup` (default: `rcap-stage-resgroup`)
 
 ## Integration with cluster-api-installer
 


### PR DESCRIPTION
## Summary

Add Azure resource group cleanup to `make clean` and `make clean-all` targets, preventing orphaned Azure resources that incur costs and cause conflicts on subsequent test runs.

## Problem

Currently `make clean` and `make clean-all` only clean up local resources (Kind cluster, repository clone, kubeconfig files, results directory). They do **not** clean up Azure resources created during the deployment phase, leaving orphaned resource groups that:
- Incur ongoing Azure costs
- Can cause naming conflicts on subsequent test runs
- Require manual cleanup using Azure portal or CLI

## Solution

Integrate Azure resource group deletion into the existing cleanup targets:

1. **`make clean`** (interactive): Now prompts for Azure resource group deletion after local cleanup
2. **`make clean-all`** (non-interactive): Now automatically deletes Azure resource group first, then local resources
3. **`make clean-azure`** (new): Standalone target for Azure-only cleanup with interactive confirmation

Key implementation details:
- Uses `az group delete --yes --no-wait` for non-blocking deletion
- Gracefully skips Azure cleanup if Azure CLI is not installed or not authenticated
- Checks if resource group exists before attempting deletion
- Resource group name derived from `${CAPZ_USER}-${DEPLOYMENT_ENV}-resgroup`

## Changes

- `Makefile`:
  - Add `CAPZ_USER`, `CS_CLUSTER_NAME`, `AZURE_RESOURCE_GROUP` variables
  - Add `clean-azure` target for standalone Azure cleanup
  - Integrate Azure cleanup into `clean` and `clean-all` targets
  - Add internal `_clean-azure-force` target for non-interactive cleanup
- `README.md`: Updated cleanup documentation with Azure resource group info
- `CLAUDE.md`: Updated cleanup documentation with Azure cleanup notes

## Testing

- [x] All check dependencies tests pass (26 tests, 0 failures)
- [x] Makefile syntax verified via `make help`
- [x] Code formatted with `go fmt`
- [x] `clean-azure` target appears in help output

Fixes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)