### PR TITLE
docs: add deployment modes analysis

### DIFF
--- a/docs/analysis/436-deployment-modes.md
+++ b/docs/analysis/436-deployment-modes.md
@@ -14,7 +14,7 @@
 |------|---------|---------|-------------|-----------|----------|------------|
 | Kind | `USE_KIND=true` | Local Kind cluster | Deployed by tests | `capi-system` / `capz-system` | Local development | v1 |
 | K8S | `USE_K8S=true` | Local K8s cluster | Deployed by tests | `multicluster-engine` | Generic Kubernetes | v1 |
-| OCP | (default) | Local CRC/OpenShift | Deployed by tests | `multicluster-engine` | Local OpenShift testing | v1 |
+| OCP | (default) | Local CRC/OpenShift | Deployed by tests | `capi-system` / `capz-system` | Local OpenShift testing | v1 |
 | MCE | `USE_KUBECONFIG=<path>` | MCE installation | Pre-installed | `multicluster-engine` | Production-like testing, OpenShift CI | v2 |
 
 ---


### PR DESCRIPTION
## Summary

Document the four deployment modes for ARO-CAPZ test suite.

## Deployment Modes

| Mode | Trigger | Cluster | Controllers | Namespace | CAPZ Tests |
|------|---------|---------|-------------|-----------|------------|
| Kind | `USE_KIND=true` | Local Kind cluster | Deployed by tests | `capi-system` / `capz-system` | v1 |
| K8S | `USE_K8S=true` | External K8s cluster | Deployed by tests | `multicluster-engine` | v1 |
| OCP | (default) | Local CRC/OpenShift | Deployed by tests | `multicluster-engine` | v1 |
| MCE | `USE_KUBECONFIG=<path>` | MCE installation | Pre-installed | `multicluster-engine` | v2 |

## Test plan

- [ ] Review deployment modes table for accuracy
- [ ] Verify modes match current implementation

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)