### PR TITLE
refactor: rename make target `_cluster` to `_management_cluster`

### DIFF
--- a/.github/workflows/management-cluster-aro.yml
+++ b/.github/workflows/management-cluster-aro.yml
@@ -117,7 +117,7 @@ jobs:
         AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
         AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-      run: make _cluster
+      run: make _management_cluster
       continue-on-error: true
       id: phase3
 

--- a/.github/workflows/management-cluster-rosa.yml
+++ b/.github/workflows/management-cluster-rosa.yml
@@ -113,7 +113,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: ${{ secrets.AWS_REGION }}
-      run: make _cluster
+      run: make _management_cluster
       continue-on-error: true
       id: phase3
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ make test-all
 # Individual test phases (internal use - called by test-all)
 make _check-dep      # Check dependencies
 make _setup          # Repository setup
-make _cluster        # Cluster deployment
+make _management_cluster # Cluster deployment
 make _generate-yamls # YAML generation
 make _deploy-crs     # CR deployment
 make _verify         # Cluster verification

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -87,7 +87,7 @@ make test-all
 # Individual test phases (internal use - called by test-all)
 make _check-dep      # Check dependencies
 make _setup          # Repository setup
-make _cluster        # Cluster deployment
+make _management_cluster # Cluster deployment
 make _generate-yamls # YAML generation
 make _deploy-crs     # CR deployment
 make _verify         # Cluster verification

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test _check-dep _setup _cluster _generate-yamls _deploy-crds _verify _delete _cleanup test-all _test-all-impl clean clean-all clean-azure help summary
+.PHONY: test _check-dep _setup _management_cluster _generate-yamls _deploy-crds _verify _delete _cleanup test-all _test-all-impl clean clean-all clean-azure help summary
 
 # Default values
 # Extract CAPZ_USER default from Go config to maintain single source of truth
@@ -78,7 +78,7 @@ help: ## Display this help message
 	@echo "Expected order for manual execution of internal targets:"
 	@echo "  1. make _check-dep       # Check software prerequisites needed for a proper test run"
 	@echo "  2. make _setup           # Setup and prepare input repositories with helm charts and CRDs"
-	@echo "  3. make _cluster         # Prepare cluster for testing, and prepare operators needed for testing"
+	@echo "  3. make _management_cluster # Prepare cluster for testing, and prepare operators needed for testing"
 	@echo "  4. make _generate-yamls  # Generate script for resource creation (yaml)"
 	@echo "  5. make _deploy-crs      # Deploy CRs and verify deployment"
 	@echo "  6. make _verify          # Verify deployed cluster"
@@ -90,12 +90,12 @@ help: ## Display this help message
 	@echo "  # ARO mode (default)"
 	@echo "  export INFRA_PROVIDER=aro"
 	@echo "  export USE_KIND=true"
-	@echo "  make _check-dep && make _setup && make _cluster"
+	@echo "  make _check-dep && make _setup && make _management_cluster"
 	@echo ""
 	@echo "  # ROSA mode"
 	@echo "  export INFRA_PROVIDER=rosa"
 	@echo "  export USE_KIND=true"
-	@echo "  make _check-dep && make _setup && make _cluster"
+	@echo "  make _check-dep && make _setup && make _management_cluster"
 
 test: _check-dep ## Run check dependencies tests only
 
@@ -141,7 +141,7 @@ _setup: check-gotestsum
 	echo ""; \
 	exit $$EXIT_CODE
 
-_cluster: check-gotestsum
+_management_cluster: check-gotestsum
 	@mkdir -p $(RESULTS_DIR)
 	@echo "=== Running Cluster Deployment Tests ==="
 	@echo "Results will be saved to: $(RESULTS_DIR)"
@@ -312,7 +312,7 @@ _test-all-impl:
 		echo ""; \
 		exit 1 \
 	)
