### PR TITLE
fix: increase DEPLOY_CRS_TIMEOUT to 60m to exceed deployment timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ TEST_VERBOSITY ?= -v
 # Individual phase timeouts (format: Go duration like 30m, 1h, etc.)
 CLUSTER_TIMEOUT ?= 30m
 GENERATE_YAMLS_TIMEOUT ?= 20m
-DEPLOY_CRS_TIMEOUT ?= 40m
+DEPLOY_CRS_TIMEOUT ?= 60m
 VERIFY_TIMEOUT ?= 20m
 
 # Results directory configuration


### PR DESCRIPTION
## Summary
- Increased `DEPLOY_CRS_TIMEOUT` from 40m to 60m
- Fixes timeout mismatch where Go test timeout (40m) was shorter than the internal deployment timeout (45m)
- Provides 15-minute buffer beyond the default 45m deployment timeout

## Problem
The test `TestDeployment_WaitForControlPlane` was being killed by Go's test runner at 40 minutes, before the internal deployment timeout (45m) could complete or properly report the actual error.

## Test plan
- [ ] Run `make _deploy-crs` and verify the test can run for the full 45m+ if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)