### PR TITLE
ci: add management cluster workflows for ARO and ROSA (ARO-24891)

### DIFF
--- a/.github/workflows/management-cluster-aro.yml
+++ b/.github/workflows/management-cluster-aro.yml
@@ -15,10 +15,6 @@ env:
   ARO_REPO_BRANCH: capi-tests
   ARO_REPO_DIR: /tmp/cluster-api-installer-aro
   USE_KIND: "true"
-  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-  AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
 jobs:
   management-cluster:
@@ -28,6 +24,11 @@ jobs:
 
     steps:
     - name: Validate Azure secrets
+      env:
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       run: |
         missing=""
         [ -z "$AZURE_TENANT_ID" ] && missing="$missing AZURE_TENANT_ID"
@@ -91,6 +92,11 @@ jobs:
         version: 'v3.16.0'
 
     - name: 'Phase 1: Check Dependencies'
+      env:
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       run: make _check-dep
       continue-on-error: true
       id: phase1
@@ -103,6 +109,11 @@ jobs:
 
     - name: 'Phase 3: Kind Cluster'
       if: steps.phase2.outcome == 'success'
+      env:
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       run: make _cluster
       continue-on-error: true
       id: phase3
@@ -151,7 +162,7 @@ jobs:
                 for tc in tree.iter("testcase"):
                     name = tc.get("name", "")
                     time_val = tc.get("time", "0")
-                    if tc.find("failure") is not None:
+                    if tc.find("failure") is not None or tc.find("error") is not None:
                         status = "❌ FAIL"
                         failed += 1
                     elif tc.find("skipped") is not None:
@@ -197,7 +208,7 @@ jobs:
                 continue
 
             for tc in tree.iter("testcase"):
-                if tc.find("failure") is not None:
+                if tc.find("failure") is not None or tc.find("error") is not None:
                     name = tc.get("name", "")
                     print(f"::error file={test_file},title=Test Failed::{name} failed")
         PYEOF
@@ -236,7 +247,7 @@ jobs:
             try:
                 tree = ET.parse(f)
                 for tc in tree.iter('testcase'):
-                    if tc.find('failure') is not None:
+                    if tc.find('failure') is not None or tc.find('error') is not None:
                         print(tc.get('name', ''))
             except Exception:
                 pass

--- a/.github/workflows/management-cluster-rosa.yml
+++ b/.github/workflows/management-cluster-rosa.yml
@@ -1,7 +1,7 @@
 name: Management Cluster (ROSA)
 
 # Manual-only trigger. Requires AWS secrets configured in repository settings:
-#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
 on:
   workflow_dispatch:
 
@@ -15,9 +15,6 @@ env:
   ARO_REPO_BRANCH: capi-tests
   ARO_REPO_DIR: /tmp/cluster-api-installer-aro
   USE_KIND: "true"
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_REGION: ${{ secrets.AWS_REGION }}
 
 jobs:
   management-cluster:
@@ -27,10 +24,15 @@ jobs:
 
     steps:
     - name: Validate AWS secrets
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: ${{ secrets.AWS_REGION }}
       run: |
         missing=""
         [ -z "$AWS_ACCESS_KEY_ID" ] && missing="$missing AWS_ACCESS_KEY_ID"
         [ -z "$AWS_SECRET_ACCESS_KEY" ] && missing="$missing AWS_SECRET_ACCESS_KEY"
+        [ -z "$AWS_REGION" ] && missing="$missing AWS_REGION"
         if [ -n "$missing" ]; then
           echo "::error::Missing required repository secrets:$missing"
           echo "Configure these in Settings > Secrets and variables > Actions"
@@ -88,6 +90,10 @@ jobs:
         version: 'v3.16.0'
 
     - name: 'Phase 1: Check Dependencies'
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: ${{ secrets.AWS_REGION }}
       run: make _check-dep
       continue-on-error: true
       id: phase1
@@ -100,6 +106,10 @@ jobs:
 
     - name: 'Phase 3: Kind Cluster'
       if: steps.phase2.outcome == 'success'
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: ${{ secrets.AWS_REGION }}
       run: make _cluster
       continue-on-error: true
       id: phase3
@@ -148,7 +158,7 @@ jobs:
                 for tc in tree.iter("testcase"):
                     name = tc.get("name", "")
                     time_val = tc.get("time", "0")
-                    if tc.find("failure") is not None:
+                    if tc.find("failure") is not None or tc.find("error") is not None:
                         status = "❌ FAIL"
                         failed += 1
                     elif tc.find("skipped") is not None:
@@ -194,7 +204,7 @@ jobs:
                 continue
 
             for tc in tree.iter("testcase"):
-                if tc.find("failure") is not None:
+                if tc.find("failure") is not None or tc.find("error") is not None:
                     name = tc.get("name", "")
                     print(f"::error file={test_file},title=Test Failed::{name} failed")
         PYEOF
@@ -233,7 +243,7 @@ jobs:
             try:
                 tree = ET.parse(f)
                 for tc in tree.iter('testcase'):
-                    if tc.find('failure') is not None:
+                    if tc.find('failure') is not None or tc.find('error') is not None:
                         print(tc.get('name', ''))
             except Exception:
                 pass


### PR DESCRIPTION
## Description

Add two new GitHub Actions workflows that run the first three test phases
(check dependencies, setup, kind cluster) to verify management cluster
deployment — one for ARO (CAPZ) and one for ROSA (CAPA).

JIRA: https://issues.redhat.com/browse/ARO-24891

## Type of Change

- [x] CI/CD changes

## Changes Made

- Add `management-cluster-aro.yml` — runs `make _check-dep && make _setup && make _cluster` with `INFRA_PROVIDER=aro` and Azure secrets
- Add `management-cluster-rosa.yml` — runs `make _check-dep && make _setup && make _cluster` with `INFRA_PROVIDER=rosa` and AWS secrets
- Both workflows include test summary generation, annotations, artifact upload, and auto issue creation on failure
- Both use env vars for all GitHub context values in run blocks (security best practice)

## Checklist

- [x] Code follows the project's coding style
- [x] No security issues introduced
- [x] Commit messages follow convention

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `AWS_ACCESS_KEY_ID` | AWS access key (ROSA workflow, repository secret) | N/A |
| `AWS_SECRET_ACCESS_KEY` | AWS secret key (ROSA workflow, repository secret) | N/A |
| `AWS_REGION` | AWS region (ROSA workflow, repository secret) | N/A |

## Additional Notes

- ARO workflow uses existing Azure secrets (already configured)
- ROSA workflow requires new AWS secrets to be configured in repository settings
- Both are manual-only (`workflow_dispatch`) — no automatic triggers
- Existing per-phase workflows are kept for debugging individual phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added two new manually-triggered CI workflows for management cluster validation (ARO and ROSA). They validate cloud credentials, run three phased checks (dependencies, repo setup, cluster), generate consolidated test summaries, upload artifacts, and fail the job if any phase fails.

* **Tests**
  * Create and annotate GitHub issues and test annotations on failures (with automated labels), and emit per-phase JUnit-style summaries and artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->