### PR TITLE
feat: add cluster and Azure configuration to version summary

### DIFF
--- a/test/06_verification_test.go
+++ b/test/06_verification_test.go
@@ -238,7 +238,7 @@ func TestVerification_TestedVersionsSummary(t *testing.T) {
 	versions := GetComponentVersions(t, context)
 
 	// Format and display the version summary
-	summary := FormatComponentVersions(versions)
+	summary := FormatComponentVersions(versions, config)
 	PrintToTTY("%s", summary)
 	t.Log(summary)
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1069,22 +1069,35 @@ func GetComponentVersions(t *testing.T, kubeContext string) []ComponentVersion {
 
 // FormatComponentVersions formats a slice of ComponentVersion for display.
 // Returns a formatted string suitable for logging.
-func FormatComponentVersions(versions []ComponentVersion) string {
+// Pass nil for config to omit cluster and Azure settings.
+func FormatComponentVersions(versions []ComponentVersion, config *TestConfig) string {
 	var result strings.Builder
-	result.WriteString("\n╔════════════════════════════════════════════════════════════════════════════════╗\n")
-	result.WriteString("║                      TESTED COMPONENT VERSIONS                                 ║\n")
-	result.WriteString("╠════════════════════════════════════════════════════════════════════════════════╣\n")
+	result.WriteString("\n=== TESTED CONFIGURATION ===\n")
 
-	for _, v := range versions {
-		// Truncate image if too long for display
-		displayImage := v.Image
-		if len(displayImage) > 60 {
-			displayImage = displayImage[:57] + "..."
+	if config != nil {
+		// Local cluster settings
+		result.WriteString("\nLocal (Kind) Cluster:\n")
+		result.WriteString(fmt.Sprintf("  Management Cluster: %s\n", config.ManagementClusterName))
+		result.WriteString(fmt.Sprintf("  Workload Cluster:   %s\n", config.WorkloadClusterName))
+
+		// Azure settings
+		result.WriteString("\nAzure Settings:\n")
+		result.WriteString(fmt.Sprintf("  Region:             %s\n", config.Region))
+		if config.AzureSubscription != "" {
+			result.WriteString(fmt.Sprintf("  Subscription:       %s\n", config.AzureSubscription))
 		}
-		result.WriteString(fmt.Sprintf("║ %-38s │ %-15s ║\n", v.Name, v.Version))
+		result.WriteString(fmt.Sprintf("  Resource Group:     %s-resgroup\n", config.ClusterNamePrefix))
+		result.WriteString(fmt.Sprintf("  OpenShift Version:  %s\n", config.OpenShiftVersion))
 	}
 
-	result.WriteString("╚════════════════════════════════════════════════════════════════════════════════╝\n")
+	// Component versions
+	result.WriteString("\n=== COMPONENT VERSIONS ===\n\n")
+
+	for _, v := range versions {
+		result.WriteString(fmt.Sprintf("%s: %s\n", v.Name, v.Version))
+		result.WriteString(fmt.Sprintf("  Image: %s\n", v.Image))
+	}
+
 	return result.String()
 }
 

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -1350,7 +1350,7 @@ func TestFormatComponentVersions(t *testing.T) {
 			versions: []ComponentVersion{
 				{Name: "CAPZ", Version: "v1.19.0", Image: "mcr.microsoft.com/capz:v1.19.0"},
 			},
-			checks: []string{"CAPZ", "v1.19.0", "TESTED COMPONENT VERSIONS"},
+			checks: []string{"CAPZ", "v1.19.0", "COMPONENT VERSIONS"},
 		},
 		{
 			name: "multiple components",
@@ -1370,26 +1370,48 @@ func TestFormatComponentVersions(t *testing.T) {
 		{
 			name:     "empty versions",
 			versions: []ComponentVersion{},
-			checks:   []string{"TESTED COMPONENT VERSIONS"},
+			checks:   []string{"COMPONENT VERSIONS"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := FormatComponentVersions(tt.versions)
+			result := FormatComponentVersions(tt.versions, nil)
 
 			for _, check := range tt.checks {
 				if !strings.Contains(result, check) {
 					t.Errorf("FormatComponentVersions() output should contain %q, got:\n%s", check, result)
 				}
 			}
-
-			// Verify box drawing characters are present
-			if !strings.Contains(result, "╔") || !strings.Contains(result, "╚") {
-				t.Errorf("FormatComponentVersions() should use box drawing characters, got:\n%s", result)
-			}
 		})
 	}
+
+	// Test with full config
+	t.Run("with config", func(t *testing.T) {
+		versions := []ComponentVersion{
+			{Name: "CAPZ", Version: "v1.19.0", Image: "mcr.microsoft.com/capz:v1.19.0"},
+		}
+		config := &TestConfig{
+			ManagementClusterName: "test-mgmt",
+			WorkloadClusterName:   "test-workload",
+			Region:                "eastus",
+			ClusterNamePrefix:     "test-prefix",
+			OpenShiftVersion:      "4.21",
+		}
+		result := FormatComponentVersions(versions, config)
+		checks := []string{
+			"test-mgmt",
+			"test-workload",
+			"eastus",
+			"test-prefix-resgroup",
+			"4.21",
+		}
+		for _, check := range checks {
+			if !strings.Contains(result, check) {
+				t.Errorf("FormatComponentVersions() should contain %q, got:\n%s", check, result)
+			}
+		}
+	})
 }
 
 func TestComponentVersionStruct(t *testing.T) {


### PR DESCRIPTION
## Summary

Enhance the component versions summary test to display comprehensive configuration information:

- **Local (Kind) Cluster**: Management and workload cluster names
- **Azure Settings**: Region, subscription, resource group, OpenShift version
- **Component Versions**: Name, version, and full container image reference

This provides complete visibility into the test configuration and deployed component versions at the end of the test run.

## Example Output

```
=== TESTED CONFIGURATION ===

Local (Kind) Cluster:
  Management Cluster: capz-tests-stage
  Workload Cluster:   capz-tests-cluster

Azure Settings:
  Region:             uksouth
  Resource Group:     rcapb-stage-resgroup
  OpenShift Version:  4.21

=== COMPONENT VERSIONS ===

CAPZ (Cluster API Provider Azure): unknown
  Image: quay.io/mveber/cluster-api-azure-controller:dev-aso.3.8
ASO (Azure Service Operator): v2.13.0-hcpclusters.1
  Image: quay.io/mveber/azureserviceoperator:v2.13.0-hcpclusters.1
CAPI (Cluster API): v4.21
  Image: quay.io/mveber/ose-cluster-api-rhel9:v4.21
```

## Test plan

- [x] `go test -v ./test -run TestVerification_TestedVersionsSummary` passes
- [x] `go test -v ./test -run TestFormatComponentVersions` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)