### PR TITLE
fix: skip Python version check on macOS

### DIFF
--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -97,7 +97,15 @@ func TestCheckDependencies_DockerDaemonRunning(t *testing.T) {
 // Newer versions (3.13+) are not supported and will cause deployment failures.
 // This is a fail-fast check - if Python version is unsupported, subsequent tests
 // that depend on Python scripts will fail.
+// Skipped on macOS where Python version management varies widely (see issue #330).
 func TestCheckDependencies_PythonVersion(t *testing.T) {
+	// Skip on macOS - Python 3.14.2 works on Mac but 3.14 fails on Fedora
+	// See issue #330 for investigation into exact version requirements
+	if runtime.GOOS == "darwin" {
+		t.Skip("Skipping Python version check on macOS (see issue #330)")
+		return
+	}
+
 	// Determine which Python command to use
 	var pythonCmd string
 	if CommandExists("python3") {


### PR DESCRIPTION
## Summary
- Skip Python version check on macOS where Python 3.14.2 works properly
- References issue #330 for tracking the investigation

## Background
- Python 3.14 fails on Fedora with cluster-api-installer scripts
- Python 3.14.2 works on macOS
- The exact version requirements need investigation (tracked in #330)

## Test plan
- [x] Verify test skips on macOS: `go test -v ./test -run TestCheckDependencies_PythonVersion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)