### PR TITLE
fix: check os.Chdir error returns to satisfy errcheck linter (fixes #423)

### DIFF
--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -69,7 +69,11 @@ func TestKindCluster_KindClusterReady(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to get current directory: %v", err)
 		}
-		defer os.Chdir(originalDir)
+		defer func() {
+			if err := os.Chdir(originalDir); err != nil {
+				t.Logf("Warning: failed to change back to original directory: %v", err)
+			}
+		}()
 
 		if err := os.Chdir(config.RepoDir); err != nil {
 			t.Fatalf("Failed to change to repository directory: %v", err)

--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -94,7 +94,11 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get current directory: %v", err)
 	}
-	defer os.Chdir(originalDir)
+	defer func() {
+		if err := os.Chdir(originalDir); err != nil {
+			t.Logf("Warning: failed to change back to original directory: %v", err)
+		}
+	}()
 
 	if err := os.Chdir(config.RepoDir); err != nil {
 		t.Fatalf("Failed to change to repository directory: %v", err)


### PR DESCRIPTION
## Summary

Fixes CI Lint failure by properly handling error returns from deferred `os.Chdir` calls.

## Problem

The CI Lint job was failing on `main` after PR #422 was merged. The `errcheck` linter reported unchecked error return values from `os.Chdir`:

```
test/03_cluster_test.go:72:17: Error return value of `os.Chdir` is not checked (errcheck)
test/04_generate_yamls_test.go:97:16: Error return value of `os.Chdir` is not checked (errcheck)
```

See: https://github.com/RadekCap/CAPZTests/actions/runs/21293474301

## Solution

Wrapped the deferred `os.Chdir` calls in anonymous functions that check and log any errors:

```go
defer func() {
    if err := os.Chdir(originalDir); err != nil {
        t.Logf("Warning: failed to change back to original directory: %v", err)
    }
}()
```

This approach:
- Satisfies the `errcheck` linter requirement
- Provides visibility into any unexpected failures via test logs
- Is more informative than simply ignoring the error with `_ = os.Chdir(...)`

## Changes

- `test/03_cluster_test.go:72` - Wrapped deferred `os.Chdir` in error-checking closure
- `test/04_generate_yamls_test.go:97` - Wrapped deferred `os.Chdir` in error-checking closure

## Testing

- [x] `go vet ./...` passes
- [x] `go build ./...` compiles successfully
- [x] CI will run the full lint check

Fixes #423

Generated with [Claude Code](https://claude.com/claude-code)