### PR TITLE
refactor: rename TestExternalCluster_02_EnableMCE to EnsureMCEComponents

### DIFF
--- a/TEST_COVERAGE.md
+++ b/TEST_COVERAGE.md
@@ -104,7 +104,7 @@ Integration tests exercise the full deployment workflow and cover functions that
 |------|----------|-------------|
 | `TestExternalCluster_01_Connectivity` | **V1.1** | External cluster node access |
 | `TestExternalCluster_01b_MCEBaselineStatus` | **V1.1** | MCE component baseline, calls `SetMCEComponentState()` |
-| `TestExternalCluster_02_EnableMCE` | **V1.1** | MCE enablement, calls `EnableMCEComponent()`, `WaitForMCEController()` |
+| `TestExternalCluster_02_EnsureMCEComponents` | **V1.1** | MCE enablement, calls `EnableMCEComponent()`, `WaitForMCEController()` |
 | `TestExternalCluster_03_ControllersReady` | **V1.1** | Controller readiness on external cluster |
 | `TestKindCluster_*` (7 tests) | Kind cluster deployment | - |
 
@@ -141,15 +141,15 @@ Integration tests exercise the full deployment workflow and cover functions that
 | Function | Unit Tests | Integration Tests | Assessment |
 |----------|-----------|-------------------|------------|
 | `SetMCEComponentState()` | None | `TestExternalCluster_01b_MCEBaselineStatus` | Adequate - requires live MCE cluster |
-| `EnableMCEComponent()` | None | `TestExternalCluster_02_EnableMCE` | Adequate - requires live MCE cluster |
-| `WaitForMCEController()` | None | `TestExternalCluster_02_EnableMCE` | Adequate - requires live cluster |
+| `EnableMCEComponent()` | None | `TestExternalCluster_02_EnsureMCEComponents` | Adequate - requires live MCE cluster |
+| `WaitForMCEController()` | None | `TestExternalCluster_02_EnsureMCEComponents` | Adequate - requires live cluster |
 | `ExtractNamespaceFromYAML()` | 100% | `TestInfrastructure_GenerateResources` | Well covered |
 | `ExtractCurrentContext()` | None | `TestCheckDependencies_ExternalKubeconfig` | Adequate - requires kubeconfig file |
 | `CheckYAMLConfigMatch()` | Unit test exists | `TestInfrastructure_GenerateResources` | Well covered |
 | `GetExistingClusterNames()` | None | `TestDeployment_01_CheckExistingClusters` | Adequate - requires live cluster |
 | `CheckForMismatchedClusters()` | Unit test (logic) | `TestDeployment_01_CheckExistingClusters` | Well covered |
 | `FormatMismatchedClustersError()` | 100% | `TestDeployment_01_CheckExistingClusters` | Well covered |
-| `IsMCECluster()` | None | `TestExternalCluster_02_EnableMCE` | Adequate - requires live cluster |
+| `IsMCECluster()` | None | `TestExternalCluster_02_EnsureMCEComponents` | Adequate - requires live cluster |
 | `GetMCEComponentStatus()` | None | `TestExternalCluster_01b_MCEBaselineStatus` | Adequate - requires live cluster |
 | `ApplyWithRetryInNamespace()` | None | `TestDeployment_ApplyResources` | Adequate - requires live cluster |
 
@@ -167,7 +167,7 @@ Integration tests exercise the full deployment workflow and cover functions that
 |------|---------|-------------------|
 | `TestExternalCluster_01_Connectivity` | Validates external cluster access | `IsExternalCluster()`, `GetKubeContext()`, kubectl node listing |
 | `TestExternalCluster_01b_MCEBaselineStatus` | Ensures MCE component baseline | `GetMCEComponentStatus()`, `SetMCEComponentState()` |
