### PR TITLE
feat: add cloned repository info to test output (fixes #376)

### DIFF
--- a/test/02_setup_test.go
+++ b/test/02_setup_test.go
@@ -21,6 +21,9 @@ func TestSetup_CloneRepository(t *testing.T) {
 			return
 		}
 
+		// Register the existing repository for tracking in test output
+		RegisterClonedRepository(config.RepoURL, config.RepoBranch, config.RepoDir)
+
 		t.Log("Using existing repository")
 		return
 	}
@@ -33,6 +36,9 @@ func TestSetup_CloneRepository(t *testing.T) {
 		t.Errorf("Failed to clone repository: %v\nOutput: %s", err, output)
 		return
 	}
+
+	// Register the cloned repository for tracking in test output
+	RegisterClonedRepository(config.RepoURL, config.RepoBranch, config.RepoDir)
 
 	t.Logf("Repository cloned successfully to %s", config.RepoDir)
 }


### PR DESCRIPTION
## Summary

Add repository tracking to display which repositories were used during test execution in the final test output.

## Problem

When debugging test failures or auditing test runs, it was not clear which repository versions were used. This made it difficult to reproduce issues or verify which code was actually tested.

## Solution

Added repository tracking that captures git clone operations and displays them in the test summary output alongside component versions.

## Changes

- `test/helpers.go`:
  - Added `ClonedRepository` struct to hold URL, branch, and path
  - Added thread-safe global registry with `RegisterClonedRepository()`, `GetClonedRepositories()`, `ClearClonedRepositories()`
  - Updated `FormatComponentVersions()` to include "USED REPOSITORIES" section

- `test/02_setup_test.go`:
  - Added `RegisterClonedRepository()` call after successful clone
  - Added registration for existing repositories (reuse case)

- `test/helpers_test.go`:
  - Added `TestClonedRepositoryTracking` for registry functionality
  - Added `TestFormatComponentVersions_WithRepositories` for output formatting

## Example Output

```
=== TESTED CONFIGURATION ===

Local (Kind) Cluster:
  Management Cluster: capz-tests-stage
  Workload Cluster:   capz-tests-cluster

=== USED REPOSITORIES ===

- https://github.com/RadekCap/cluster-api-installer
  Branch: ARO-ASO

=== COMPONENT VERSIONS ===

CAPZ (Cluster API Provider Azure): v1.19.0
  Image: mcr.microsoft.com/capz:v1.19.0
```

## Testing

- [x] All existing tests pass (`make test`)
- [x] New unit tests pass
- [x] Code formatted (`go fmt`)
- [x] Linter passes (`go vet`)

Fixes #376

Generated with [Claude Code](https://claude.com/claude-code)