### PR TITLE
ci: switch Repository Setup workflow to manual trigger

### DIFF
--- a/.github/workflows/test-setup.yml
+++ b/.github/workflows/test-setup.yml
@@ -1,10 +1,6 @@
 name: Repository Setup
 
 on:
-  push:
-    branches: [ "**" ]
-  pull_request:
-    branches: [ "**" ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Switch Repository Setup workflow from push/PR triggers to manual-only (workflow_dispatch)
- The workflow fails because `scripts/aro-hcp/gen.sh` does not yet exist in `stolostron/cluster-api-installer`
- Related: #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)