-| `TestExternalCluster_02_EnableMCE` | Enables CAPI/CAPZ on MCE | `EnableMCEComponent()`, `WaitForMCEController()`, `IsMCECluster()` |
+| `TestExternalCluster_02_EnsureMCEComponents` | Enables CAPI/CAPZ on MCE | `EnableMCEComponent()`, `WaitForMCEController()`, `IsMCECluster()` |
 | `TestExternalCluster_03_ControllersReady` | Validates controller deployments | Controller namespace lookups, deployment checks |
 | `TestDeployment_00_CreateNamespace` | Creates workload cluster namespace | Namespace generation, `kubectl create namespace` |
 | `TestDeployment_01_CheckExistingClusters` | Detects stale clusters | `GetExistingClusterNames()`, `CheckForMismatchedClusters()` |
@@ -181,10 +181,10 @@ These functions have 0% unit test coverage but are exercised by integration test
 | Function | Reason | Integration Coverage |
 |----------|--------|---------------------|
 | `SetMCEComponentState()` | Requires MCE cluster | `TestExternalCluster_01b_MCEBaselineStatus` |
-| `EnableMCEComponent()` | Requires MCE cluster | `TestExternalCluster_02_EnableMCE` |
-| `WaitForMCEController()` | Requires MCE cluster | `TestExternalCluster_02_EnableMCE` |
+| `EnableMCEComponent()` | Requires MCE cluster | `TestExternalCluster_02_EnsureMCEComponents` |
+| `WaitForMCEController()` | Requires MCE cluster | `TestExternalCluster_02_EnsureMCEComponents` |
 | `GetMCEComponentStatus()` | Requires MCE cluster | `TestExternalCluster_01b_MCEBaselineStatus` |
-| `IsMCECluster()` | Requires kubectl | `TestExternalCluster_02_EnableMCE` |
+| `IsMCECluster()` | Requires kubectl | `TestExternalCluster_02_EnsureMCEComponents` |
 | `ExtractCurrentContext()` | Requires kubeconfig + kubectl | `TestCheckDependencies_ExternalKubeconfig` |
 | `GetExistingClusterNames()` | Requires kubectl | `TestDeployment_01_CheckExistingClusters` |
 | `ApplyWithRetryInNamespace()` | Requires kubectl | `TestDeployment_ApplyResources` |
@@ -242,7 +242,7 @@ USE_KUBECONFIG=/path/to/kubeconfig make test-all
 **Additional phases activated**:
 - `TestExternalCluster_01_Connectivity`
 - `TestExternalCluster_01b_MCEBaselineStatus`
-- `TestExternalCluster_02_EnableMCE`
+- `TestExternalCluster_02_EnsureMCEComponents`
 - `TestExternalCluster_03_ControllersReady`
 
 **Phases skipped**:

--- a/docs/test-analysis/03-cluster/00-Overview.md
+++ b/docs/test-analysis/03-cluster/00-Overview.md
@@ -20,7 +20,7 @@ Deploy a Kind cluster with CAPI, CAPZ, and ASO controllers, then verify all cont
 |---|------|---------|
 | 1 | [08-ExternalCluster-Connectivity](08-ExternalCluster-Connectivity.md) | Validate external cluster connectivity |
 | 2 | [09-ExternalCluster-MCEBaselineStatus](09-ExternalCluster-MCEBaselineStatus.md) | Validate and configure MCE component baseline |
-| 3 | [10-ExternalCluster-EnableMCE](10-ExternalCluster-EnableMCE.md) | Enable CAPI/CAPZ components in MCE |
+| 3 | [10-ExternalCluster-EnsureMCEComponents](10-ExternalCluster-EnsureMCEComponents.md) | Ensure CAPI/CAPZ components are enabled in MCE |
 | 4 | [11-ExternalCluster-ControllersReady](11-ExternalCluster-ControllersReady.md) | Validate pre-installed controllers |
 
 ### Kind Cluster Tests (default mode)

--- a/docs/test-analysis/03-cluster/09-ExternalCluster-MCEBaselineStatus.md
+++ b/docs/test-analysis/03-cluster/09-ExternalCluster-MCEBaselineStatus.md
@@ -54,4 +54,4 @@
 
 - HyperShift and Cluster API components are **mutually exclusive** in MCE
 - This test automatically corrects mismatched component states
