### PR TITLE
docs: add transition notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# ARO-CAPZ Test Suite
+# CAPI Test Suite (formerly ARO-CAPZ Test Suite)
+
+> [!IMPORTANT]
+> **This repository is being transitioned** from its original form (CAPZTests) to a generalized CAPI test suite.
+> Provider-specific configuration is being extracted and the codebase is under active review.
+> The documentation below still reflects the original CAPZ-focused scope and will be updated as the generalization progresses.
 
 [![Check Dependencies](https://github.com/RadekCap/CAPZTests/actions/workflows/check-dependencies.yml/badge.svg)](https://github.com/RadekCap/CAPZTests/actions/workflows/check-dependencies.yml)
 [![Repository Setup](https://github.com/RadekCap/CAPZTests/actions/workflows/test-setup.yml/badge.svg)](https://github.com/RadekCap/CAPZTests/actions/workflows/test-setup.yml)


### PR DESCRIPTION
## Summary
- Updated README title to "CAPI Test Suite (formerly ARO-CAPZ Test Suite)"
- Added prominent transition notice using GitHub's `> [!IMPORTANT]` alert syntax

## Context
This repository is being transitioned from CAPZTests to a generalized CAPI test suite. The notice informs users that provider-specific configuration is being extracted and documentation will be updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)