### PR TITLE
ci: remove dead pull_request guard from manual-only workflows (fixes #501)

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -103,7 +103,7 @@ jobs:
         retention-days: 30
 
     - name: Create GitHub issue on failure
-      if: failure() && github.event_name != 'pull_request'
+      if: failure()
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/.github/workflows/test-setup.yml
+++ b/.github/workflows/test-setup.yml
@@ -91,7 +91,7 @@ jobs:
         retention-days: 30
 
     - name: Create GitHub issue on failure
-      if: failure() && github.event_name != 'pull_request'
+      if: failure()
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |


### PR DESCRIPTION
## Summary
- Remove `github.event_name != 'pull_request'` guard from `test-setup.yml` and `check-dependencies.yml`
- Both workflows only trigger on `workflow_dispatch`, so the check is always true (dead code)

Fixes #501
Jira: [ARO-24886](https://issues.redhat.com/browse/ARO-24886)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated issue creation behavior for workflow failures. Issues will now be created when workflows fail in all scenarios, including pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->