### PR TITLE
fix: update misleading output message about cluster types (fixes #388)

### DIFF
--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1377,13 +1377,13 @@ func FormatComponentVersions(versions []ComponentVersion, config *TestConfig) st
 	result.WriteString("\n=== TESTED CONFIGURATION ===\n")
 
 	if config != nil {
-		// Local cluster settings
-		result.WriteString("\nLocal (Kind) Cluster:\n")
+		// Local Kind cluster (management cluster)
+		result.WriteString("\nLocal Kind Cluster:\n")
 		result.WriteString(fmt.Sprintf("  Management Cluster: %s\n", config.ManagementClusterName))
-		result.WriteString(fmt.Sprintf("  Workload Cluster:   %s\n", config.WorkloadClusterName))
 
-		// Azure settings
-		result.WriteString("\nAzure Settings:\n")
+		// Azure ARO cluster (workload cluster)
+		result.WriteString("\nAzure ARO Cluster:\n")
+		result.WriteString(fmt.Sprintf("  Workload Cluster:   %s\n", config.WorkloadClusterName))
 		result.WriteString(fmt.Sprintf("  Region:             %s\n", config.Region))
 		if config.AzureSubscription != "" {
 			result.WriteString(fmt.Sprintf("  Subscription:       %s\n", config.AzureSubscription))


### PR DESCRIPTION
## Summary
- Fixes misleading output message that incorrectly grouped both Management and Workload clusters under "Local (Kind) Cluster:"
- Separates local Kind cluster from Azure ARO cluster in the output

## Problem
The output message from `FormatComponentVersions()` was displaying:

```
Local (Kind) Cluster:
  Management Cluster: capz-tests-stage
  Workload Cluster:   capz-tests-cluster
```

This was misleading because the Workload Cluster is actually an ARO cluster deployed on Azure, not a local cluster.

## Solution
Updated the output format to clearly distinguish between the local management cluster and the Azure workload cluster:

```
Local Kind Cluster:
  Management Cluster: capz-tests-stage

Azure ARO Cluster:
  Workload Cluster:   capz-tests-cluster
  Region:             uksouth
  Subscription:       <subscription>
  Resource Group:     <prefix>-resgroup
  OpenShift Version:  4.21
```

## Changes
- Renamed section header from "Local (Kind) Cluster:" to "Local Kind Cluster:"
- Moved Workload Cluster to new "Azure ARO Cluster:" section
- Grouped Azure-related settings (Region, Subscription, Resource Group, OpenShift Version) under the Azure ARO Cluster section

## Testing
- [x] All existing tests pass
- [x] `TestFormatComponentVersions` tests pass

Fixes #388

Generated with [Claude Code](https://claude.com/claude-code)