### PR TITLE
docs: update README with comprehensive make targets documentation (fixes #326)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,59 @@ TEST_VERBOSITY=-v make test
 
 **Note**: All test targets automatically generate JUnit XML reports in a timestamped `results/` directory. The path to the results directory is displayed when tests run.
 
+### All Make Targets
+
+Run `make help` to see all available targets. Here's the complete reference:
+
+#### Test Targets
+
+| Target | Description |
+|--------|-------------|
+| `make test` | Run check dependencies tests only (fast, no Azure resources) |
+| `make test-all` | Run all test phases sequentially |
+| `make summary` | Generate test results summary from latest results |
+
+#### Internal Test Phases
+
+These targets are called by `make test-all` but can be run individually for debugging:
+
+| Target | Description |
+|--------|-------------|
+| `make _check-dep` | Check software prerequisites needed for a proper test run |
+| `make _setup` | Setup and prepare input repositories with helm charts and CRDs |
+| `make _cluster` | Prepare cluster for testing and operators |
+| `make _generate-yamls` | Generate script for resource creation (yaml) |
+| `make _deploy-crs` | Deploy CRs and verify deployment |
+| `make _verify` | Verify deployed cluster |
+
+#### Cleanup Targets
+
+| Target | Description |
+|--------|-------------|
+| `make clean` | Interactive cleanup - prompts before deleting each resource |
+| `make clean-all` | Delete ALL resources without prompting (local + Azure) |
+| `FORCE=1 make clean` | Same as `make clean-all` |
+| `make clean-azure` | Delete only Azure resource group (interactive) |
+
+#### Setup and Prerequisites
+
+| Target | Description |
+|--------|-------------|
+| `make check-prereq` | Check if required tools are installed |
+| `make setup-submodule` | Add cluster-api-installer as a git submodule |
+| `make update-submodule` | Update cluster-api-installer submodule |
+| `make install-gotestsum` | Install gotestsum for test summaries |
+| `make check-gotestsum` | Check if gotestsum is installed, install if missing |
+| `make fix-docker-config` | Fix Docker credential helper configuration issues |
+
+#### Development Targets
+
+| Target | Description |
+|--------|-------------|
+| `make fmt` | Format Go code |
+| `make lint` | Run linters |
+| `make deps` | Download Go dependencies |
+
 #### Using Go Test Directly
 
 ```bash


### PR DESCRIPTION
## Summary

Updates the README.md with comprehensive documentation of all available make targets.

## Problem

Issue #326 identified that the make documentation in README was incomplete. Several make targets were available but not documented, making it difficult for users to discover all available commands.

## Solution

Added a new "All Make Targets" section to README.md organized into logical categories:

- **Test Targets**: `test`, `test-all`, `summary`
- **Internal Test Phases**: `_check-dep`, `_setup`, `_cluster`, `_generate-yamls`, `_deploy-crs`, `_verify`
- **Cleanup Targets**: `clean`, `clean-all`, `clean-azure`, `FORCE=1 make clean`
- **Setup and Prerequisites**: `check-prereq`, `setup-submodule`, `update-submodule`, `install-gotestsum`, `check-gotestsum`, `fix-docker-config`
- **Development Targets**: `fmt`, `lint`, `deps`

## Changes

- Added comprehensive tables documenting all make targets with descriptions
- Organized targets into logical categories for easy reference
- Added note about `make help` for quick reference
- Documented internal test phases that can be run individually for debugging

## Testing

- [x] Documentation-only change, no code affected
- [x] Verified all targets match current Makefile output from `make help`
- [x] Tables properly formatted in markdown

Fixes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)