### PR TITLE
fix: remove -u flag from generate-summary.sh to fix unbound variable error

### DIFF
--- a/scripts/generate-summary.sh
+++ b/scripts/generate-summary.sh
@@ -21,7 +21,7 @@
 #   - Overall totals across all phases
 #   - Links to controller logs (CAPI, CAPZ, ASO) if available
 
-set -euo pipefail
+set -eo pipefail
 
 # Colors for terminal output (disabled if not a terminal or NO_COLOR is set)
 if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then


### PR DESCRIPTION
## Summary
- Removes `-u` (nounset) flag from `set -euo pipefail` in `generate-summary.sh`
- This fixes the "junit: unbound variable" error on line 73
- The `-u` flag was causing bash to interpret associative array keys like `["junit-check-dep"]` as variable references

## Test plan
- [ ] Run `bash -n scripts/generate-summary.sh` to verify syntax
- [ ] Run `make test-all` to verify summary generation works
- [ ] Verify summary.txt is created in results directory

Fixes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)