### PR TITLE
fix: remove source injection lines from Dockerfile.prow (ARO-24304)

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -41,10 +41,3 @@ RUN GOBIN=/usr/local/bin go install gotest.tools/gotestsum@${GOTESTSUM_VERSION}
 RUN curl -Lo /usr/local/bin/clusterctl "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterctl-linux-amd64" && \
     echo "${CLUSTERCTL_SHA256}  /usr/local/bin/clusterctl" | sha256sum -c && \
     chmod +x /usr/local/bin/clusterctl
-
-# Copy repo source
-WORKDIR /go/src/github.com/stolostron/capi-tests
-COPY . .
-
-# Download Go dependencies
-RUN go mod download


### PR DESCRIPTION
## Description

Fix Dockerfile.prow for ci-operator compatibility (ARO-24304).

## Changes Made

- Remove `WORKDIR`, `COPY . .`, and `RUN go mod download` from Dockerfile.prow
- ci-operator handles source injection when using `build_root.project_image` — the Dockerfile should only install tools

## Configuration Changes

No configuration changes.

## Additional Notes

Part of OpenShift CI onboarding (ARO-24304). The companion PR to `openshift/release` adds the ci-operator config that references this Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process configuration to streamline Docker image preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->