-- Must run before `TestExternalCluster_02_EnableMCE` to ensure proper baseline
+- Must run before `TestExternalCluster_02_EnsureMCEComponents` to ensure proper baseline

--- a/docs/test-analysis/03-cluster/10-ExternalCluster-EnsureMCEComponents.md
+++ b/docs/test-analysis/03-cluster/10-ExternalCluster-EnsureMCEComponents.md
@@ -1,4 +1,4 @@
-# Test 10: TestExternalCluster_02_EnableMCE
+# Test 10: TestExternalCluster_02_EnsureMCEComponents
 
 **Location:** `test/03_cluster_test.go:187-296`
 

--- a/docs/test-analysis/03-cluster/11-ExternalCluster-ControllersReady.md
+++ b/docs/test-analysis/03-cluster/11-ExternalCluster-ControllersReady.md
@@ -43,5 +43,5 @@
 
 - Provides MCE-specific remediation hints when controllers are missing
 - If MCE_AUTO_ENABLE is false, suggests enabling it
-- Runs after `TestExternalCluster_02_EnableMCE` so controllers should be available
+- Runs after `TestExternalCluster_02_EnsureMCEComponents` so controllers should be available
 - The CAPINamespace/CAPZNamespace may differ between Kind and MCE deployments

--- a/docs/test-analysis/README.md
+++ b/docs/test-analysis/README.md
@@ -210,7 +210,7 @@ docs/test-analysis/
 │   ├── 07-WebhooksReady.md
 │   ├── 08-ExternalCluster-Connectivity.md
 │   ├── 09-ExternalCluster-MCEBaselineStatus.md
-│   ├── 10-ExternalCluster-EnableMCE.md
+│   ├── 10-ExternalCluster-EnsureMCEComponents.md
 │   └── 11-ExternalCluster-ControllersReady.md
 ├── 04-generate-yamls/
 │   ├── 00-Overview.md

--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -179,12 +179,12 @@ func TestExternalCluster_01b_MCEBaselineStatus(t *testing.T) {
 	t.Log("MCE component baseline validation passed")
 }
 
-// TestExternalCluster_02_EnableMCE enables CAPI and CAPZ components if not already enabled.
+// TestExternalCluster_02_EnsureMCEComponents ensures CAPI and CAPZ components are enabled in MCE.
 // This test runs only when:
 // - USE_KUBECONFIG is set (external cluster mode)
 // - MCE is installed on the cluster
 // - MCE_AUTO_ENABLE is true (default)
-func TestExternalCluster_02_EnableMCE(t *testing.T) {
+func TestExternalCluster_02_EnsureMCEComponents(t *testing.T) {
 	config := NewTestConfig()
 
 	if !config.IsExternalCluster() {
@@ -204,7 +204,7 @@ func TestExternalCluster_02_EnableMCE(t *testing.T) {
 		t.Skip("MCE auto-enablement disabled (MCE_AUTO_ENABLE=false)")
 	}
 
-	PrintTestHeader(t, "TestExternalCluster_02_EnableMCE",
+	PrintTestHeader(t, "TestExternalCluster_02_EnsureMCEComponents",
 		"Enable CAPI and CAPZ components in MCE if not already enabled")
 
 	PrintToTTY("\n=== Checking MCE component status ===\n")


### PR DESCRIPTION
## Description

Rename `TestExternalCluster_02_EnableMCE` to `TestExternalCluster_02_EnsureMCEComponents` — the old name implied a one-shot "enable" action, but the test is idempotent (checks each component and only enables what is missing). "Ensure" better reflects that behavior, and "Components" clarifies it operates on individual MCE components (CAPI, CAPZ), not the MCE operator itself.

## Additional Notes

No functional changes — pure rename for clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test naming and documentation to improve clarity regarding external cluster component validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->