### PR TITLE
fix: update default OCP_VERSION from 4.21 to 4.20

### DIFF
--- a/test/config.go
+++ b/test/config.go
@@ -174,7 +174,7 @@ func NewTestConfig() *TestConfig {
 		ManagementClusterName:    GetEnvOrDefault("MANAGEMENT_CLUSTER_NAME", "capz-tests-stage"),
 		WorkloadClusterName:      GetEnvOrDefault("WORKLOAD_CLUSTER_NAME", "capz-tests-cluster"),
 		ClusterNamePrefix:        GetEnvOrDefault("CS_CLUSTER_NAME", fmt.Sprintf("%s-%s", GetEnvOrDefault("CAPZ_USER", DefaultCAPZUser), GetEnvOrDefault("DEPLOYMENT_ENV", DefaultDeploymentEnv))),
-		OCPVersion:               GetEnvOrDefault("OCP_VERSION", "4.21"),
+		OCPVersion:               GetEnvOrDefault("OCP_VERSION", "4.20"),
 		Region:                   GetEnvOrDefault("REGION", "uksouth"),
 		AzureSubscriptionName:    os.Getenv("AZURE_SUBSCRIPTION_NAME"),
 		Environment:              GetEnvOrDefault("DEPLOYMENT_ENV", DefaultDeploymentEnv),


### PR DESCRIPTION
## Summary
- Default `OCP_VERSION` changed from `4.21` to `4.20` because `openshift-v4.21.0` does not exist in Azure yet
- This caused `HcpClusterReady: False (InvalidRequestContent)` during deployment

## Test plan
- [x] `go build ./test/...` compiles successfully
- [ ] Re-run deployment with `OCP_VERSION=4.20` to verify cluster provisioning succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)