### PR TITLE
fix: use Azure CLI yum repo in Dockerfile.prow (ARO-24304)

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -11,7 +11,14 @@ ARG GOTESTSUM_VERSION=v1.13.0
 
 # Install Azure CLI from Microsoft repo and other tools
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
-    echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo && \
+    printf '%s\n' \
+      '[azure-cli]' \
+      'name=Azure CLI' \
+      'baseurl=https://packages.microsoft.com/yumrepos/azure-cli' \
+      'enabled=1' \
+      'gpgcheck=1' \
+      'gpgkey=https://packages.microsoft.com/keys/microsoft.asc' \
+      > /etc/yum.repos.d/azure-cli.repo && \
     dnf install -y azure-cli jq && dnf clean all
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Description

Fix Azure CLI installation in Dockerfile.prow. The `packages-microsoft-prod` RPM (used in PR #546) provides .NET/PowerShell repos but not Azure CLI. Use the dedicated `azure-cli` yum repo directly.

## Changes Made

- Replace `packages-microsoft-prod.rpm` with direct `azure-cli` yum repo configuration
- Fixes OpenShift CI rehearsal failure on openshift/release PR

## Configuration Changes

N/A

## Additional Notes

Follow-up to #546. Fixes rehearsal failure: `No match for argument: azure-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changed how the Azure CLI is installed in the build image to use a dedicated repository and package manager.
  * Continued installation of required tooling (azure-cli, jq) during image setup.
  * Removed a redundant repository-package install step to simplify and slightly speed up image builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->