### PR TITLE
fix: extract CAPZ_USER from Go config for single source of truth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 .PHONY: test _check-dep _setup _cluster _generate-yamls _deploy-crds _verify test-all clean clean-all clean-azure help summary
 
 # Default values
+# Extract CAPZ_USER default from Go config to maintain single source of truth
+CAPZ_USER_DEFAULT := $(shell grep 'DefaultCAPZUser = ' test/config.go | grep -o '"[^"]*"' | tr -d '"')
+CAPZ_USER ?= $(CAPZ_USER_DEFAULT)
 DEPLOYMENT_ENV ?= stage
 REGION ?= uksouth
 MANAGEMENT_CLUSTER_NAME ?= capz-tests-stage
-CAPZ_USER ?= rcap
 CS_CLUSTER_NAME ?= $(CAPZ_USER)-$(DEPLOYMENT_ENV)
 AZURE_RESOURCE_GROUP ?= $(CS_CLUSTER_NAME)-resgroup
 


### PR DESCRIPTION
## Summary
- Makefile now extracts `CAPZ_USER` default from `test/config.go` (`DefaultCAPZUser` constant)
- Eliminates duplication and potential mismatch between Go and Makefile defaults

## Problem
Previously, `CAPZ_USER` was hardcoded in both:
- `Makefile`: `CAPZ_USER ?= rcap`
- `test/config.go`: `DefaultCAPZUser = "rcapd"`

This caused `make clean-azure` to target `rcap-stage-resgroup` while tests created `rcapd-stage-resgroup`.

## Solution
Makefile now extracts the value from Go config:
```make
CAPZ_USER_DEFAULT := $(shell grep 'DefaultCAPZUser = ' test/config.go | grep -o '"[^"]*"' | tr -d '"')
CAPZ_USER ?= $(CAPZ_USER_DEFAULT)
```

## Test plan
- [x] Verify extraction works: `make -p 2>/dev/null | grep CAPZ_USER_DEFAULT`
- [x] Verify resource group name matches between tests and cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)