### PR TITLE
fix: use 'default' namespace where CAPI resources are deployed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,12 +206,13 @@ These environment variables are validated in the Check Dependencies phase. If mi
 - `REGION` - Azure region (default: `uksouth`)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)
 - `CAPZ_USER` - User identifier for domain prefix (default: `rcap`). Must be short enough that `${CAPZ_USER}-${DEPLOYMENT_ENV}` does not exceed 15 characters.
-- `TEST_NAMESPACE` - Kubernetes namespace for testing resources (default: `capz_tests`). All resource checks will be scoped to this namespace instead of using `-A` (all namespaces).
+- `TEST_NAMESPACE` - Kubernetes namespace for testing resources (default: `default`). All resource checks will be scoped to this namespace instead of using `-A` (all namespaces).
 
 **RFC 1123 Naming Compliance**: The following variables must be RFC 1123 compliant (lowercase alphanumeric and hyphens only, must start/end with alphanumeric):
 - `CAPZ_USER`
 - `CS_CLUSTER_NAME`
 - `DEPLOYMENT_ENV`
+- `TEST_NAMESPACE`
 
 This is validated during Check Dependencies (phase 1) to prevent late deployment failures.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Tests are configured via environment variables:
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)
 - `CAPZ_USER` - User identifier for domain prefix (default: `rcap`)
-- `TEST_NAMESPACE` - Kubernetes namespace for testing resources (default: `capz_tests`). All resource checks will be scoped to this namespace.
+- `TEST_NAMESPACE` - Kubernetes namespace for testing resources (default: `default`). All resource checks will be scoped to this namespace.
 
 #### Naming Requirements (RFC 1123)
 
@@ -84,6 +84,7 @@ The following variables must be **RFC 1123 compliant** to avoid deployment failu
 - `CAPZ_USER`
 - `CS_CLUSTER_NAME`
 - `DEPLOYMENT_ENV`
+- `TEST_NAMESPACE`
 
 **RFC 1123 naming rules:**
 - Only lowercase alphanumeric characters and hyphens (`a-z`, `0-9`, `-`)

--- a/test/README.md
+++ b/test/README.md
@@ -87,7 +87,7 @@ Tests are configured via environment variables:
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `DEPLOYMENT_ENV` - Deployment environment (stage/prod) (default: `stage`)
 - `USER` - User identifier
-- `TEST_NAMESPACE` - Kubernetes namespace for testing resources (default: `capz_tests`)
+- `TEST_NAMESPACE` - Kubernetes namespace for testing resources (default: `default`)
 
 ## Running Tests
 

--- a/test/config.go
+++ b/test/config.go
@@ -94,7 +94,7 @@ func NewTestConfig() *TestConfig {
 		AzureSubscription:     os.Getenv("AZURE_SUBSCRIPTION_NAME"),
 		Environment:           GetEnvOrDefault("DEPLOYMENT_ENV", DefaultDeploymentEnv),
 		User:                  GetEnvOrDefault("CAPZ_USER", DefaultCAPZUser),
-		TestNamespace:         GetEnvOrDefault("TEST_NAMESPACE", "capztest"),
+		TestNamespace:         GetEnvOrDefault("TEST_NAMESPACE", "default"),
 
 		// Paths
 		ClusterctlBinPath: GetEnvOrDefault("CLUSTERCTL_BIN", "./bin/clusterctl"),


### PR DESCRIPTION
## Summary

- Change `TEST_NAMESPACE` default from `capztest` to `default`
- Update documentation in README.md, CLAUDE.md, and test/README.md
- Add `TEST_NAMESPACE` to RFC 1123 compliance validation list

## Problem

The previous PR #313 fixed the invalid underscore in `capz_tests` by changing it to `capztest`. However, the generated YAML files from `aro-hcp-gen.sh` deploy resources to the `default` namespace, not `capztest`.

This caused tests to look in `capztest` namespace while resources were actually deployed to `default`:

```
=== Monitoring cluster deployment ===
Cluster: rcapc-stage
Namespace: capztest  <-- Looking here
...
⚠️  Cluster resource not found (may not be deployed yet)
```

## Solution

Changed the default `TEST_NAMESPACE` to `default` to match where CAPI/ARO resources are actually deployed by the aro-hcp-gen.sh script.

## Test plan

- [x] Verify `TestCheckDependencies_NamingCompliance/TEST_NAMESPACE` passes
- [ ] Verify tests can find cluster resources in the correct namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)