### PR TITLE
ci: disable CodeRabbit auto-label on PR approval

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,6 +9,7 @@ reviews:
   high_level_summary: true
   collapse_walkthrough: true
   request_changes_workflow: true
+  auto_apply_labels: false
 
   auto_review:
     enabled: true


### PR DESCRIPTION
## Description

Disable CodeRabbit auto-labeling on PR approval. CodeRabbit will still
review and approve PRs, but will no longer add the "Approved" label
automatically.

## Type of Change

- [x] CI/CD changes

## Changes Made

- Add `.coderabbit.yaml` with `auto_label.enabled: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default review configuration: auto_apply_labels set to false. No functional behavior changes; existing workflows remain unchanged unless explicitly overridden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->