### PR TITLE
fix: tighten file/directory permissions for gosec security compliance (fixes #312)

### DIFF
--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1338,7 +1338,7 @@ func SaveControllerLogs(t *testing.T, kubeContext, namespace, deploymentName, co
 	}
 
 	// Create output directory if it doesn't exist
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
+	if err := os.MkdirAll(outputDir, 0750); err != nil {
 		return "", fmt.Errorf("failed to create output directory: %w", err)
 	}
 
@@ -1347,7 +1347,7 @@ func SaveControllerLogs(t *testing.T, kubeContext, namespace, deploymentName, co
 	logFilePath := fmt.Sprintf("%s/%s", outputDir, filename)
 
 	// Write logs to file
-	if err := os.WriteFile(logFilePath, []byte(logs), 0644); err != nil {
+	if err := os.WriteFile(logFilePath, []byte(logs), 0600); err != nil {
 		return "", fmt.Errorf("failed to write log file: %w", err)
 	}
 
@@ -1510,7 +1510,7 @@ func GetResultsDir() string {
 	// Create a new results directory with current timestamp
 	timestamp := time.Now().Format("20060102_150405")
 	newDir := fmt.Sprintf("results/%s", timestamp)
-	if err := os.MkdirAll(newDir, 0755); err != nil {
+	if err := os.MkdirAll(newDir, 0750); err != nil {
 		// Fall back to /tmp if we can't create the directory
 		return os.TempDir()
 	}


### PR DESCRIPTION
## Summary
Fixes 3 medium-severity gosec security findings by tightening file and directory permissions.

## Problem
The gosec security scanner detected 3 permission-related issues in `test/helpers.go`:
- **G301** (line 1341): Directory created with 0755 permissions (should be 0750 or less)
- **G306** (line 1350): File written with 0644 permissions (should be 0600 or less)
- **G301** (line 1513): Directory created with 0755 permissions (should be 0750 or less)

See issue #312 for the full security report.

## Solution
Tightened all file and directory permissions to meet gosec security requirements:
- Changed `os.MkdirAll()` permissions from `0755` to `0750` (removes world read/execute)
- Changed `os.WriteFile()` permissions from `0644` to `0600` (removes group/world read)

## Changes
- `test/helpers.go:1341` - `SaveControllerLogs()`: Directory permission 0755 → 0750
- `test/helpers.go:1350` - `SaveControllerLogs()`: File permission 0644 → 0600  
- `test/helpers.go:1513` - `GetResultsDir()`: Directory permission 0755 → 0750

## Testing
- [x] All check dependencies tests pass
- [x] Code formatted with `go fmt`
- [x] gosec workflow will verify the fixes on CI

Fixes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)