### PR TITLE
fix: restore default repo URL and branch to upstream values (fixes #461)

### DIFF
--- a/test/config.go
+++ b/test/config.go
@@ -175,8 +175,8 @@ func NewTestConfig() *TestConfig {
 
 	return &TestConfig{
 		// Repository defaults
-		RepoURL:    GetEnvOrDefault("ARO_REPO_URL", "https://github.com/marek-veber/cluster-api-installer"),
-		RepoBranch: GetEnvOrDefault("ARO_REPO_BRANCH", "fix-mp-providerIDList"),
+		RepoURL:    GetEnvOrDefault("ARO_REPO_URL", "https://github.com/stolostron/cluster-api-installer"),
+		RepoBranch: GetEnvOrDefault("ARO_REPO_BRANCH", "main"),
 		RepoDir:    getDefaultRepoDir(),
 
 		// Cluster defaults


### PR DESCRIPTION
## Summary
- Restore `RepoURL` and `RepoBranch` defaults in `test/config.go` to point to the upstream `stolostron/cluster-api-installer` repository on the `main` branch, replacing the temporary fork reference

## Problem
The default values for `ARO_REPO_URL` and `ARO_REPO_BRANCH` in `NewTestConfig()` were pointing to a fork (`marek-veber/cluster-api-installer`, branch `fix-mp-providerIDList`) instead of the upstream repository. This was a temporary override that was no longer needed after the fix was merged upstream. The govulncheck alert (issue #461) was triggered on the now-deleted `dev` branch; govulncheck passes clean on `main`.

## Changes
- `test/config.go`: Updated `RepoURL` default from `marek-veber/cluster-api-installer` to `stolostron/cluster-api-installer`
- `test/config.go`: Updated `RepoBranch` default from `fix-mp-providerIDList` to `main`

## Test plan
- [x] `make test` passes (all 37 tests pass, 2 skipped)
- [x] `make fmt` clean
- [x] `govulncheck ./...` reports no vulnerabilities

Fixes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)