### PR TITLE
feat: make K8s namespace labels and prefix provider-specific (ARO-24952)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,8 +289,8 @@ export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 - `REGION` - Azure region (default: `uksouth`)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)
 - `CAPZ_USER` - User identifier for domain prefix (default: `rcap`). Must be short enough that `${CAPZ_USER}-${DEPLOYMENT_ENV}` does not exceed 15 characters.
-- `WORKLOAD_CLUSTER_NAMESPACE` - Namespace for workload cluster resources (CAPI CRs that create Azure resources). If set, uses the exact value provided (for resume scenarios). If not set, generates a unique namespace per test run using `${WORKLOAD_CLUSTER_NAMESPACE_PREFIX}-${TIMESTAMP}` format (e.g., `capz-test-20260202-135526`). This namespace is passed as `$NAMESPACE` to the YAML generation script.
-- `WORKLOAD_CLUSTER_NAMESPACE_PREFIX` - Prefix for auto-generated workload cluster namespace (default: `capz-test`). Only used when `WORKLOAD_CLUSTER_NAMESPACE` is not set.
+- `WORKLOAD_CLUSTER_NAMESPACE` - Namespace for workload cluster resources (CAPI CRs that create cloud resources). If set, uses the exact value provided (for resume scenarios). If not set, generates a unique namespace per test run using `${WORKLOAD_CLUSTER_NAMESPACE_PREFIX}-${TIMESTAMP}` format (e.g., `capz-test-20260202-135526` for ARO, `capa-test-20260202-135526` for ROSA). This namespace is passed as `$NAMESPACE` to the YAML generation script.
+- `WORKLOAD_CLUSTER_NAMESPACE_PREFIX` - Prefix for auto-generated workload cluster namespace (default: provider-specific — `capz-test` for ARO, `capa-test` for ROSA). Only used when `WORKLOAD_CLUSTER_NAMESPACE` is not set.
 
 ### Kind Mode
 - `USE_KIND` - Enable Kind deployment mode (default: `false`). When set to `true`:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Tests are configured via environment variables:
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)
 - `CAPZ_USER` - User identifier for domain prefix (default: `rcap`)
 - `WORKLOAD_CLUSTER_NAMESPACE` - Namespace for workload cluster resources. If set, uses the exact value provided (for resume scenarios). If not set, auto-generates a unique namespace per test run using `${WORKLOAD_CLUSTER_NAMESPACE_PREFIX}-${TIMESTAMP}` format.
-- `WORKLOAD_CLUSTER_NAMESPACE_PREFIX` - Prefix for auto-generated namespace (default: `capz-test`). Only used when `WORKLOAD_CLUSTER_NAMESPACE` is not set.
+- `WORKLOAD_CLUSTER_NAMESPACE_PREFIX` - Prefix for auto-generated namespace (default: provider-specific — `capz-test` for ARO, `capa-test` for ROSA). Only used when `WORKLOAD_CLUSTER_NAMESPACE` is not set.
 
 #### Naming Requirements (RFC 1123)
 

--- a/docs/API_REVIEW.md
+++ b/docs/API_REVIEW.md
@@ -32,7 +32,7 @@ This document provides a comprehensive review of all public interfaces. These co
 
 | Change | V1 Behavior | V1.1 Behavior |
 |--------|-------------|---------------|
-| Namespace | Static `TEST_NAMESPACE` (default: `default`) | Auto-generated unique namespace per test run (`capz-test-YYYYMMDD-HHMMSS`). Set `WORKLOAD_CLUSTER_NAMESPACE` to override. |
+| Namespace | Static `TEST_NAMESPACE` (default: `default`) | Auto-generated unique namespace per test run (provider-specific prefix: `capz-test-YYYYMMDD-HHMMSS` for ARO, `capa-test-YYYYMMDD-HHMMSS` for ROSA). Set `WORKLOAD_CLUSTER_NAMESPACE` to override. |
 | `TestNamespace` field | `TestConfig.TestNamespace` | Renamed to `TestConfig.WorkloadClusterNamespace` |
 
 ### New Environment Variables (V1.1)
@@ -41,7 +41,7 @@ This document provides a comprehensive review of all public interfaces. These co
 |----------|----------|---------|---------|
 | `USE_KUBECONFIG` | No | _(unset)_ | Path to external kubeconfig; enables external cluster mode |
 | `WORKLOAD_CLUSTER_NAMESPACE` | No | _(auto-generated)_ | Explicit namespace override for resume scenarios |
