### PR TITLE
fix: generate test summary from all phases in test-all (fixes #317)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,15 +253,14 @@ test-all: ## Run all test phases sequentially
 	@echo "=== All Test Phases Completed Successfully ==="
 	@echo "======================================="
 	@echo ""
-	@# Generate test results summary
+	@# Generate test results summary from LATEST_RESULTS_DIR which contains all phases
+	@# Each phase copies its results to LATEST_RESULTS_DIR, so the summary aggregates all
 	@if [ -x scripts/generate-summary.sh ]; then \
 		echo ""; \
-		./scripts/generate-summary.sh $(RESULTS_DIR); \
-		cp -f $(RESULTS_DIR)/summary.txt $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
+		./scripts/generate-summary.sh $(LATEST_RESULTS_DIR); \
 	fi
 	@echo ""
-	@echo "All test results saved to: $(RESULTS_DIR)"
-	@echo "Latest results copied to: $(LATEST_RESULTS_DIR)/"
+	@echo "All test results saved to: $(LATEST_RESULTS_DIR)/"
 
 clean: ## Clean up test resources (interactive, use FORCE=1 to skip prompts)
 	@if [ "$(FORCE)" = "1" ]; then \


### PR DESCRIPTION
## Summary

Fixes the issue where `make test-all` was generating the overall summary only for the latest test phase instead of aggregating results from all 6 test phases.

## Problem

When running `make test-all`, the final "OVERALL SUMMARY" section only showed results from the last phase (typically ~28 tests from check dependencies) instead of all ~57 tests across all phases.

**Root Cause**: Each internal target (`_check-dep`, `_setup`, `_cluster`, etc.) is invoked via `$(MAKE)` which creates a new make invocation with a fresh `TIMESTAMP`. This means each phase saves results to a **different** `RESULTS_DIR`, but they all copy their results to `LATEST_RESULTS_DIR`.

The `test-all` target was passing `$(RESULTS_DIR)` to `generate-summary.sh`, which only contained the results from the final phase.

## Solution

Changed `test-all` to pass `$(LATEST_RESULTS_DIR)` to `generate-summary.sh` instead of `$(RESULTS_DIR)`. Since all phases copy their XML results to `LATEST_RESULTS_DIR`, the summary now correctly aggregates all test phases.

## Changes

- `Makefile`: Updated `test-all` target to use `LATEST_RESULTS_DIR` for summary generation

### Before

```
OVERALL SUMMARY
Total tests:   28
Passed:        27
Skipped:       1
```

### After

```
OVERALL SUMMARY
Total tests:   57
Passed:        54
Skipped:       3
```

## Testing

- [x] `make test` passes
- [x] `./scripts/generate-summary.sh results/latest` correctly shows all 57 tests across 6 phases
- [x] Makefile syntax is correct

Fixes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)