### PR TITLE
fix: remove source injection lines from Dockerfile.prow (ARO-24304)

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,0 +1,23 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20
+
+# Install tools needed for CAPZ tests
+RUN dnf install -y azure-cli jq && dnf clean all
+
+# Install kind
+RUN curl -Lo /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64 && \
+    chmod +x /usr/local/bin/kind
+
+# Install kubectl
+RUN curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    chmod +x /usr/local/bin/kubectl
+
+# Install helm
+RUN curl -fsSL https://get.helm.sh/helm-v3.16.0-linux-amd64.tar.gz | tar xz -C /tmp && \
+    mv /tmp/linux-amd64/helm /usr/local/bin/helm && chmod +x /usr/local/bin/helm
+
+# Install gotestsum
+RUN GOBIN=/usr/local/bin go install gotest.tools/gotestsum@v1.13.0
+
+# Install clusterctl
+RUN curl -Lo /usr/local/bin/clusterctl "https://github.com/kubernetes-sigs/cluster-api/releases/latest/download/clusterctl-linux-amd64" && \
+    chmod +x /usr/local/bin/clusterctl


### PR DESCRIPTION
## Description

Fix Dockerfile.prow for ci-operator compatibility (ARO-24304).

## Changes Made

- Remove `WORKDIR`, `COPY . .`, and `RUN go mod download` from Dockerfile.prow
- ci-operator handles source injection when using `build_root.project_image` — the Dockerfile should only install tools

## Configuration Changes

No configuration changes.

## Additional Notes

Part of OpenShift CI onboarding (ARO-24304). The companion PR to `openshift/release` adds the ci-operator config that references this Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced testing infrastructure configuration to include required build tools and utilities for comprehensive testing workflows in development and CI/CD environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->