### PR TITLE
feat: support service principal authentication as alternative to az login (fixes #242)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,18 +178,46 @@ See `docs/INTEGRATION.md` for detailed integration patterns.
 
 ### Azure Authentication (Required)
 
-These environment variables are validated in the Check Dependencies phase. If missing, tests will fail with clear remediation instructions.
+The test suite supports two authentication methods. Choose the one that best fits your workflow:
 
+#### Option 1: Service Principal (Recommended for CI/Automation)
+
+Set these environment variables to authenticate using an existing service principal:
+
+- `AZURE_CLIENT_ID` - Service principal application (client) ID (**required for SP auth**)
+- `AZURE_CLIENT_SECRET` - Service principal secret (**required for SP auth**)
 - `AZURE_TENANT_ID` - Azure tenant ID (**required**)
-  ```bash
-  export AZURE_TENANT_ID=$(az account show --query tenantId -o tsv)
-  ```
-- `AZURE_SUBSCRIPTION_ID` or `AZURE_SUBSCRIPTION_NAME` - Azure subscription identifier (**one required**)
-  ```bash
-  export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
-  # OR
-  export AZURE_SUBSCRIPTION_NAME=$(az account show --query name -o tsv)
-  ```
+- `AZURE_SUBSCRIPTION_ID` - Azure subscription ID (**required**)
+
+```bash
+export AZURE_CLIENT_ID=<your-client-id>
+export AZURE_CLIENT_SECRET=<your-client-secret>
+export AZURE_TENANT_ID=<your-tenant-id>
+export AZURE_SUBSCRIPTION_ID=<your-subscription-id>
+```
+
+To create a new service principal:
+```bash
+az ad sp create-for-rbac --name <name> --role Contributor --scopes /subscriptions/<subscription-id>
+```
+
+#### Option 2: Azure CLI (Convenient for Development)
+
+Simply login with Azure CLI and the test suite will auto-extract required credentials:
+
+```bash
+az login
+```
+
+The following environment variables can be auto-extracted from Azure CLI if not set:
+- `AZURE_TENANT_ID` - Azure tenant ID (auto-extracted via `az account show`)
+- `AZURE_SUBSCRIPTION_ID` or `AZURE_SUBSCRIPTION_NAME` - Azure subscription identifier (auto-extracted)
+
+Manual export if needed:
+```bash
+export AZURE_TENANT_ID=$(az account show --query tenantId -o tsv)
+export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+```
 
 ### Repository Configuration
 - `ARO_REPO_URL` - cluster-api-installer URL (default: RadekCap/cluster-api-installer)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ Target usage of this test suite will be:
 
 - Azure account with appropriate permissions
 - Access to Azure subscription for ARO deployment
-- Authenticated via `az login`
+- Authenticated via one of:
+  - **Service principal** (recommended for CI): Set `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID`
+  - **Azure CLI** (for development): Run `az login`
 
 ## Configuration
 
@@ -122,9 +124,16 @@ The test suite validates naming compliance during the Check Dependencies phase (
    make check-prereq
    ```
 
-2. **Authenticate with Azure**:
+2. **Authenticate with Azure** (choose one):
    ```bash
+   # Option A: Azure CLI (convenient for development)
    az login
+
+   # Option B: Service Principal (recommended for CI/automation)
+   export AZURE_CLIENT_ID=<your-client-id>
+   export AZURE_CLIENT_SECRET=<your-client-secret>
+   export AZURE_TENANT_ID=<your-tenant-id>
+   export AZURE_SUBSCRIPTION_ID=<your-subscription-id>
    ```
 
 3. **Run check dependencies tests**:


### PR DESCRIPTION
## Summary
- Adds support for service principal authentication as an alternative to `az login`
- Enables reusing existing service principal credentials for CI/automation workflows
- Maintains full backward compatibility with Azure CLI authentication

## Problem
Users needed to run `az login` every time before running tests, which is inconvenient for CI/CD pipelines and automated workflows where service principal credentials are already available.

See issue #242

## Solution
Added dual authentication support:

1. **Service Principal Authentication** (recommended for CI/automation):
   - Set `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID`
   - Tests validate credentials by performing actual SP login
   - No manual `az login` required

2. **Azure CLI Authentication** (convenient for development):
   - Run `az login` as before
   - Auto-extracts tenant ID and subscription ID if not set

## Changes
- **test/helpers.go**: Added 4 new helper functions:
  - `DetectAzureAuthMode()` - Detects which auth method is available
  - `HasServicePrincipalCredentials()` - Quick SP credential check
  - `ValidateServicePrincipalCredentials()` - Validates SP can authenticate
  - `GetAzureAuthDescription()` - Human-readable auth mode description

- **test/01_check_dependencies_test.go**:
  - Renamed `TestCheckDependencies_AzureCLILogin_IsLoggedIn` to `TestCheckDependencies_AzureAuthentication`
  - Updated to support both authentication methods
  - Improved error messages with guidance for both options

- **test/helpers_test.go**: Added comprehensive tests for new functions

- **CLAUDE.md & README.md**: Updated documentation to describe both auth methods

## Testing
- [x] All new helper tests pass
- [x] Existing tests unaffected
- [x] Code compiles without errors
- [x] Code formatted with `go fmt`

Fixes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)