-	@$(MAKE) --no-print-directory _cluster RESULTS_DIR=$(RESULTS_DIR) || ( \
+	@$(MAKE) --no-print-directory _management_cluster RESULTS_DIR=$(RESULTS_DIR) || ( \
 		echo ""; \
 		echo "❌ ERROR: Cluster deployment phase failed. Cannot continue with test suite."; \
 		echo "   Previous stages (check dependencies, setup) completed successfully."; \

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ These targets are called by `make test-all` but can be run individually for debu
 |--------|-------------|
 | `make _check-dep` | Check software prerequisites needed for a proper test run |
 | `make _setup` | Setup and prepare input repositories with helm charts and CRDs |
-| `make _cluster` | Prepare cluster for testing and operators |
+| `make _management_cluster` | Prepare cluster for testing and operators |
 | `make _generate-yamls` | Generate script for resource creation (yaml) |
 | `make _deploy-crs` | Deploy CRs and verify deployment |
 | `make _verify` | Verify deployed cluster |

--- a/TEST_COVERAGE.md
+++ b/TEST_COVERAGE.md
@@ -224,7 +224,7 @@ make test-all
 **Phases Executed**:
 1. Check Dependencies (`_check-dep`)
 2. Setup (`_setup`)
-3. Cluster (`_cluster`) - Kind or External cluster mode
+3. Cluster (`_management_cluster`) - Kind or External cluster mode
 4. Generate YAMLs (`_generate-yamls`)
 5. Deploy CRs (`_deploy-crs`)
 6. Verification (`_verify`)

--- a/docs/API_REVIEW.md
+++ b/docs/API_REVIEW.md
@@ -315,7 +315,7 @@ type TestConfig struct {
 |--------|--------|-------|
 | `_check-dep` | ✅ Approved | Internal phase, underscore prefix correct |
 | `_setup` | ✅ Approved | Internal phase |
-| `_cluster` | ✅ Approved | Internal phase |
+| `_management_cluster` | ✅ Approved | Internal phase |
 | `_generate-yamls` | ✅ Approved | Internal phase |
 | `_deploy-crs` | ✅ Approved | Internal phase |
 | `_verify` | ✅ Approved | Internal phase |

--- a/docs/PERFORMANCE_REVIEW.md
+++ b/docs/PERFORMANCE_REVIEW.md
@@ -330,7 +330,7 @@ time make test-all
 # Time individual phases
 time make _check-dep
 time make _setup
-time make _cluster
+time make _management_cluster
 time make _generate-yamls
 time make _deploy-crs
 time make _verify

--- a/docs/test-analysis/03-cluster/00-Overview.md
+++ b/docs/test-analysis/03-cluster/00-Overview.md
@@ -1,6 +1,6 @@
 # Phase 3: Cluster
 
-**Make target:** `make _cluster`
+**Make target:** `make _management_cluster`
 **Test file:** `test/03_cluster_test.go`
 **Timeout:** 30 minutes
 
@@ -41,7 +41,7 @@ Deploy a Kind cluster with CAPI, CAPZ, and ASO controllers, then verify all cont
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                    make _cluster                                 │
+│                    make _management_cluster                      │
 └─────────────────────────────────────────────────────────────────┘
                               │
                     ┌─────────┴─────────┐

--- a/docs/test-analysis/README.md
+++ b/docs/test-analysis/README.md
@@ -15,7 +15,7 @@ make test-all
     │
     ├── 2. make _setup         Repository Setup
     │
-    ├── 3. make _cluster       Kind Cluster Deployment
+    ├── 3. make _management_cluster  Kind Cluster Deployment
     │
     ├── 4. make _generate-yamls YAML Generation
     │
@@ -36,7 +36,7 @@ make test-all
 |-------|-------------|-----------|-------|---------|-------------|
 | 1 | [_check-dep](01-check-dependencies/00-Overview.md) | `01_check_dependencies_test.go` | 18 | 2m | Verify tools, authentication, and naming |
 | 2 | [_setup](02-setup/00-Overview.md) | `02_setup_test.go` | 3 | 2m | Clone repository, verify scripts |
-| 3 | [_cluster](03-cluster/00-Overview.md) | `03_cluster_test.go` | 11 | 30m | Deploy Kind/external cluster with controllers |
+| 3 | [_management_cluster](03-cluster/00-Overview.md) | `03_cluster_test.go` | 11 | 30m | Deploy Kind/external cluster with controllers |
 | 4 | [_generate-yamls](04-generate-yamls/00-Overview.md) | `04_generate_yamls_test.go` | 4 | 20m | Generate YAML manifests |
 | 5 | [_deploy-crs](05-deploy-crs/00-Overview.md) | `05_deploy_crs_test.go` | 9 | 40m | Apply CRs, wait for deployment |
 | 6 | [_verify](06-verification/00-Overview.md) | `06_verification_test.go` | 7 | 20m | Validate workload cluster |
@@ -146,7 +146,7 @@ make test-all
 ```bash
 make _check-dep      # Phase 1
 make _setup          # Phase 2
-make _cluster        # Phase 3
+make _management_cluster # Phase 3
 make _generate-yamls # Phase 4
 make _deploy-crs     # Phase 5
 make _verify         # Phase 6


### PR DESCRIPTION
## Description

Rename the `make _cluster` target to `make _management_cluster` for clarity, since the test suite deals with both management and workload clusters.

## Changes Made

- Renamed `_cluster` Make target to `_management_cluster` in Makefile (target definition, `.PHONY`, help text, quick start, `_test-all-impl`)
- Updated all documentation references (CLAUDE.md, GEMINI.md, README.md, TEST_COVERAGE.md, docs/API_REVIEW.md, docs/PERFORMANCE_REVIEW.md, docs/test-analysis/)
- Updated GitHub Actions workflows (management-cluster-aro.yml, management-cluster-rosa.yml)

## Configuration Changes

No new environment variables.

## Additional Notes

No functional changes - purely a rename for clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system target naming to standardize management cluster deployment references across build configuration and CI/CD workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->