### PR TITLE
refactor: update project identity from ARO-CAPZ to CAPI Test Suite (ARO-24950)

### DIFF
--- a/.claude/commands/add-test-phase.md
+++ b/.claude/commands/add-test-phase.md
@@ -1,4 +1,4 @@
-Create a new test phase file for the ARO-CAPZ test suite following the established patterns.
+Create a new test phase file for the CAPI test suite following the established patterns.
 
 ## Instructions
 

--- a/.claude/commands/review-test.md
+++ b/.claude/commands/review-test.md
@@ -1,4 +1,4 @@
-Review test files in this repository for compliance with ARO-CAPZ test suite patterns and guidelines.
+Review test files in this repository for compliance with CAPI test suite patterns and guidelines.
 
 ## What to Review
 

--- a/.claude/commands/troubleshoot.md
+++ b/.claude/commands/troubleshoot.md
@@ -1,4 +1,4 @@
-Systematically troubleshoot test failures in the ARO-CAPZ test suite.
+Systematically troubleshoot test failures in the CAPI test suite.
 
 ## Instructions
 

--- a/.claude/commands/update-docs.md
+++ b/.claude/commands/update-docs.md
@@ -1,4 +1,4 @@
-Update all documentation files to stay in sync with code changes in the ARO-CAPZ test repository.
+Update all documentation files to stay in sync with code changes in the CAPI test repository.
 
 ## Instructions
 

--- a/.gemini/commands/add-test-phase.md
+++ b/.gemini/commands/add-test-phase.md
@@ -1,4 +1,4 @@
-Create a new test phase file for the ARO-CAPZ test suite following the established patterns.
+Create a new test phase file for the CAPI test suite following the established patterns.
 
 ## Instructions
 

--- a/.gemini/commands/review-test.md
+++ b/.gemini/commands/review-test.md
@@ -1,4 +1,4 @@
-Review test files in this repository for compliance with ARO-CAPZ test suite patterns and guidelines.
+Review test files in this repository for compliance with CAPI test suite patterns and guidelines.
 
 ## What to Review
 

--- a/.gemini/commands/troubleshoot.md
+++ b/.gemini/commands/troubleshoot.md
@@ -1,4 +1,4 @@
-Systematically troubleshoot test failures in the ARO-CAPZ test suite.
+Systematically troubleshoot test failures in the CAPI test suite.
 
 ## Instructions
 

--- a/.gemini/commands/update-docs.md
+++ b/.gemini/commands/update-docs.md
@@ -1,4 +1,4 @@
-Update all documentation files to stay in sync with code changes in the ARO-CAPZ test repository.
+Update all documentation files to stay in sync with code changes in the CAPI test repository.
 
 ## Instructions
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug in the ARO-CAPZ test suite
+about: Report a bug in the CAPI test suite
 title: '[BUG] '
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,7 +8,7 @@ contact_links:
     about: Detailed test suite documentation
   - name: cluster-api-installer
     url: https://github.com/RadekCap/cluster-api-installer
-    about: Issues with the ARO-CAPZ deployment itself (not the test suite)
+    about: Issues with the CAPI deployment itself (not the test suite)
   - name: Security Vulnerabilities
     url: https://github.com/RadekCap/capi-tests/blob/main/SECURITY.md
     about: Report security issues privately (do not open public issues)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Purpose
 
-This is a Go-based test suite for validating Azure Red Hat OpenShift (ARO) deployments using Cluster API Provider Azure (CAPZ) and Azure Service Operator (ASO). The tests verify the complete deployment workflow from prerequisites to cluster verification.
-
-**Important**: This is NOT a multi-cloud CAPI testing framework. It is specifically for ARO-CAPZ on Azure only.
+This is a Go-based CAPI test suite, currently supporting CAPZ/ARO and CAPA/ROSA paths. The tests verify the complete deployment workflow from prerequisites to cluster verification.
 
 ## Test Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to ARO-CAPZ Test Suite
+# Contributing to CAPI Test Suite
 
-Thank you for your interest in contributing to the ARO-CAPZ Test Suite! This document provides guidelines for contributing to the project.
+Thank you for your interest in contributing to the CAPI Test Suite! This document provides guidelines for contributing to the project.
 
 ## Table of Contents
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,9 +4,7 @@ This file provides guidance to Gemini when working with code in this repository.
 
 ## Repository Purpose
 
