### PR TITLE
fix: tighten file permissions for commands.log

### DIFF
--- a/test/helpers.go
+++ b/test/helpers.go
@@ -293,13 +293,13 @@ func logCommandToFile(testName, cmdStr string) {
 	logPath := filepath.Join(commandLogDir, "commands.log")
 
 	// #nosec G304 -- path constructed from results directory and fixed filename
-	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
-	fmt.Fprintf(f, "%s\n", entry)
+	_, _ = fmt.Fprintf(f, "%s\n", entry)
 }
 
 // SetEnvVar sets an environment variable for testing


### PR DESCRIPTION
## Summary
- Reduce `commands.log` file permissions from `0640` to `0600` to satisfy gosec rule G302
- The log file only needs owner read/write access; group read was unnecessary

Fixes #468

## Test plan
- [x] `make test` passes
- [x] `gosec ./...` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)