### PR TITLE
fix: add Microsoft RPM repo for Azure CLI in Dockerfile.prow (ARO-24304)

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -9,8 +9,10 @@ ARG CLUSTERCTL_VERSION=v1.12.3
 ARG CLUSTERCTL_SHA256=9b75287b15656a62ece65c8ad7491412cebfd30c78e085a9d61396a50df17349
 ARG GOTESTSUM_VERSION=v1.13.0
 
-# Install tools needed for CAPZ tests
-RUN dnf install -y azure-cli jq && dnf clean all
+# Install Azure CLI from Microsoft RPM repo and other tools
+RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
+    dnf install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm && \
+    dnf install -y azure-cli jq && dnf clean all
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
## Description

Add Microsoft RPM repository for Azure CLI installation in Dockerfile.prow. The CI build environment (RHEL 9 base image) does not include Microsoft's repo, causing `dnf install azure-cli` to fail during OpenShift CI rehearsals.

## Changes Made

- Import Microsoft GPG key and install `packages-microsoft-prod` RPM repo
- Azure CLI is then installed from the Microsoft repo alongside `jq`

## Configuration Changes

N/A

## Additional Notes

This fixes the rehearsal failure on openshift/release PR #75733 (OpenShift CI onboarding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure container build to use Microsoft's official Azure CLI repository for improved dependency consistency.
  * Streamlined container build configuration by optimizing installation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->