### PR TITLE
fix: prevent CodeRabbit bot approval from satisfying Prow OWNERS check (fixes #524)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,7 +8,7 @@ reviews:
   profile: assertive
   high_level_summary: true
   collapse_walkthrough: true
-  request_changes_workflow: true
+  request_changes_workflow: false
   auto_apply_labels: false
 
   auto_review:


### PR DESCRIPTION
## Description

Disable CodeRabbit's `request_changes_workflow` to prevent its bot approval from satisfying Prow's OWNERS-based approval requirement.

When `request_changes_workflow: true`, CodeRabbit submits a formal "Approved" GitHub review after all its comments are resolved. Prow's APPROVALNOTIFIER then counts this as a valid approval against the OWNERS file, meaning a bot review can satisfy the human approval requirement.

Fixes #524

## Changes Made

- Set `request_changes_workflow: false` in `.coderabbit.yaml`

## Additional Notes

With this change, CodeRabbit will continue to post review comments but will no longer submit formal GitHub review approvals/request-changes. This means only human reviewers listed in OWNERS can satisfy Prow's approval requirement.

Observed in: https://github.com/stolostron/capi-tests/pull/523#issuecomment-3993456879

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to disable change request handling during reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->