### PR TITLE
chore: update Go version to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/rcap/CAPZTests
 
-go 1.22
+go 1.24
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
## Summary
- Update `go.mod` to require Go 1.24

## Context
This change is required to unblock PR #412 (actions/setup-go v6 upgrade).

The `setup-go@v6` action sets `GOTOOLCHAIN=local` which prevents automatic toolchain downloading. Our CI workflows use `gotestsum v1.13.0` which requires Go 1.24+, causing builds to fail with Go 1.22.

## Test plan
- [ ] Verify all CI checks pass
- [ ] After merge, rebase PR #412 and verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)