### PR TITLE
feat: check cluster ready state before kubeconfig retrieval (fixes #275)

### DIFF
--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -1243,3 +1243,35 @@ func TestRetryConstants(t *testing.T) {
 		t.Errorf("DefaultApplyRetryDelay = %v, expected at least 5s", DefaultApplyRetryDelay)
 	}
 }
+
+func TestClusterPhaseConstants(t *testing.T) {
+	// Verify cluster phase constants are correctly defined
+	if ClusterPhaseProvisioned != "Provisioned" {
+		t.Errorf("ClusterPhaseProvisioned = %q, expected \"Provisioned\"", ClusterPhaseProvisioned)
+	}
+
+	if ClusterPhaseProvisioning != "Provisioning" {
+		t.Errorf("ClusterPhaseProvisioning = %q, expected \"Provisioning\"", ClusterPhaseProvisioning)
+	}
+
+	if ClusterPhaseFailed != "Failed" {
+		t.Errorf("ClusterPhaseFailed = %q, expected \"Failed\"", ClusterPhaseFailed)
+	}
+}
+
+func TestClusterReadyConstants(t *testing.T) {
+	// Verify cluster ready timeout constants have sensible values
+	if DefaultClusterReadyTimeout < 30*time.Minute {
+		t.Errorf("DefaultClusterReadyTimeout = %v, expected at least 30m", DefaultClusterReadyTimeout)
+	}
+
+	if DefaultClusterReadyPollInterval < 10*time.Second {
+		t.Errorf("DefaultClusterReadyPollInterval = %v, expected at least 10s", DefaultClusterReadyPollInterval)
+	}
+
+	// Verify poll interval is less than timeout
+	if DefaultClusterReadyPollInterval >= DefaultClusterReadyTimeout {
+		t.Errorf("DefaultClusterReadyPollInterval (%v) should be less than DefaultClusterReadyTimeout (%v)",
+			DefaultClusterReadyPollInterval, DefaultClusterReadyTimeout)
+	}
+}


### PR DESCRIPTION
## Summary
Adds a precondition check to verify the cluster is in `Provisioned` state before attempting to retrieve the kubeconfig secret.

## Problem
When a cluster is still in `Provisioning` phase:
- The kubeconfig secret is created by ASO but with an empty value
- ASO only populates the secret after the HcpOpenShiftCluster resource is fully provisioned in Azure
- The test didn't check cluster status before attempting retrieval
- This caused confusing failures with "Secret value is empty, cannot decode kubeconfig"

Reference: #275

## Solution
- Added `GetClusterPhase` helper function to retrieve the CAPI Cluster resource phase
- Added `IsClusterReady` helper to check if cluster is in `Provisioned` state
- Added `WaitForClusterReady` helper for cases where waiting is preferred over skipping
- Added cluster phase constants (`ClusterPhaseProvisioned`, `ClusterPhaseProvisioning`, `ClusterPhaseFailed`)
- Updated `TestVerification_RetrieveKubeconfig` to check cluster phase and skip with a clear message if not ready

## Changes
- `test/helpers.go` - Added 4 new helper functions and 5 constants (+121 lines)
- `test/06_verification_test.go` - Added cluster phase check before kubeconfig retrieval (+13 lines)
- `test/helpers_test.go` - Added unit tests for new constants (+32 lines)

## Testing
- [x] All helper unit tests pass
- [x] `make test` passes (check dependencies)
- [x] Code formatted with `go fmt`

Fixes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)