### PR TITLE
refactor: update GitHub URLs from CAPZTests to capi-tests (ARO-24949)

### DIFF
--- a/.gemini/commands/implement-issue.md
+++ b/.gemini/commands/implement-issue.md
@@ -305,8 +305,8 @@ Pushed to remote ✅
 Created PR #73 ✅
 Posted explanation on issue #72 ✅
 
-Pull Request: https://github.com/RadekCap/CAPZTests/pull/73
-Issue updated: https://github.com/RadekCap/CAPZTests/issues/72
+Pull Request: https://github.com/RadekCap/capi-tests/pull/73
+Issue updated: https://github.com/RadekCap/capi-tests/issues/72
 ```
 
 ### Example 2: New feature with tests
@@ -341,8 +341,8 @@ Files changed:
 - test/helpers_test.go (+150 lines)
 - GEMINI.md (+10 lines)
 
-Pull Request: https://github.com/RadekCap/CAPZTests/pull/76
-Issue updated: https://github.com/RadekCap/CAPZTests/issues/75
+Pull Request: https://github.com/RadekCap/capi-tests/pull/76
+Issue updated: https://github.com/RadekCap/capi-tests/issues/75
 ```
 
 ### Example 3: CI/Workflow fix
@@ -370,8 +370,8 @@ Posted explanation on issue #77 ✅
 
 Note: CI will validate this fix when the PR runs
 
-Pull Request: https://github.com/RadekCap/CAPZTests/pull/78
-Issue updated: https://github.com/RadekCap/CAPZTests/issues/77
+Pull Request: https://github.com/RadekCap/capi-tests/pull/78
+Issue updated: https://github.com/RadekCap/capi-tests/issues/77
 ```
 
 ## Post-Implementation Checklist

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://github.com/RadekCap/CAPZTests/blob/main/README.md
+    url: https://github.com/RadekCap/capi-tests/blob/main/README.md
     about: Check the documentation before opening an issue
   - name: Test Suite Details
-    url: https://github.com/RadekCap/CAPZTests/blob/main/test/README.md
+    url: https://github.com/RadekCap/capi-tests/blob/main/test/README.md
     about: Detailed test suite documentation
   - name: cluster-api-installer
     url: https://github.com/RadekCap/cluster-api-installer
     about: Issues with the ARO-CAPZ deployment itself (not the test suite)
   - name: Security Vulnerabilities
-    url: https://github.com/RadekCap/CAPZTests/blob/main/SECURITY.md
+    url: https://github.com/RadekCap/capi-tests/blob/main/SECURITY.md
     about: Report security issues privately (do not open public issues)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ Before contributing, ensure you have:
 
 1. Fork and clone the repository:
    ```bash
-   git clone https://github.com/<your-username>/CAPZTests.git
-   cd CAPZTests
+   git clone https://github.com/<your-username>/capi-tests.git
+   cd capi-tests
    ```
 
 2. Verify prerequisites:

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 > Provider-specific configuration is being extracted and the codebase is under active review.
 > The documentation below still reflects the original CAPZ-focused scope and will be updated as the generalization progresses.
 
-[![Check Dependencies](https://github.com/RadekCap/CAPZTests/actions/workflows/check-dependencies.yml/badge.svg)](https://github.com/RadekCap/CAPZTests/actions/workflows/check-dependencies.yml)
-[![Repository Setup](https://github.com/RadekCap/CAPZTests/actions/workflows/test-setup.yml/badge.svg)](https://github.com/RadekCap/CAPZTests/actions/workflows/test-setup.yml)
+[![Check Dependencies](https://github.com/RadekCap/capi-tests/actions/workflows/check-dependencies.yml/badge.svg)](https://github.com/RadekCap/capi-tests/actions/workflows/check-dependencies.yml)
+[![Repository Setup](https://github.com/RadekCap/capi-tests/actions/workflows/test-setup.yml/badge.svg)](https://github.com/RadekCap/capi-tests/actions/workflows/test-setup.yml)
 
 **Security Scanning:**
 
-[![govulncheck](https://github.com/RadekCap/CAPZTests/actions/workflows/security-govulncheck.yml/badge.svg)](https://github.com/RadekCap/CAPZTests/actions/workflows/security-govulncheck.yml)
-[![gosec](https://github.com/RadekCap/CAPZTests/actions/workflows/security-gosec.yml/badge.svg)](https://github.com/RadekCap/CAPZTests/actions/workflows/security-gosec.yml)
-[![Trivy](https://github.com/RadekCap/CAPZTests/actions/workflows/security-trivy.yml/badge.svg)](https://github.com/RadekCap/CAPZTests/actions/workflows/security-trivy.yml)
-[![nancy](https://github.com/RadekCap/CAPZTests/actions/workflows/security-nancy.yml/badge.svg)](https://github.com/RadekCap/CAPZTests/actions/workflows/security-nancy.yml)
+[![govulncheck](https://github.com/RadekCap/capi-tests/actions/workflows/security-govulncheck.yml/badge.svg)](https://github.com/RadekCap/capi-tests/actions/workflows/security-govulncheck.yml)
+[![gosec](https://github.com/RadekCap/capi-tests/actions/workflows/security-gosec.yml/badge.svg)](https://github.com/RadekCap/capi-tests/actions/workflows/security-gosec.yml)
+[![Trivy](https://github.com/RadekCap/capi-tests/actions/workflows/security-trivy.yml/badge.svg)](https://github.com/RadekCap/capi-tests/actions/workflows/security-trivy.yml)
+[![nancy](https://github.com/RadekCap/capi-tests/actions/workflows/security-nancy.yml/badge.svg)](https://github.com/RadekCap/capi-tests/actions/workflows/security-nancy.yml)
 
 Comprehensive test suite for Azure Red Hat OpenShift (ARO) deployment using Cluster API Provider Azure (CAPZ) and Azure Service Operator (ASO).
 

--- a/docs/FEDORA-43-AZURE-CLI.md
+++ b/docs/FEDORA-43-AZURE-CLI.md
@@ -183,5 +183,5 @@ sudo dnf remove azure-cli
 
 ## Related
 
-- [Issue #283](https://github.com/RadekCap/CAPZTests/issues/283) - Original issue tracking this problem
+- [Issue #283](https://github.com/RadekCap/capi-tests/issues/283) - Original issue tracking this problem
 - [Azure CLI GitHub](https://github.com/Azure/azure-cli) - Azure CLI repository

--- a/docs/KIND-INOTIFY-FIX.md
+++ b/docs/KIND-INOTIFY-FIX.md
@@ -166,6 +166,6 @@ kind delete cluster --name test
 
 ## Related
 
-- [Issue #285](https://github.com/RadekCap/CAPZTests/issues/285) - Original issue tracking this problem
+- [Issue #285](https://github.com/RadekCap/capi-tests/issues/285) - Original issue tracking this problem
 - [Kind GitHub](https://github.com/kubernetes-sigs/kind) - Kind repository
 - Similar issues affect VS Code, JetBrains IDEs, and other development tools

--- a/docs/ORPHANED-RESOURCES.md
+++ b/docs/ORPHANED-RESOURCES.md
@@ -163,7 +163,7 @@ az resource show --ids "<RESOURCE_ID>"
 
 ## Related Documentation
 
-- [ARO HCP Domain Prefix Reservation](https://github.com/RadekCap/CAPZTests/issues/289) - Cluster name reuse limitations
+- [ARO HCP Domain Prefix Reservation](https://github.com/RadekCap/capi-tests/issues/289) - Cluster name reuse limitations
 - [Azure Resource Graph Query Language](https://learn.microsoft.com/en-us/azure/governance/resource-graph/concepts/query-language)
 - [Azure CLI Resource Management](https://learn.microsoft.com/en-us/cli/azure/resource)
 

--- a/docs/TLDR.md
+++ b/docs/TLDR.md
@@ -1,8 +1,8 @@
 # TLDR for Running Tests Locally
 
 ```bash
