### PR TITLE
fix: include _delete phase in make test-all

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ make _cluster        # Cluster deployment
 make _generate-yamls # YAML generation
 make _deploy-crs     # CR deployment
 make _verify         # Cluster verification
+make _delete         # Cluster deletion
 
 # Run specific test function
 go test -v ./test -run TestCheckDependencies_ToolAvailable

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -86,6 +86,7 @@ make _cluster        # Cluster deployment
 make _generate-yamls # YAML generation
 make _deploy-crs     # CR deployment
 make _verify         # Cluster verification
+make _delete         # Cluster deletion
 
 # Run specific test function
 go test -v ./test -run TestCheckDependencies_ToolAvailable

--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,13 @@ _test-all-impl:
 		echo ""; \
 		exit 1 \
 	)
+	@$(MAKE) --no-print-directory _delete || ( \
+		echo ""; \
+		echo "❌ ERROR: Cluster deletion phase failed."; \
+		echo "   Previous stages completed successfully but cluster deletion encountered issues."; \
+		echo ""; \
+		exit 1 \
+	)
 	@echo ""
 	@echo "======================================="
 	@echo "=== All Test Phases Completed Successfully ==="

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ These targets are called by `make test-all` but can be run individually for debu
 | `make _generate-yamls` | Generate script for resource creation (yaml) |
 | `make _deploy-crs` | Deploy CRs and verify deployment |
 | `make _verify` | Verify deployed cluster |
+| `make _delete` | Delete workload cluster and verify cleanup |
 
 #### Cleanup Targets
 

--- a/docs/test-analysis/README.md
+++ b/docs/test-analysis/README.md
@@ -21,7 +21,9 @@ make test-all
     │
     ├── 5. make _deploy-crs    CR Deployment
     │
-    └── 6. make _verify        Cluster Verification
+    ├── 6. make _verify        Cluster Verification
+    │
+    └── 7. make _delete        Cluster Deletion
 ```
 
 ---
@@ -36,8 +38,9 @@ make test-all
 | 4 | [_generate-yamls](04-generate-yamls/00-Overview.md) | `04_generate_yamls_test.go` | 4 | 20m | Generate YAML manifests |
 | 5 | [_deploy-crs](05-deploy-crs/00-Overview.md) | `05_deploy_crs_test.go` | 7 | 40m | Apply CRs, wait for deployment |
 | 6 | [_verify](06-verification/00-Overview.md) | `06_verification_test.go` | 7 | 20m | Validate workload cluster |
+| 7 | _delete | `07_deletion_test.go` | 6 | 60m | Delete workload cluster and verify cleanup |
 
-**Total: 40 tests across 6 phases**
+**Total: 46 tests across 7 phases**
 
 ---
 
@@ -95,6 +98,15 @@ make test-all
 │  Health: kubectl get pods -A (check for non-running)                        │
 │  Summary: Display component versions and save controller logs               │
 └─────────────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                            PHASE 7: DELETION                                 │
+│  Delete: kubectl delete cluster <cluster-name>                              │
+│  Wait: Monitor cluster resource until deleted                                │
+│  Verify: Check AROControlPlane, MachinePool deleted                         │
+│  Azure: Verify Azure resource group cleanup                                  │
+└─────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -114,6 +126,7 @@ make _cluster        # Phase 3
 make _generate-yamls # Phase 4
 make _deploy-crs     # Phase 5
 make _verify         # Phase 6
+make _delete         # Phase 7
 ```
 
 ### Key Environment Variables

--- a/scripts/generate-summary.sh
+++ b/scripts/generate-summary.sh
@@ -81,6 +81,7 @@ get_phase_name() {
         "junit-generate-yamls") echo "YAML Generation" ;;
         "junit-deploy-crs") echo "CR Deployment" ;;
         "junit-verify") echo "Cluster Verification" ;;
+        "junit-delete") echo "Cluster Deletion" ;;
         *) echo "$1" ;;
     esac
 }
@@ -93,6 +94,7 @@ PHASE_ORDER=(
     "junit-generate-yamls"
     "junit-deploy-crs"
     "junit-verify"
+    "junit-delete"
 )
 
 # Global counters (will be modified by functions)

--- a/test/README.md
+++ b/test/README.md
@@ -41,6 +41,11 @@ This test suite validates each step of the ARO deployment process as documented 
    - Checks OpenShift version and operators
    - Performs health checks
 
+7. **`07_deletion_test.go`** - Cluster deletion
+   - Deletes workload cluster from management cluster
+   - Waits for cluster deletion to complete
+   - Verifies Azure resources are cleaned up
+
 ### Helper Files
 
 - **`config.go`** - Test configuration management


### PR DESCRIPTION
## Summary

- Fix `make test-all` to include the `_delete` phase after `_verify`
- The deletion tests in `07_deletion_test.go` were not being executed as part of the full test suite
- Update `generate-summary.sh` to display "Cluster Deletion" phase results
- Update all documentation to reflect 7 phases instead of 6

## Changes

**Makefile:**
- Add `_delete` phase call in `_test-all-impl` target after `_verify`

**scripts/generate-summary.sh:**
- Add `junit-delete` to `PHASE_ORDER` array
- Add "Cluster Deletion" case to `get_phase_name` function

**Documentation updates:**
- `CLAUDE.md`: Add `make _delete` to individual test phases list
- `GEMINI.md`: Add `make _delete` to individual test phases list
- `README.md`: Add `_delete` to Internal Test Phases table
- `test/README.md`: Add `07_deletion_test.go` description
- `docs/test-analysis/README.md`: Add phase 7 to flow diagrams, tables, quick reference, and update total counts (40 → 46 tests, 6 → 7 phases)

## Test plan

- [x] `make test` passes (check dependencies tests)
- [ ] `make test-all` runs all 7 phases including deletion
- [ ] `make summary` shows "Cluster Deletion" phase in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)