### PR TITLE
fix: ensure controller logs are copied to results/latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,9 +186,10 @@ _verify: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	$(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-verify.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestVerification -timeout $(VERIFY_TIMEOUT) || EXIT_CODE=$$?; \
+	TEST_RESULTS_DIR=$(RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-verify.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestVerification -timeout $(VERIFY_TIMEOUT) || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
+	cp -f $(RESULTS_DIR)/*.log $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	echo ""; \
 	echo "Test results saved to: $(RESULTS_DIR)/junit-verify.xml"; \
 	echo "Latest results copied to: $(LATEST_RESULTS_DIR)/"; \

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1722,8 +1722,17 @@ func SaveAllControllerLogs(t *testing.T, kubeContext, outputDir string, summarie
 }
 
 // GetResultsDir returns the appropriate results directory for saving logs.
-// It looks for the latest results directory, or creates one if needed.
+// It checks TEST_RESULTS_DIR env var first (set by Makefile), then falls back
+// to looking for the latest results directory, or creates one if needed.
 func GetResultsDir() string {
+	// Check for environment variable set by Makefile
+	if envDir := os.Getenv("TEST_RESULTS_DIR"); envDir != "" {
+		// Ensure directory exists
+		if err := os.MkdirAll(envDir, 0750); err == nil {
+			return envDir
+		}
+	}
+
 	// Check for latest results directory first
 	latestDir := "results/latest"
 	if DirExists(latestDir) {


### PR DESCRIPTION
## Summary
- Adds `TEST_RESULTS_DIR` env var support to `GetResultsDir()` so tests save logs to the correct directory
- Updates Makefile `_verify` target to pass `TEST_RESULTS_DIR` and copy `*.log` files to `results/latest`

## Problem
Controller logs were being saved during verification tests but not appearing in `results/latest` because:
1. `GetResultsDir()` returned a previous run's directory (timing issue)
2. Makefile only copied `*.xml` files, not `*.log` files

## Test plan
- [ ] Run `make _verify`
- [ ] Check `ls results/latest/*.log` - should show capi, capz, aso log files
- [ ] Run `make summary` - should list controller logs in the summary output

🤖 Generated with [Claude Code](https://claude.com/claude-code)