### PR TITLE
fix: remove redundant workflow env vars and clone step (fixes #499)

### DIFF
--- a/.github/workflows/test-kind-cluster.yml
+++ b/.github/workflows/test-kind-cluster.yml
@@ -10,9 +10,6 @@ permissions:
   issues: write
 
 env:
-  ARO_REPO_URL: https://github.com/stolostron/cluster-api-installer.git
-  ARO_REPO_BRANCH: main
-  ARO_REPO_DIR: /tmp/cluster-api-installer-aro
   USE_KIND: "true"
   AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
   AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -74,15 +71,6 @@ jobs:
       with:
         # Helm 3.12+ required
         version: 'v3.16.0'
-
-    - name: Clone cluster-api-installer repository
-      run: |
-        if [ -d "$ARO_REPO_DIR" ]; then
-          echo "Repository already exists, skipping clone"
-        else
-          git clone -b "$ARO_REPO_BRANCH" "$ARO_REPO_URL" "$ARO_REPO_DIR"
-          echo "Repository cloned successfully"
-        fi
 
     - name: Run Kind cluster tests
       run: |


### PR DESCRIPTION
## Summary
- Remove hardcoded `ARO_REPO_URL`, `ARO_REPO_BRANCH`, `ARO_REPO_DIR` env vars from `test-kind-cluster.yml` (Go test config already handles these defaults)
- Remove manual clone step from workflow (Go tests clone the repo via `TestSetup`)

Fixes #499
Jira: [ARO-24884](https://issues.redhat.com/browse/ARO-24884)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing workflow configuration by removing unused environment variables and streamlining workflow steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->