### PR TITLE
fix: correct config.go defaults and complete hardcoded values audit (fixes #374, #375)

### DIFF
--- a/test/config.go
+++ b/test/config.go
@@ -83,8 +83,8 @@ type TestConfig struct {
 func NewTestConfig() *TestConfig {
 	return &TestConfig{
 		// Repository defaults
-		RepoURL:    GetEnvOrDefault("ARO_REPO_URL", "https://github.com/marek-veber/cluster-api-installer"),
-		RepoBranch: GetEnvOrDefault("ARO_REPO_BRANCH", "add-aro-hcp-scripts"),
+		RepoURL:    GetEnvOrDefault("ARO_REPO_URL", "https://github.com/RadekCap/cluster-api-installer"),
+		RepoBranch: GetEnvOrDefault("ARO_REPO_BRANCH", "ARO-ASO"),
 		RepoDir:    getDefaultRepoDir(),
 
 		// Cluster defaults


### PR DESCRIPTION
## Summary

Fix incorrect defaults in config.go and complete the comprehensive hardcoded values audit.

## Problem

Issue #374 identified that `test/config.go` defaults didn't match documentation:

| Variable | config.go (was) | Documentation (correct) |
|----------|-----------------|-------------------------|
| `ARO_REPO_URL` | `marek-veber/cluster-api-installer` | `RadekCap/cluster-api-installer` |
| `ARO_REPO_BRANCH` | `add-aro-hcp-scripts` | `ARO-ASO` |

Issue #375 requested a comprehensive audit of all hardcoded values.

## Solution

1. Fixed config.go defaults to match documentation
2. Performed comprehensive audit of all hardcoded values

## Audit Results

### Repository Configuration
| Check | Status | Notes |
|-------|--------|-------|
| cluster-api-installer URLs | ✅ Fixed | This PR |
| Branch names | ✅ Fixed | This PR |
| /tmp/cluster-api-installer-aro | ✅ OK | Uses config via `getDefaultRepoDir()` |
| Workflow clone | ✅ Fixed | PR #377 |

### Cluster Configuration
| Check | Status | Notes |
|-------|--------|-------|
| Cluster names | ✅ OK | All use `GetEnvOrDefault()` |
| Azure regions | ✅ OK | All use `GetEnvOrDefault()` |
| OpenShift versions | ✅ OK | All use `GetEnvOrDefault()` |
| Namespaces | ✅ OK | All use `getControllerNamespace()` |

### User/Environment Configuration
| Check | Status | Notes |
|-------|--------|-------|
| CAPZ_USER | ✅ OK | All use config |
| DEPLOYMENT_ENV | ✅ OK | All use config |

### Documentation
All documentation files correctly describe the defaults:
- CLAUDE.md ✅
- README.md ✅
- test/README.md ✅
- docs/INTEGRATION.md ✅

## Changes

- `test/config.go`: Updated `ARO_REPO_URL` and `ARO_REPO_BRANCH` defaults

## Testing

- [x] All tests pass (`make test`)
- [x] Code formatted (`go fmt`)
- [x] Linter passes (`go vet`)

Fixes #374
Fixes #375

Generated with [Claude Code](https://claude.com/claude-code)