### PR TITLE
fix: add --wait=false to cluster deletion command

### DIFF
--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -33,8 +33,9 @@ func TestDeletion_DeleteCluster(t *testing.T) {
 	t.Logf("Deleting cluster '%s' from namespace '%s'", provisionedClusterName, config.TestNamespace)
 
 	// Delete the cluster resource - this triggers cascading deletion of all related resources
+	// Use --wait=false to return immediately so the next test can monitor deletion progress
 	output, err := RunCommand(t, "kubectl", "--context", context, "-n", config.TestNamespace,
-		"delete", "cluster", provisionedClusterName)
+		"delete", "cluster", provisionedClusterName, "--wait=false")
 	if err != nil {
 		PrintToTTY("❌ Failed to delete cluster: %v\n", err)
 		PrintToTTY("Output: %s\n\n", output)


### PR DESCRIPTION
## Summary

- Add `--wait=false` flag to the `kubectl delete cluster` command in `TestDeletion_DeleteCluster`
- This allows the delete command to return immediately after initiating deletion
- Enables `TestDeletion_WaitForClusterDeletion` to run and report deletion progress

## Problem

The `kubectl delete cluster` command was blocking for 30-45 minutes until deletion completed. This prevented the progress reporting test from ever running, even though the progress reporting code was fully implemented.

## Solution

Adding `--wait=false` makes the command return immediately after marking the cluster for deletion. The subsequent test then monitors and reports detailed progress every 30 seconds.

## Test plan

- [ ] Run `make _delete` and verify progress reporting is displayed
- [ ] Verify deletion completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)