-This is a Go-based test suite for validating Azure Red Hat OpenShift (ARO) deployments using Cluster API Provider Azure (CAPZ) and Azure Service Operator (ASO). The tests verify the complete deployment workflow from prerequisites to cluster verification.
-
-**Important**: This is NOT a multi-cloud CAPI testing framework. It is specifically for ARO-CAPZ on Azure only.
+This is a Go-based CAPI test suite, currently supporting CAPZ/ARO and CAPA/ROSA paths. The tests verify the complete deployment workflow from prerequisites to cluster verification.
 
 ## Core Principles
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ _copy-latest-results:
 	@cp -f $(RESULTS_DIR)/*.log $(LATEST_RESULTS_DIR)/ 2>/dev/null || true
 
 help: ## Display this help message
-	@echo "ARO-CAPZ Test Suite Makefile"
+	@echo "CAPI Test Suite Makefile"
 	@echo ""
 	@echo "Usage: make [target]"
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Target usage of this test suite will be:
 
 - **OSCI (OpenShift CI)** - Automated continuous integration testing for OpenShift deployments
 - **ACM (Advanced Cluster Management)** - Multi-cluster management and validation workflows
-- **Manual Testing** - Developer and QA validation of ARO-CAPZ deployments
+- **Manual Testing** - Developer and QA validation of CAPI deployments
 
 ## Prerequisites
 

--- a/TEST_COVERAGE.md
+++ b/TEST_COVERAGE.md
@@ -1,6 +1,6 @@
 # Test Coverage Documentation
 
-This document provides comprehensive information about the test coverage for the ARO-CAPZ deployment test suite.
+This document provides comprehensive information about the test coverage for the CAPI deployment test suite.
 
 ## Review History
 
@@ -271,7 +271,7 @@ USE_KUBECONFIG=/path/to/kubeconfig make test-all
 
 ## Deployment Workflow Coverage
 
-The test suite covers 100% of the documented ARO-CAPZ deployment workflow:
+The test suite covers 100% of the documented CAPI deployment workflow:
 
 - Check dependencies verification
 - Repository setup

--- a/docs/CI_CD_REVIEW.md
+++ b/docs/CI_CD_REVIEW.md
@@ -173,7 +173,7 @@ All workflows now specify explicit permissions at the workflow level:
 
 ### Rationale
 
-This is a test suite for ARO-CAPZ, which only runs on Kubernetes/Linux. Multiple OS testing is not required. The Go version is pinned to the project's `go.mod` to ensure consistency.
+This is a CAPI test suite, which only runs on Kubernetes/Linux. Multiple OS testing is not required. The Go version is pinned to the project's `go.mod` to ensure consistency.
 
 ---
 

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -1,6 +1,6 @@
 # Cross-Platform Compatibility Guide
 
-This document provides a comprehensive cross-platform compatibility review of the ARO-CAPZ test suite, addressing issue #402.
+This document provides a comprehensive cross-platform compatibility review of the CAPI test suite, addressing issue #402.
 
 ## Supported Platforms
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,6 +1,6 @@
 # Dependency Management
 
-This document describes how dependencies are managed in the ARO-CAPZ test suite, including Go modules, external tools, and security scanning.
+This document describes how dependencies are managed in the CAPI test suite, including Go modules, external tools, and security scanning.
 
 ## Overview
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -131,7 +131,7 @@ make test
 **Best Choice: Dynamic Clone**
 
 ```yaml
-name: ARO-CAPZ Tests
+name: CAPI Tests
 
 on: [push, pull_request]
 

--- a/docs/PERFORMANCE_REVIEW.md
+++ b/docs/PERFORMANCE_REVIEW.md
@@ -21,7 +21,7 @@ This document provides a comprehensive performance review identifying unnecessar
 
 ## Executive Summary
 
-The ARO-CAPZ test suite demonstrates **good overall performance design** with appropriate polling intervals, exponential backoff patterns, and progress visibility during long-running operations. The main waiting time is inherent to Azure resource provisioning rather than test inefficiencies.
+The CAPI test suite demonstrates **good overall performance design** with appropriate polling intervals, exponential backoff patterns, and progress visibility during long-running operations. The main waiting time is inherent to Azure resource provisioning rather than test inefficiencies.
 
 **Key Findings:**
 - Polling intervals are appropriate (5-30 seconds depending on operation)
@@ -341,7 +341,7 @@ time make _delete
 
 ## Conclusion
 
-The ARO-CAPZ test suite is well-optimized for performance. The main time costs are:
+The CAPI test suite is well-optimized for performance. The main time costs are:
 
 1. **Azure resource provisioning** (30-45 minutes) - inherent to ARO deployment
 2. **Controller initialization** (5-10 minutes) - inherent to CAPI/CAPZ/ASO

--- a/docs/SECURITY_REVIEW.md
+++ b/docs/SECURITY_REVIEW.md
@@ -1,6 +1,6 @@
 # Security Review
 
-This document summarizes the security reviews conducted for the ARO-CAPZ test suite.
+This document summarizes the security reviews conducted for the CAPI test suite.
 
 ## Review History
 

--- a/docs/TESTING_GUIDELINES.md
+++ b/docs/TESTING_GUIDELINES.md
@@ -1,4 +1,4 @@
-# Go Testing Guidelines for ARO-CAPZ Test Suite
+# Go Testing Guidelines for CAPI Test Suite
 
 This document outlines the testing guidelines and best practices used in this repository, based on proven Go testing patterns from official Go documentation and industry standards.
 

--- a/docs/analysis/433-external-kubeconfig-support.md
+++ b/docs/analysis/433-external-kubeconfig-support.md
@@ -10,7 +10,7 @@
 
 ## Executive Summary
 
-This document describes the implementation approach for adding support to run the ARO-CAPZ test suite against an external Kubernetes cluster (e.g., MCE installation) instead of creating a local Kind cluster.
+This document describes the implementation approach for adding support to run the CAPI test suite against an external Kubernetes cluster (e.g., MCE installation) instead of creating a local Kind cluster.
 
 The solution introduces a single environment variable `USE_KUBECONFIG` that, when set to a kubeconfig file path, switches the test suite to "external cluster mode" where it validates pre-installed controllers rather than deploying them.
 

--- a/docs/analysis/434-openshift-ci-sippy-integration.md
+++ b/docs/analysis/434-openshift-ci-sippy-integration.md
@@ -10,7 +10,7 @@
 
 ## Executive Summary
 
-This document outlines the integration of the ARO-CAPZ test suite with OpenShift CI (Prow) and Sippy analytics. The goal is to run tests automatically in OpenShift CI and have results visible in Sippy dashboards for tracking test reliability and regressions.
+This document outlines the integration of the CAPI test suite with OpenShift CI (Prow) and Sippy analytics. The goal is to run tests automatically in OpenShift CI and have results visible in Sippy dashboards for tracking test reliability and regressions.
 
 **Key Finding:** The test suite already produces JUnit XML output (required by Sippy). The remaining work is CI infrastructure configuration and onboarding.
 

--- a/docs/analysis/436-deployment-modes.md
+++ b/docs/analysis/436-deployment-modes.md
@@ -1,4 +1,4 @@
-# Deployment Modes for ARO-CAPZ Test Suite
+# Deployment Modes for CAPI Test Suite
 
 **Issue:** [#436 - Document supported testing paths and deployment modes](https://github.com/RadekCap/capi-tests/issues/436)
 

--- a/docs/test-analysis/README.md
+++ b/docs/test-analysis/README.md
@@ -1,6 +1,6 @@
-# ARO-CAPZ Test Suite Analysis
+# CAPI Test Suite Analysis
 
-This directory contains detailed analysis of all test phases in the ARO-CAPZ test suite.
+This directory contains detailed analysis of all test phases in the CAPI test suite.
 
 ---
 

--- a/scripts/cleanup-azure-resources.sh
+++ b/scripts/cleanup-azure-resources.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# cleanup-azure-resources.sh - Clean up Azure resources created during ARO-CAPZ testing
+# cleanup-azure-resources.sh - Clean up Azure resources created during CAPI testing
 #
 # This script finds and deletes Azure resources that match the naming patterns used
 # during testing. It cleans up:

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,4 @@
-# ARO-CAPZ Test Suite
+# CAPI Test Suite
 
 Comprehensive test suite for Azure Red Hat OpenShift (ARO) deployment using Cluster API Provider Azure (CAPZ) and Azure Service Operator (ASO).
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1826,7 +1826,7 @@ func extractVersionFromImage(image string) string {
 func GetComponentVersions(t *testing.T, kubeContext string) []ComponentVersion {
 	t.Helper()
 
-	// Define components to check - these are the key components for ARO-CAPZ deployment
+	// Define components to check - these are the key components for CAPI deployment
 	// Get namespace configuration
 	config := NewTestConfig()
 


### PR DESCRIPTION
## Description

Update all project-level identity text from "ARO-CAPZ Test Suite" to "CAPI Test Suite" to reflect the evolution to a multi-provider CAPI test suite supporting CAPZ/ARO and CAPA/ROSA paths.

JIRA: https://issues.redhat.com/browse/ARO-24950
Fixes #529

## Changes Made

- Updated CLAUDE.md and GEMINI.md: new project description, removed "NOT a multi-cloud framework" note
- Renamed project identity across 30 files: documentation, AI commands, GitHub templates, Makefile, code comments
- Preserved all provider-specific references (CAPZ_USER, ARO_REPO_*, resource types, etc.)

## Additional Notes

Pure identity/text rename — no code or behavioral changes. This is issue 3 of 6 in the CAPZTests → capi-tests rename series, building on PR #535 (GitHub URL updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology from "ARO-CAPZ" to "CAPI" in help text and issue templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->