-git clone https://github.com/RadekCap/CAPZTests.git
-cd CAPZTests
+git clone https://github.com/RadekCap/capi-tests.git
+cd capi-tests
 git checkout dev
 ```
 

--- a/docs/analysis/433-external-kubeconfig-support.md
+++ b/docs/analysis/433-external-kubeconfig-support.md
@@ -1,6 +1,6 @@
 # Analysis: External Kubernetes Cluster Support via Kubeconfig
 
-**Issue:** [#433 - Add support for external Kubernetes cluster via kubeconfig](https://github.com/RadekCap/CAPZTests/issues/433)
+**Issue:** [#433 - Add support for external Kubernetes cluster via kubeconfig](https://github.com/RadekCap/capi-tests/issues/433)
 
 **Date:** 2025-01-28
 

--- a/docs/analysis/434-openshift-ci-sippy-integration.md
+++ b/docs/analysis/434-openshift-ci-sippy-integration.md
@@ -1,6 +1,6 @@
 # Analysis: OpenShift CI and Sippy Integration
 
-**Issue:** [#434 - Integrate with OpenShift CI and Sippy reporting](https://github.com/RadekCap/CAPZTests/issues/434)
+**Issue:** [#434 - Integrate with OpenShift CI and Sippy reporting](https://github.com/RadekCap/capi-tests/issues/434)
 
 **Date:** 2025-01-28
 

--- a/docs/analysis/436-deployment-modes.md
+++ b/docs/analysis/436-deployment-modes.md
@@ -1,6 +1,6 @@
 # Deployment Modes for ARO-CAPZ Test Suite
 
-**Issue:** [#436 - Document supported testing paths and deployment modes](https://github.com/RadekCap/CAPZTests/issues/436)
+**Issue:** [#436 - Document supported testing paths and deployment modes](https://github.com/RadekCap/capi-tests/issues/436)
 
 **Date:** 2025-01-28
 


### PR DESCRIPTION
## Description

Update all GitHub URLs from `RadekCap/CAPZTests` to `RadekCap/capi-tests` to match the renamed repository.

JIRA: https://issues.redhat.com/browse/ARO-24949
Fixes #528

## Changes Made

- Updated badge URLs in `README.md` (6 occurrences)
- Updated help resource URLs in `.github/ISSUE_TEMPLATE/config.yml` (3 occurrences)
- Updated clone instructions in `CONTRIBUTING.md` and `docs/TLDR.md`
- Updated issue reference URLs in `docs/FEDORA-43-AZURE-CLI.md`, `docs/KIND-INOTIFY-FIX.md`, `docs/ORPHANED-RESOURCES.md`
- Updated analysis document URLs in `docs/analysis/` (3 files)
- Updated example URLs in `.gemini/commands/implement-issue.md` (6 occurrences)

## Additional Notes

Pure find-and-replace of documentation/config URLs — no code or behavioral changes. This is issue 2 of 6 in the CAPZTests → capi-tests rename series, building on PR #534 (Go module rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated issue template configuration with revised repository contact links for documentation, test suite details, and security vulnerability reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->