### PR TITLE
fix: use config variables for repo clone in workflow (fixes #373)

### DIFF
--- a/.github/workflows/test-kind-cluster.yml
+++ b/.github/workflows/test-kind-cluster.yml
@@ -10,6 +10,11 @@ on:
   # pull_request:
   #   branches: [ "**" ]
 
+env:
+  ARO_REPO_URL: https://github.com/RadekCap/cluster-api-installer.git
+  ARO_REPO_BRANCH: ARO-ASO
+  ARO_REPO_DIR: /tmp/cluster-api-installer-aro
+
 jobs:
   test-kind:
     name: Cluster Preparation
@@ -50,16 +55,14 @@ jobs:
 
     - name: Clone cluster-api-installer repository
       run: |
-        if [ -d "/tmp/cluster-api-installer-aro" ]; then
+        if [ -d "$ARO_REPO_DIR" ]; then
           echo "Repository already exists, skipping clone"
         else
-          git clone -b ARO-ASO https://github.com/RadekCap/cluster-api-installer.git /tmp/cluster-api-installer-aro
+          git clone -b "$ARO_REPO_BRANCH" "$ARO_REPO_URL" "$ARO_REPO_DIR"
           echo "Repository cloned successfully"
         fi
 
     - name: Run Kind cluster tests
-      env:
-        ARO_REPO_DIR: /tmp/cluster-api-installer-aro
       run: |
         mkdir -p test-results
         go run gotest.tools/gotestsum@v1.13.0 --format testname --jsonfile test-results/tests.json --junitfile test-results/junit.xml -- -v ./test -run TestKindCluster -timeout 30m


### PR DESCRIPTION
## Summary

Replace hardcoded repository clone command in the GitHub workflow with environment variables for flexibility.

## Problem

The workflow `.github/workflows/test-kind-cluster.yml` hardcoded the repository clone command:
```bash
git clone -b ARO-ASO https://github.com/RadekCap/cluster-api-installer.git /tmp/cluster-api-installer-aro
```

This bypassed `ARO_REPO_URL` and `ARO_REPO_BRANCH` configuration entirely, making it impossible to test against different repositories or branches.

## Solution

Added workflow-level environment variables and updated the clone command to use them:
- `ARO_REPO_URL` - Repository URL (default: `https://github.com/RadekCap/cluster-api-installer.git`)
- `ARO_REPO_BRANCH` - Branch to clone (default: `ARO-ASO`)
- `ARO_REPO_DIR` - Local directory path (default: `/tmp/cluster-api-installer-aro`)

## Changes

- Added `env:` block at workflow level with the three configuration variables
- Updated clone command to use `$ARO_REPO_URL`, `$ARO_REPO_BRANCH`, `$ARO_REPO_DIR`
- Removed redundant step-level `ARO_REPO_DIR` since it's now defined globally

## Testing

- [x] YAML syntax validated
- [x] Local tests pass (`make test`)
- [ ] Workflow can be tested manually via `workflow_dispatch`

Fixes #373

Generated with [Claude Code](https://claude.com/claude-code)