### PR TITLE
Remove fork-specific reviewer from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,6 @@ updates:
     labels:
       - "dependencies"
       - "go"
-    reviewers:
-      - "RadekCap"
     # Group minor and patch updates to reduce PR noise
     groups:
       go-dependencies:
@@ -42,8 +40,6 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
-    reviewers:
-      - "RadekCap"
     # Group action updates
     groups:
       github-actions:


### PR DESCRIPTION
## Summary
- Remove hardcoded `RadekCap` reviewer from both `gomod` and `github-actions` sections in `dependabot.yml`

Reviewer assignment in the upstream stolostron repo should be handled via CODEOWNERS or manual assignment rather than hardcoded in the dependabot config.

## Test plan
- [ ] Verify the diff only removes the `reviewers` blocks
- [ ] Dependabot PRs will no longer auto-assign RadekCap as reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)