### PR TITLE
fix: use deploy-charts.sh script for Kind cluster deployment (fixes #358)

### DIFF
--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -42,7 +42,7 @@ func TestKindCluster_KindClusterReady(t *testing.T) {
 		PrintToTTY("✅ Azure credentials available\n")
 
 		// Deploy Kind cluster using the script
-		scriptPath := filepath.Join(config.RepoDir, "scripts", "deploy-charts-kind-capz.sh")
+		scriptPath := filepath.Join(config.RepoDir, "scripts", "deploy-charts.sh")
 		if !FileExists(scriptPath) {
 			PrintToTTY("❌ Deployment script not found: %s\n", scriptPath)
 			t.Errorf("Deployment script not found: %s", scriptPath)


### PR DESCRIPTION
## Summary
Updates the deployment script path to use the consolidated `deploy-charts.sh` script from cluster-api-installer, fixing the issue where CAPI/CAPZ/ASO controllers were not being deployed.

## Problem
After upstream changes in [cluster-api-installer PR #547](https://github.com/stolostron/cluster-api-installer/pull/547), the `deploy-charts-kind-capz.sh` script that was being used set `USE_KIND=true`, which caused `deploy-charts.sh` to look for charts with `-kind` suffix (e.g., `cluster-api-kind/Chart.yaml`). These charts no longer exist in the repository.

The script silently skipped chart installation due to this check:
```bash
[ -f $CHART/Chart.yaml ] || continue
```

**Result**: Only `cert-manager` and `multicluster-engine` were deployed. The critical namespaces `capi-system` and `capz-system` were never created, causing downstream failures when trying to patch the ASO credentials secret.

## Solution
Change the script path from `deploy-charts-kind-capz.sh` to `deploy-charts.sh`. The consolidated script handles both execution paths:
- Default: Kind cluster deployment (what we use)
- `USE_K8S=true`: K8s-specific namespace changes

## Changes
- `test/03_cluster_test.go`: Line 45 - updated script path

## Testing
- [x] `make test` passes (28 tests, 1 skipped)
- [x] Code formatted with `go fmt`

Fixes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)