### PR TITLE
feat: make default cluster names provider-configurable (ARO-24951)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,10 +280,10 @@ export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 - `ARO_REPO_DIR` - Local path (default: `/tmp/cluster-api-installer-aro`)
 
 ### Cluster Configuration
-- `MANAGEMENT_CLUSTER_NAME` - Management cluster name (default: `capz-tests-stage`)
+- `MANAGEMENT_CLUSTER_NAME` - Management cluster name (default: `capz-tests-stage` for ARO, `capa-tests-stage` for ROSA)
   - **Note**: Tests automatically translate this to `KIND_CLUSTER_NAME` for the deployment script
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
-- `WORKLOAD_CLUSTER_NAME` - ARO workload cluster name (default: `capz-tests-cluster`)
+- `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests-cluster` for ARO, `capa-tests-cluster` for ROSA)
 - `CS_CLUSTER_NAME` - **C**luster **S**ervice cluster name prefix used for YAML generation and Azure resource naming (default: `${CAPZ_USER}-${DEPLOYMENT_ENV}`). The Azure resource group will be named `${CS_CLUSTER_NAME}-resgroup`. This prefix is also used for the ExternalAuth resource ID.
 - `OCP_VERSION` - OpenShift version (default: `4.21`)
 - `REGION` - Azure region (default: `uksouth`)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -165,10 +165,10 @@ See `docs/INTEGRATION.md` for detailed integration patterns.
 - `ARO_REPO_DIR` - Local path (default: `/tmp/cluster-api-installer-aro`)
 
 ### Cluster Configuration
-- `MANAGEMENT_CLUSTER_NAME` - Management cluster name (default: `capz-tests-stage`)
+- `MANAGEMENT_CLUSTER_NAME` - Management cluster name (default: `capz-tests-stage` for ARO, `capa-tests-stage` for ROSA)
   - **Note**: Tests automatically translate this to `KIND_CLUSTER_NAME` for the deployment script
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
-- `WORKLOAD_CLUSTER_NAME` - ARO workload cluster name (default: `capz-tests-cluster`)
+- `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests-cluster` for ARO, `capa-tests-cluster` for ROSA)
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPZ_USER}-${DEPLOYMENT_ENV}`). The Azure resource group will be named `${CS_CLUSTER_NAME}-resgroup`.
 - `OCP_VERSION` - OpenShift version (default: `4.21`)
 - `REGION` - Azure region (default: `uksouth`)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,12 @@ CAPZ_USER_DEFAULT := $(shell grep 'DefaultCAPZUser = ' test/config.go | grep -o 
 CAPZ_USER ?= $(CAPZ_USER_DEFAULT)
 DEPLOYMENT_ENV ?= stage
 REGION ?= uksouth
+INFRA_PROVIDER ?= aro
+ifeq ($(INFRA_PROVIDER),rosa)
+MANAGEMENT_CLUSTER_NAME ?= capa-tests-stage
+else
 MANAGEMENT_CLUSTER_NAME ?= capz-tests-stage
+endif
 CS_CLUSTER_NAME ?= $(CAPZ_USER)-$(DEPLOYMENT_ENV)
 AZURE_RESOURCE_GROUP ?= $(CS_CLUSTER_NAME)-resgroup
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Tests are configured via environment variables:
 
 ### Cluster Configuration
 
-- `MANAGEMENT_CLUSTER_NAME` - Management cluster name (default: `capz-tests-stage`)
+- `MANAGEMENT_CLUSTER_NAME` - Management cluster name (default: `capz-tests-stage` for ARO, `capa-tests-stage` for ROSA)
   - **Note**: Tests automatically translate this to `KIND_CLUSTER_NAME` for the deployment script
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
-- `WORKLOAD_CLUSTER_NAME` - ARO workload cluster name (default: `capz-tests-cluster`)
+- `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests-cluster` for ARO, `capa-tests-cluster` for ROSA)
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPZ_USER}-${DEPLOYMENT_ENV}`). The Azure resource group will be named `${CS_CLUSTER_NAME}-resgroup`.
 - `OCP_VERSION` - OpenShift version (default: `4.21`)
 - `REGION` - Azure region (default: `uksouth`)

--- a/test/README.md
+++ b/test/README.md
@@ -82,10 +82,10 @@ Tests are configured via environment variables:
 
 ### Cluster Configuration
 
