### PR TITLE
feat: implement fail-fast for infrastructure tests (fixes #278)

### DIFF
--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 )
 
+// infrastructureGenerationSucceeded tracks whether TestInfrastructure_GenerateResources completed successfully.
+// When false, dependent verification tests will skip to avoid confusing cascading failures.
+var infrastructureGenerationSucceeded bool
+
 // TestInfrastructure_GenerateResources tests generating ARO infrastructure resources
 func TestInfrastructure_GenerateResources(t *testing.T) {
 
@@ -104,10 +108,19 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 		}
 	}
 	PrintToTTY("\n")
+
+	// Mark generation as successful only if no errors occurred
+	if !t.Failed() {
+		infrastructureGenerationSucceeded = true
+	}
 }
 
 // TestInfrastructure_VerifyCredentialsYAML verifies credentials.yaml exists and is valid
 func TestInfrastructure_VerifyCredentialsYAML(t *testing.T) {
+	if !infrastructureGenerationSucceeded {
+		t.Skip("Skipping: TestInfrastructure_GenerateResources did not succeed")
+	}
+
 	t.Log("Verifying credentials.yaml")
 
 	config := NewTestConfig()
@@ -139,6 +152,10 @@ func TestInfrastructure_VerifyCredentialsYAML(t *testing.T) {
 
 // TestInfrastructure_VerifyInfrastructureSecretsYAML verifies is.yaml exists and is valid
 func TestInfrastructure_VerifyInfrastructureSecretsYAML(t *testing.T) {
+	if !infrastructureGenerationSucceeded {
+		t.Skip("Skipping: TestInfrastructure_GenerateResources did not succeed")
+	}
+
 	t.Log("Verifying is.yaml (infrastructure secrets)")
 
 	config := NewTestConfig()
@@ -170,6 +187,10 @@ func TestInfrastructure_VerifyInfrastructureSecretsYAML(t *testing.T) {
 
 // TestInfrastructure_VerifyAROClusterYAML verifies aro.yaml exists and is valid
 func TestInfrastructure_VerifyAROClusterYAML(t *testing.T) {
+	if !infrastructureGenerationSucceeded {
+		t.Skip("Skipping: TestInfrastructure_GenerateResources did not succeed")
+	}
+
 	t.Log("Verifying aro.yaml (ARO cluster configuration)")
 
 	config := NewTestConfig()


### PR DESCRIPTION
## Summary
- When `TestInfrastructure_GenerateResources` fails, dependent verification tests now skip instead of running and failing with confusing errors

## Problem
When `TestInfrastructure_GenerateResources` fails, subsequent infrastructure verification tests still run and fail with confusing errors, since they depend on the generated files (`credentials.yaml`, `is.yaml`, `aro.yaml`).

## Solution
Implement a fail-fast mechanism using a shared state variable:
- Add `infrastructureGenerationSucceeded` package-level flag
- Set flag to `true` at end of `GenerateResources` only if `!t.Failed()`
- Add skip check at start of all three verification tests
- Skip message clearly indicates the dependency: "Skipping: TestInfrastructure_GenerateResources did not succeed"

## Changes
- `test/04_generate_yamls_test.go`:
  - Add `infrastructureGenerationSucceeded` package variable
  - Update `TestInfrastructure_GenerateResources` to set flag on success
  - Update `TestInfrastructure_VerifyCredentialsYAML` to check flag
  - Update `TestInfrastructure_VerifyInfrastructureSecretsYAML` to check flag
  - Update `TestInfrastructure_VerifyAROClusterYAML` to check flag

## Testing
- [x] All `TestInfrastructure` tests pass when generation succeeds
- [x] `make test` passes (check dependencies tests)
- [x] Code formatted with `go fmt`

Fixes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)