### PR TITLE
docs: remove Test Plan section from PR description template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,6 +386,17 @@ Centralized helpers in `helpers.go` ensure:
 
 ## Git Workflow
 
+### Pull Request Descriptions
+
+When creating pull requests, use this format (no "Test plan" section):
+
+```
+## Summary
+<1-3 bullet points>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
 ### Branching Strategy
 - Main branch for PRs: `main`
 - Tests run on: `main` and feature branches


### PR DESCRIPTION
## Summary
- Add a PR description template to CLAUDE.md that omits the "Test plan" section
- Future PRs will use a cleaner format with just Summary and the Claude Code footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)