-- `MANAGEMENT_CLUSTER_NAME` - Management cluster name (default: `capz-tests-stage`)
+- `MANAGEMENT_CLUSTER_NAME` - Management cluster name (default: `capz-tests-stage` for ARO, `capa-tests-stage` for ROSA)
   - **Note**: Tests automatically translate this to `KIND_CLUSTER_NAME` for the deployment script
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
-- `WORKLOAD_CLUSTER_NAME` - ARO workload cluster name (default: `capz-tests-cluster`)
+- `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests-cluster` for ARO, `capa-tests-cluster` for ROSA)
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPZ_USER}-${DEPLOYMENT_ENV}`). The Azure resource group will be named `${CS_CLUSTER_NAME}-resgroup`.
 - `OCP_VERSION` - OpenShift version (default: `4.21`)
 - `REGION` - Azure region (default: `uksouth`)

--- a/test/config.go
+++ b/test/config.go
@@ -249,7 +249,7 @@ func getWorkloadClusterNamespace() string {
 	return workloadClusterNamespace
 }
 
-// TestConfig holds configuration for ARO-CAPZ tests
+// TestConfig holds configuration for CAPI tests
 type TestConfig struct {
 	// Repository configuration
 	RepoURL    string
@@ -326,16 +326,20 @@ func NewTestConfig() *TestConfig {
 	// ASOControllerTimeout is always a valid duration (used by ValidateAllConfigurations).
 	asoTimeout := parseASOControllerTimeout()
 
-	// Resolve provider-specific namespace and build provider config
+	// Resolve provider-specific namespace, cluster names, and build provider config
 	var providerNamespace string
 	var infraProviders []InfraProvider
 	var defaultGenScriptPath string
+	var defaultMgmtCluster string
+	var defaultWorkloadCluster string
 
 	switch infraProviderName {
 	case "rosa":
 		providerNamespace = getControllerNamespace("CAPA_NAMESPACE", "capa-system")
 		infraProviders = []InfraProvider{NewAWSProvider(providerNamespace)}
 		defaultGenScriptPath = "./scripts/rosa-hcp/gen.sh"
+		defaultMgmtCluster = "capa-tests-stage"
+		defaultWorkloadCluster = "capa-tests-cluster"
 	default: // "aro"
 		infraProviderName = "aro" // normalize unknown values
 		providerNamespace = getControllerNamespace("CAPZ_NAMESPACE", "capz-system")
@@ -347,6 +351,8 @@ func NewTestConfig() *TestConfig {
 		}
 		infraProviders = []InfraProvider{azureProvider}
 		defaultGenScriptPath = "./scripts/aro-hcp/gen.sh"
+		defaultMgmtCluster = "capz-tests-stage"
+		defaultWorkloadCluster = "capz-tests-cluster"
 	}
 
 	return &TestConfig{
@@ -356,8 +362,8 @@ func NewTestConfig() *TestConfig {
 		RepoDir:    getDefaultRepoDir(),
 
 		// Cluster defaults
-		ManagementClusterName:    GetEnvOrDefault("MANAGEMENT_CLUSTER_NAME", "capz-tests-stage"),
-		WorkloadClusterName:      GetEnvOrDefault("WORKLOAD_CLUSTER_NAME", "capz-tests-cluster"),
+		ManagementClusterName:    GetEnvOrDefault("MANAGEMENT_CLUSTER_NAME", defaultMgmtCluster),
+		WorkloadClusterName:      GetEnvOrDefault("WORKLOAD_CLUSTER_NAME", defaultWorkloadCluster),
 		ClusterNamePrefix:        GetEnvOrDefault("CS_CLUSTER_NAME", fmt.Sprintf("%s-%s", GetEnvOrDefault("CAPZ_USER", DefaultCAPZUser), GetEnvOrDefault("DEPLOYMENT_ENV", DefaultDeploymentEnv))),
 		OCPVersion:               GetEnvOrDefault("OCP_VERSION", "4.20"),
 		Region:                   GetEnvOrDefault("REGION", "uksouth"),


### PR DESCRIPTION
## Description

Make default management/workload cluster names provider-configurable so they vary by infrastructure provider (ARO vs ROSA).

JIRA: https://issues.redhat.com/browse/ARO-24951
Fixes #530

## Changes Made

- `test/config.go`: Added `defaultMgmtCluster` and `defaultWorkloadCluster` variables in the provider switch block, used as defaults for `MANAGEMENT_CLUSTER_NAME` and `WORKLOAD_CLUSTER_NAME`
  - ARO: `capz-tests-stage` / `capz-tests-cluster` (unchanged)
  - ROSA: `capa-tests-stage` / `capa-tests-cluster` (new)
- `Makefile`: Made `MANAGEMENT_CLUSTER_NAME` default provider-aware via `INFRA_PROVIDER` variable
- Updated documentation in `CLAUDE.md`, `GEMINI.md`, `README.md`, and `test/README.md` to show per-provider defaults

## Additional Notes

This is issue 4 of 6 in the CAPZTests → capi-tests rename series, building on PR #536 (project identity update). Env var overrides still take priority over provider defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting between multiple infrastructure providers (ROSA for AWS and ARO for Azure) with automatic cluster configuration based on the chosen provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->