### PR TITLE
fix: use absolute path for TEST_RESULTS_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ _verify: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	TEST_RESULTS_DIR=$(RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-verify.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestVerification -timeout $(VERIFY_TIMEOUT) || EXIT_CODE=$$?; \
+	TEST_RESULTS_DIR=$(CURDIR)/$(RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-verify.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestVerification -timeout $(VERIFY_TIMEOUT) || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	cp -f $(RESULTS_DIR)/*.log $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \


### PR DESCRIPTION
## Summary
- Uses `$(CURDIR)/$(RESULTS_DIR)` instead of just `$(RESULTS_DIR)` for `TEST_RESULTS_DIR`

## Problem
Go tests run from the package directory (`test/`), so relative paths like `results/...` resolved to `test/results/...` instead of the repo root's `results/...`.

## Verification
After this fix:
```
$ make _verify
$ ls results/latest/*.log
results/latest/aso-20260109_235314.log
results/latest/capi-20260109_235314.log
results/latest/capz-20260109_235314.log
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)