### PR TITLE
chore: add credentials.json and CLAUDE.local.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ results/
 
 # Deployment state (written by tests, read by cleanup)
 .deployment-state.json
+
+# Credentials (never commit)
+credentials.json
+
+# Local Claude instructions (not committed)
+CLAUDE.local.md


### PR DESCRIPTION
## Summary
- Add `credentials.json` to .gitignore (local Jira/GitHub credentials)
- Add `CLAUDE.local.md` to .gitignore (local Claude Code instructions)

## Test plan
- [x] Verify files are ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)