### PR TITLE
fix: remove broken schedule trigger from Cluster Preparation workflow

### DIFF
--- a/.github/workflows/test-kind-cluster.yml
+++ b/.github/workflows/test-kind-cluster.yml
@@ -1,16 +1,19 @@
 name: Cluster Preparation
 
-# DISABLED: This workflow is disabled.
-# To re-enable, uncomment the triggers below.
+# DISABLED: This workflow requires Azure credentials not available in GitHub Actions.
+# To re-enable, uncomment the triggers below and configure Azure secrets.
 on:
   # workflow_dispatch:
   # push:
   #   branches: [ "**" ]
   # pull_request:
   #   branches: [ "**" ]
-  schedule:
-    # Never runs - placeholder to satisfy GitHub Actions syntax
-    - cron: '0 0 31 2 *'
+  workflow_dispatch:
+    inputs:
+      placeholder:
+        description: 'Workflow is disabled - do not run'
+        required: false
+        default: 'disabled'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Remove the broken schedule trigger (`0 0 31 2 *` / February 31st) that was causing repeated workflow failures
- Replace with a minimal `workflow_dispatch` placeholder to keep the workflow file valid but inactive
- Update comment to clarify that Azure credentials are required to run this workflow

## Root Cause

The schedule trigger with cron `0 0 31 2 *` was intended as a "never runs" placeholder (February 31st doesn't exist), but GitHub Actions interpreted it incorrectly and triggered the workflow repeatedly (~every 10-15 minutes). Since the workflow requires Azure credentials not configured in GitHub Actions, every run failed.

## Test plan

- [ ] Verify workflow no longer triggers automatically after merge
- [ ] Confirm workflow can still be manually dispatched (though it will fail without Azure creds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)