### PR TITLE
fix: resolve golangci-lint errors (errcheck, staticcheck)

### DIFF
--- a/test/config.go
+++ b/test/config.go
@@ -161,7 +161,7 @@ func NewTestConfig() *TestConfig {
 	// When using external kubeconfig, default to MCE namespaces (USE_K8S=true)
 	// This triggers multicluster-engine namespace for all controllers
 	if useKubeconfig != "" && os.Getenv("USE_K8S") == "" {
-		os.Setenv("USE_K8S", "true") // #nosec G104 - os.Setenv with fixed key/value cannot fail in practice
+		_ = os.Setenv("USE_K8S", "true") // #nosec G104 - os.Setenv with fixed key/value cannot fail in practice
 	}
 
 	return &TestConfig{

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2705,9 +2705,9 @@ func FormatMismatchedClustersError(mismatched []string, expectedPrefix, namespac
 		sb.WriteString(fmt.Sprintf("  kubectl delete cluster %s -n %s\n\n", mismatched[0], namespace))
 	} else {
 		// Multiple clusters
-		sb.WriteString(fmt.Sprintf("  # Delete specific cluster:\n"))
+		sb.WriteString("  # Delete specific cluster:\n")
 		sb.WriteString(fmt.Sprintf("  kubectl delete cluster %s -n %s\n\n", mismatched[0], namespace))
-		sb.WriteString(fmt.Sprintf("  # Or delete all clusters in namespace:\n"))
+		sb.WriteString("  # Or delete all clusters in namespace:\n")
 		sb.WriteString(fmt.Sprintf("  kubectl delete cluster --all -n %s\n\n", namespace))
 	}
 


### PR DESCRIPTION
## Summary

- Handle `os.Setenv` return value with blank identifier (errcheck)
- Remove unnecessary `fmt.Sprintf` for static strings (S1039)

Fixes lint failures blocking the v2 -> main merge (PR #448).

## Test plan

- [ ] Lint check passes
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)