### PR TITLE
Fix fork-specific ARO_REPO_URL in test-kind-cluster workflow

### DIFF
--- a/.github/workflows/test-kind-cluster.yml
+++ b/.github/workflows/test-kind-cluster.yml
@@ -20,7 +20,7 @@ permissions:
   issues: write
 
 env:
-  ARO_REPO_URL: https://github.com/RadekCap/cluster-api-installer.git
+  ARO_REPO_URL: https://github.com/stolostron/cluster-api-installer.git
   ARO_REPO_BRANCH: ARO-ASO
   ARO_REPO_DIR: /tmp/cluster-api-installer-aro
 


### PR DESCRIPTION
## Summary
- Update hardcoded `RadekCap/cluster-api-installer` URL to `stolostron/cluster-api-installer` in the test-kind-cluster workflow

The workflow is currently disabled, but the repo URL should point to the upstream stolostron org for when it's re-enabled.

## Test plan
- [ ] Verify the workflow file diff contains only the URL change
- [ ] No functional impact (workflow is disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)