### PR TITLE
feat: add tested versions summary to verification phase (fixes #239)

### DIFF
--- a/test/06_verification_test.go
+++ b/test/06_verification_test.go
@@ -222,3 +222,46 @@ func TestVerification_ClusterHealth(t *testing.T) {
 		}
 	}
 }
+
+// TestVerification_TestedVersionsSummary displays a summary of all tested component versions.
+// This test collects version information from the management cluster for CAPZ, ASO, CAPI,
+// and other infrastructure components, providing a clear summary at the end of testing.
+func TestVerification_TestedVersionsSummary(t *testing.T) {
+
+	config := NewTestConfig()
+	context := fmt.Sprintf("kind-%s", config.ManagementClusterName)
+
+	PrintTestHeader(t, "TestVerification_TestedVersionsSummary",
+		"Display summary of tested infrastructure component versions")
+
+	// Get component versions from the management cluster
+	versions := GetComponentVersions(t, context)
+
+	// Format and display the version summary
+	summary := FormatComponentVersions(versions)
+	PrintToTTY("%s", summary)
+	t.Log(summary)
+
+	// Log individual component details for test output
+	for _, v := range versions {
+		if v.Version == "not found" {
+			t.Logf("Component %s: not deployed or not accessible", v.Name)
+		} else {
+			t.Logf("Component %s: version %s (image: %s)", v.Name, v.Version, v.Image)
+		}
+	}
+
+	// Count successfully retrieved versions
+	foundCount := 0
+	for _, v := range versions {
+		if v.Version != "not found" {
+			foundCount++
+		}
+	}
+
+	if foundCount == 0 {
+		t.Log("Warning: No component versions could be retrieved. Management cluster may not be running.")
+	} else {
+		t.Logf("Successfully retrieved version information for %d/%d components", foundCount, len(versions))
+	}
+}


### PR DESCRIPTION
## Summary
Adds a new test function that displays a formatted summary of all tested infrastructure component versions (CAPZ, ASO, CAPI) at the end of the verification phase.

## Problem
When running the test suite, there was no easy way to see what versions of the infrastructure components (CAPZ, ASO, CAPI) were being tested. This made it difficult to track which versions were validated during test runs.

Addresses #239: "Add a summary info about tested versions - CAPZ, ASO ... Into the final verification state."

## Solution
Added a new `TestVerification_TestedVersionsSummary` test that:
1. Queries the management cluster for deployed component versions
2. Extracts version information from container images
3. Displays a formatted summary table

The version summary displays in a formatted box:
```
╔════════════════════════════════════════════════════════════════════════════════╗
║                      TESTED COMPONENT VERSIONS                                 ║
╠════════════════════════════════════════════════════════════════════════════════╣
║ CAPZ (Cluster API Provider Azure)        │ v1.19.0         ║
║ ASO (Azure Service Operator)             │ v2.10.0         ║
║ CAPI (Cluster API)                       │ v1.8.4          ║
╚════════════════════════════════════════════════════════════════════════════════╝
```

## Changes
- **test/helpers.go**: Added new helper functions:
  - `ComponentVersion` struct to represent version info
  - `GetDeploymentImage()` - retrieves container image from deployment
  - `extractVersionFromImage()` - extracts version tag from image reference
  - `GetComponentVersions()` - collects versions for CAPZ, ASO, and CAPI
  - `FormatComponentVersions()` - formats version summary for display

- **test/06_verification_test.go**: Added `TestVerification_TestedVersionsSummary` test

- **test/helpers_test.go**: Added comprehensive unit tests:
  - `TestExtractVersionFromImage` - 9 test cases
  - `TestFormatComponentVersions` - 4 test cases
  - `TestComponentVersionStruct` - struct validation

## Testing
- [x] All new unit tests pass
- [x] `make test` passes (27 tests, 1 skipped)
- [x] Code formatted with `go fmt`

Fixes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)