### PR TITLE
fix: resolve AROControlPlane name mismatch in WaitForControlPlane

### DIFF
--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -424,7 +424,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 	// Get the specific AROControlPlane name for the cluster being deployed
 	// This prevents checking the wrong control plane when multiple clusters exist (issue #355)
 	provisionedClusterName := config.GetProvisionedClusterName()
-	aroControlPlaneName := provisionedClusterName
+	aroControlPlaneName := config.GetProvisionedAROControlPlaneName()
 
 	// Wait for control plane to be ready (with configurable timeout)
 	timeout := config.DeploymentTimeout


### PR DESCRIPTION
## Summary
- The `TestDeployment_WaitForControlPlane` test assumed the AROControlPlane resource has the same name as the Cluster (e.g., `rcapb-stage`), but the YAML generation creates it with a `-control-plane` suffix (`rcapb-stage-control-plane`)
- Added `ExtractAROControlPlaneNameFromYAML()` helper and `GetProvisionedAROControlPlaneName()` config method to resolve the correct name from `aro.yaml`, falling back to the suffix convention when unavailable
- Fixed the lookup in `TestDeployment_WaitForControlPlane` to use the new method

## Test plan
- [x] `go build ./test/...` compiles successfully
- [x] `go vet ./...` passes
- [ ] Re-run `make _deploy-crs` to verify the test finds the correct AROControlPlane resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)