### PR TITLE
fix: add Azure AD App and Service Principal cleanup (fixes #380)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ make clean-all
 # OR use the FORCE variable:
 FORCE=1 make clean
 
-# Clean up only Azure resource group (interactive)
+# Clean up all Azure resources (resource group + orphaned resources)
 make clean-azure
 ```
 
@@ -138,29 +138,32 @@ For non-interactive cleanup (useful for CI/CD, scripted workflows, or quick rese
 - Use `make clean-all` to delete all resources without prompts (includes Azure resources and orphaned resources)
 - Or use `FORCE=1 make clean` to skip all confirmation prompts
 
-**Azure Resource Cleanup Notes**:
+**Azure Resource Cleanup (`make clean-azure`)**:
+
+The unified `make clean-azure` command cleans up all Azure resources in one operation:
+- Azure Resource Group (`${CS_CLUSTER_NAME}-resgroup`)
+- Orphaned ARM resources (Managed Identities, VNets, NSGs, DNS Zones)
+- Azure AD Applications (App Registrations)
+- Service Principals
+
+```bash
+# Interactive cleanup of all Azure resources
+make clean-azure
+
+# Non-interactive cleanup
+FORCE=1 make clean-azure
+
+# Dry-run to see what would be deleted
+./scripts/cleanup-azure-resources.sh --resource-group myapp-resgroup --prefix myapp --dry-run
+
+# Clean with custom prefix
+CAPZ_USER=myprefix make clean-azure
+```
+
+Notes:
 - The resource group name is derived from `${CAPZ_USER}-${DEPLOYMENT_ENV}-resgroup` (default: `rcap-stage-resgroup`)
 - Uses `az group delete --yes --no-wait` for non-blocking deletion
 - Gracefully skips Azure cleanup if Azure CLI is not installed or not authenticated
-- Checks if the resource group exists before attempting deletion
-
-**Orphaned Azure Resources**:
-Some Azure resources created during testing are not tied to the resource group and may survive its deletion. These include:
-- Managed Identities (control-plane and data-plane components)
-- Virtual Networks and Network Security Groups
-- DNS Zones
-
-Use `make clean-azure-resources` to find and delete these orphaned resources:
-```bash
-# Interactive cleanup of orphaned resources
-make clean-azure-resources
-
-# Non-interactive cleanup
-FORCE=1 make clean-azure-resources
-
-# Dry-run to see what would be deleted
-./scripts/cleanup-azure-resources.sh --dry-run --prefix rcapd
-```
 
 ### Code Quality
 


### PR DESCRIPTION
## Summary

Add cleanup for Azure AD Applications and Service Principals, and unify all Azure cleanup into a single `make clean-azure` command.

## Problem

1. When running `make clean-azure`, the cleanup process only handled the Azure resource group. Azure AD Applications (App Registrations) and Service Principals created during tests were left behind as orphaned resources.

2. There were two separate targets (`make clean-azure` and `make clean-azure-resources`) which was confusing and required running both for complete cleanup.

## Solution

1. Extended the cleanup script to find and delete:
   - Azure Resource Group (via `--resource-group` option)
   - ARM resources via Azure Resource Graph
   - Azure AD Applications using `az ad app list --filter`
   - Service Principals using `az ad sp list --filter`

2. Unified the Makefile targets so `make clean-azure` handles everything.

## Changes

### `scripts/cleanup-azure-resources.sh`
- Added `--resource-group` option to also delete resource group
- Added `find_ad_applications()` to search for App Registrations by displayName prefix
- Added `find_service_principals()` to search for Service Principals by displayName prefix
- Added `display_ad_applications()` and `delete_ad_applications()` functions
- Added `display_service_principals()` and `delete_service_principals()` functions
- Added `delete_resource_group()` function
- Fixed: redirect print_info to stderr in find_* functions (was corrupting JSON output)

### `Makefile`
- Unified `clean-azure` to call script with `--resource-group` and `--prefix`
- Removed separate `clean-azure-resources` target
- Simplified `_clean-azure-force` to use unified script
- Updated `clean-all` to use single Azure cleanup call

### `CLAUDE.md`
- Updated documentation to reflect unified `make clean-azure` command
- Added examples for all cleanup options

## Testing

- [x] Script syntax validated with `bash -n`
- [x] Dry-run tested successfully with all resource types
- [x] Makefile syntax verified with `make -n`
- [x] Verified AD Applications and Service Principals are now detected

## Usage

```bash
# Clean all Azure resources (interactive)
make clean-azure

# Clean all Azure resources (non-interactive)
FORCE=1 make clean-azure

# Dry-run to see what would be deleted
./scripts/cleanup-azure-resources.sh --resource-group myapp-resgroup --prefix myapp --dry-run

# Clean with custom prefix
CAPZ_USER=myprefix make clean-azure
```

Fixes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)