### PR TITLE
docs: add PR format instruction to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,6 +530,10 @@ Simply type the command in Claude Code:
 
 Commands will prompt for any required information and guide you through the task.
 
+## Pull Request Format
+
+When creating pull requests, always read and follow `.github/PULL_REQUEST_TEMPLATE.md`. Do not add sections that aren't in the template (e.g., do not add "Test plan"). Before creating the PR, always print the full PR description to the terminal and wait for user confirmation before proceeding.
+
 ## Destructive Actions
 
 - Never delete Azure resources without explicit confirmation


### PR DESCRIPTION
## Description

Add instruction to CLAUDE.md requiring Claude Code to follow the repository's
PR template (`.github/PULL_REQUEST_TEMPLATE.md`) instead of its built-in default
format, and to show the PR description for user confirmation before creating.

## Type of Change

- [x] Documentation update

## Changes Made

- Add "Pull Request Format" section to CLAUDE.md

## Additional Notes

Previously, Claude Code used its built-in PR format which included a "Test plan"
section that was intentionally removed from the repo template in PR #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Pull Request Format guidelines to clarify submission requirements and the review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->