### PR TITLE
feat: add deployment state file for accurate cleanup targeting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ vendor/
 *.log
 *.out
 results/
+
+# Deployment state (written by tests, read by cleanup)
+.deployment-state.json

--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -120,6 +120,14 @@ func TestKindCluster_KindClusterReady(t *testing.T) {
 	PrintToTTY("✅ Kind cluster is ready\n\n")
 	t.Logf("Kind cluster nodes:\n%s", output)
 	t.Log("Kind cluster is ready")
+
+	// Write deployment state file for cleanup to know what was actually deployed
+	if err := WriteDeploymentState(config); err != nil {
+		t.Logf("Warning: failed to write deployment state file: %v", err)
+	} else {
+		PrintToTTY("📝 Deployment state saved to %s\n", DeploymentStateFile)
+		t.Logf("Deployment state saved to %s", DeploymentStateFile)
+	}
 }
 
 // TestKindCluster_CAPINamespacesExists verifies CAPI namespaces are installed


### PR DESCRIPTION
## Summary

Fixes the issue where `make clean` targets a different Azure resource group than what was actually created during `make test-all`.

**Problem**: Go tests use `config.go` defaults, while Makefile uses its own defaults. If the user has a local config change (e.g., `DefaultCAPZUser = "rcapb"`) but the Makefile still has `CAPZ_USER ?= rcap`, cleanup would look for `rcap-stage-resgroup` instead of the actual `rcapb-stage-resgroup`.

**Solution**: Add a deployment state file (`.deployment-state.json`) that:
- Is written during cluster deployment with actual config values used
- Is read by Makefile cleanup targets to determine correct resource group
- Falls back to Makefile defaults if state file doesn't exist
- Is removed after cleanup completes

## Changes

- `test/helpers.go`: Add `DeploymentState` struct and read/write functions
- `test/03_cluster_test.go`: Write state file after cluster is ready
- `Makefile`: Read state file values, use for cleanup targets
- `.gitignore`: Add `.deployment-state.json`

## Example

After running tests:
```json
// .deployment-state.json
{
  "resource_group": "rcapb-stage-resgroup",
  "management_cluster_name": "capz-tests-stage",
  ...
}
```

Running cleanup:
```
📝 Using deployment state from .deployment-state.json
   Resource group: rcapb-stage-resgroup
   Management cluster: capz-tests-stage
```

## Test plan

- [x] Code compiles (`go build ./...`)
- [ ] Manual test: run `make test-all`, verify `.deployment-state.json` is created
- [ ] Manual test: run `make clean`, verify it uses values from state file

🤖 Generated with [Claude Code](https://claude.com/claude-code)