-| `WORKLOAD_CLUSTER_NAMESPACE_PREFIX` | No | `capz-test` | Prefix for auto-generated namespace |
+| `WORKLOAD_CLUSTER_NAMESPACE_PREFIX` | No | Provider-specific (`capz-test` / `capa-test`) | Prefix for auto-generated namespace |
 | `MCE_AUTO_ENABLE` | No | `true` (when `USE_KUBECONFIG` set) | Auto-enable MCE CAPI/CAPZ components |
 | `MCE_ENABLEMENT_TIMEOUT` | No | `15m` | Timeout for MCE component enablement |
 

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -53,8 +53,8 @@ func TestDeployment_00_CreateNamespace(t *testing.T) {
 	// Add labels for easy identification and cleanup
 	PrintToTTY("Adding labels to namespace...\n")
 	_, err = RunCommand(t, "kubectl", "--context", context, "label", "namespace", config.WorkloadClusterNamespace,
-		"capz-test=true",
-		fmt.Sprintf("capz-test-prefix=%s", GetEnvOrDefault("WORKLOAD_CLUSTER_NAMESPACE_PREFIX", "capz-test")),
+		fmt.Sprintf("%s=true", config.TestLabelPrefix),
+		fmt.Sprintf("%s-prefix=%s", config.TestLabelPrefix, GetEnvOrDefault("WORKLOAD_CLUSTER_NAMESPACE_PREFIX", config.TestLabelPrefix)),
 		"--overwrite")
 	if err != nil {
 		PrintToTTY("⚠️  Failed to add labels (non-fatal): %v\n", err)

--- a/test/README.md
+++ b/test/README.md
@@ -93,7 +93,7 @@ Tests are configured via environment variables:
 - `DEPLOYMENT_ENV` - Deployment environment (stage/prod) (default: `stage`)
 - `CAPZ_USER` - User identifier for domain prefix (default: `rcap`)
 - `WORKLOAD_CLUSTER_NAMESPACE` - Namespace for workload cluster resources (auto-generated if not set)
-- `WORKLOAD_CLUSTER_NAMESPACE_PREFIX` - Prefix for auto-generated namespace (default: `capz-test`)
+- `WORKLOAD_CLUSTER_NAMESPACE_PREFIX` - Prefix for auto-generated namespace (default: provider-specific — `capz-test` for ARO, `capa-test` for ROSA)
 
 ## Running Tests
 

--- a/test/config.go
+++ b/test/config.go
@@ -205,18 +205,20 @@ func getDefaultRepoDir() string {
 
 // getWorkloadClusterNamespace returns the namespace for workload cluster resources.
 // The namespace is unique per test run, combining the configured prefix with a timestamp.
-// Format: {prefix}-{YYYYMMDD-HHMMSS} (e.g., "capz-test-20260203-140812")
+// Format: {prefix}-{YYYYMMDD-HHMMSS} (e.g., "capz-test-20260203-140812" or "capa-test-20260203-140812")
 // This namespace is passed as $NAMESPACE to the YAML generation script and used for
-// all Azure resource checks.
+// all resource checks.
+//
+// The defaultPrefix parameter is provider-specific: "capz-test" for ARO, "capa-test" for ROSA.
 //
 // Resolution order:
 // 1. WORKLOAD_CLUSTER_NAMESPACE env var (explicit override for resume scenarios)
 // 2. Existing deployment state file in RepoDir (auto-resume from previous run)
-// 3. Generate unique namespace using WORKLOAD_CLUSTER_NAMESPACE_PREFIX (default: "capz-test")
+// 3. Generate unique namespace using WORKLOAD_CLUSTER_NAMESPACE_PREFIX (default: provider-specific prefix)
 //
 // The auto-resume from deployment state ensures that subsequent test phases
 // (run as separate go test invocations) use the same namespace as YAML generation.
-func getWorkloadClusterNamespace() string {
+func getWorkloadClusterNamespace(defaultPrefix string) string {
 	workloadClusterNamespaceOnce.Do(func() {
 		// Check if a full namespace is explicitly provided (for resume scenarios)
 		if ns := os.Getenv("WORKLOAD_CLUSTER_NAMESPACE"); ns != "" {
@@ -241,7 +243,7 @@ func getWorkloadClusterNamespace() string {
 		}
 
 		// Generate unique namespace with timestamp for fresh runs
-		prefix := GetEnvOrDefault("WORKLOAD_CLUSTER_NAMESPACE_PREFIX", "capz-test")
+		prefix := GetEnvOrDefault("WORKLOAD_CLUSTER_NAMESPACE_PREFIX", defaultPrefix)
 		timestamp := time.Now().Format("20060102-150405")
 		workloadClusterNamespace = fmt.Sprintf("%s-%s", prefix, timestamp)
 	})
@@ -266,6 +268,7 @@ type TestConfig struct {
 	Environment              string
 	CAPZUser                 string // User identifier for CAPZ resources (from CAPZ_USER env var)
 	WorkloadClusterNamespace string // Namespace for workload cluster resources on management cluster (unique per test run)
+	TestLabelPrefix          string // Provider-specific label prefix for test namespaces (e.g., "capz-test" for ARO, "capa-test" for ROSA)
 	CAPINamespace            string // Namespace for CAPI controller (default: "capi-system", or "multicluster-engine" when USE_K8S=true)
 	CAPZNamespace            string // Namespace for CAPZ/ASO controllers (default: "capz-system", or "multicluster-engine" when USE_K8S=true)
 
@@ -332,6 +335,7 @@ func NewTestConfig() *TestConfig {
 	var defaultGenScriptPath string
 	var defaultMgmtCluster string
 	var defaultWorkloadCluster string
+	var testLabelPrefix string
 
 	switch infraProviderName {
 	case "rosa":
@@ -340,6 +344,7 @@ func NewTestConfig() *TestConfig {
 		defaultGenScriptPath = "./scripts/rosa-hcp/gen.sh"
 		defaultMgmtCluster = "capa-tests-stage"
 		defaultWorkloadCluster = "capa-tests-cluster"
+		testLabelPrefix = "capa-test"
 	default: // "aro"
 		infraProviderName = "aro" // normalize unknown values
 		providerNamespace = getControllerNamespace("CAPZ_NAMESPACE", "capz-system")
@@ -353,6 +358,7 @@ func NewTestConfig() *TestConfig {
 		defaultGenScriptPath = "./scripts/aro-hcp/gen.sh"
 		defaultMgmtCluster = "capz-tests-stage"
 		defaultWorkloadCluster = "capz-tests-cluster"
+		testLabelPrefix = "capz-test"
 	}
 
 	return &TestConfig{
@@ -370,7 +376,8 @@ func NewTestConfig() *TestConfig {
 		AzureSubscriptionName:    os.Getenv("AZURE_SUBSCRIPTION_NAME"),
 		Environment:              GetEnvOrDefault("DEPLOYMENT_ENV", DefaultDeploymentEnv),
 		CAPZUser:                 GetEnvOrDefault("CAPZ_USER", DefaultCAPZUser),
-		WorkloadClusterNamespace: getWorkloadClusterNamespace(),
+		WorkloadClusterNamespace: getWorkloadClusterNamespace(testLabelPrefix),
+		TestLabelPrefix:          testLabelPrefix,
 		CAPINamespace:            getControllerNamespace("CAPI_NAMESPACE", "capi-system"),
 		CAPZNamespace:            providerNamespace,
 


### PR DESCRIPTION
## Description

Make K8s namespace labels and prefix provider-specific to support multi-provider paths.

Ref: ARO-24952

## Changes Made

- Add `TestLabelPrefix` field to `TestConfig` (set per provider: `capz-test` for ARO, `capa-test` for ROSA)
- Update `getWorkloadClusterNamespace()` to accept a provider-specific default prefix parameter
- Replace hardcoded `capz-test=true` and `capz-test-prefix=...` labels in deploy test with provider-derived values
- Update documentation (CLAUDE.md, README.md, test/README.md, docs/API_REVIEW.md) to reflect provider-specific defaults

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `WORKLOAD_CLUSTER_NAMESPACE_PREFIX` | Prefix for auto-generated namespace | Provider-specific: `capz-test` (ARO), `capa-test` (ROSA) |

## Additional Notes

- ARO path behavior is preserved (no breaking changes)
- ROSA path now uses `capa-test` prefix and labels instead of `capz-test`
- Test fixture data in `helpers_test.go` remains valid (uses ARO defaults)

JIRA: https://issues.redhat.com/browse/ARO-24952

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made test namespace labeling configurable via environment variables and provider-specific prefixes instead of hard-coded labels.
  * Enabled reusing previous deployment state to persist and resume test namespaces, improving reliability and efficiency.
  * Updated test initialization to generate provider-aware namespace names and persist the chosen label prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->