### PR TITLE
refactor: rename Go module from CAPZTests to capi-tests (ARO-24948)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rcap/CAPZTests
+module github.com/rcap/capi-tests
 
 go 1.24
 

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -3268,9 +3268,9 @@ func TestCheckForMismatchedClusters_Logic(t *testing.T) {
 // This prevents false positives in TestDeployment_01_CheckExistingClusters (ARO-24822).
 func TestGetExistingClusterNames_WarningFiltering(t *testing.T) {
 	tests := []struct {
-		name       string
-		output     string
-		wantNames  []string
+		name      string
+		output    string
+		wantNames []string
 	}{
 		{
 			name:      "clean output - no warnings",


### PR DESCRIPTION
## Description

Rename Go module path from `github.com/rcap/CAPZTests` to `github.com/rcap/capi-tests` to match the renamed repository.

JIRA: https://issues.redhat.com/browse/ARO-24948
Fixes #527

## Changes Made

- Updated `go.mod` module path from `github.com/rcap/CAPZTests` to `github.com/rcap/capi-tests`
- Minor `go fmt` formatting fix in `test/helpers_test.go` (struct field alignment)

## Additional Notes

No internal Go files import the module path directly (all test files use relative references within the `./test` package), so this change is safe and low-risk. This is the first change in the CAPZTests → capi-tests rename series (Issue 1 of 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module identifiers.

* **Tests**
  * Minor formatting adjustments to test definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->