### PR TITLE
ci: update Kind from v0.20.0 to v0.31.0 (fixes #500)

### DIFF
--- a/.github/workflows/test-kind-cluster.yml
+++ b/.github/workflows/test-kind-cluster.yml
@@ -55,9 +55,13 @@ jobs:
     # Tool versions - keep in sync with README.md Prerequisites
     - name: Install Kind
       run: |
-        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
-        chmod +x ./kind
-        sudo mv ./kind /usr/local/bin/kind
+        KIND_VERSION=v0.31.0
+        KIND_BIN=kind-linux-amd64
+        curl -fsSLo "./${KIND_BIN}" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}"
+        curl -fsSLo "./${KIND_BIN}.sha256sum" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}.sha256sum"
+        sha256sum --check "./${KIND_BIN}.sha256sum"
+        chmod +x "./${KIND_BIN}"
+        sudo mv "./${KIND_BIN}" /usr/local/bin/kind
         kind version
 
     - name: Install kubectl


### PR DESCRIPTION
## Summary
- Update Kind from v0.20.0 (June 2023) to v0.31.0 (December 2025) in `test-kind-cluster.yml`
- Remove misleading "minimum version" comment

Fixes #500
Jira: [ARO-24885](https://issues.redhat.com/browse/ARO-24885)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure tooling to use a newer Kind release (v0.31.0) and a more robust install process.
  * Added checksum verification and improved binary installation steps to enhance security and reliability of CI test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->