### PR TITLE
docs: document INFRA_PROVIDER environment variable (fixes #515)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,12 @@ export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 - `ARO_REPO_BRANCH` - Branch to use (default: `ARO-ASO`)
 - `ARO_REPO_DIR` - Local path (default: `/tmp/cluster-api-installer-aro`)
 
+### Infrastructure Provider
+- `INFRA_PROVIDER` - Infrastructure provider to use (values: `aro`, `rosa`; default: `aro`). Selects which CAPI infrastructure provider configuration to load:
+  - `aro` - Azure Red Hat OpenShift via CAPZ/ASO
+  - `rosa` - Red Hat OpenShift on AWS via CAPA
+  - Affects defaults for `MANAGEMENT_CLUSTER_NAME`, `WORKLOAD_CLUSTER_NAME`, `WORKLOAD_CLUSTER_NAMESPACE_PREFIX`, and controller configurations
+
 ### Cluster Configuration
 - `MANAGEMENT_CLUSTER_NAME` - Management cluster name (default: `capz-tests-stage` for ARO, `capa-tests-stage` for ROSA)
   - **Note**: Tests automatically translate this to `KIND_CLUSTER_NAME` for the deployment script

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -164,6 +164,9 @@ See `docs/INTEGRATION.md` for detailed integration patterns.
 - `ARO_REPO_BRANCH` - Branch to use (default: `ARO-ASO`)
 - `ARO_REPO_DIR` - Local path (default: `/tmp/cluster-api-installer-aro`)
 
+### Infrastructure Provider
+- `INFRA_PROVIDER` - Infrastructure provider to use (values: `aro`, `rosa`; default: `aro`)
+
 ### Cluster Configuration
 - `MANAGEMENT_CLUSTER_NAME` - Management cluster name (default: `capz-tests-stage` for ARO, `capa-tests-stage` for ROSA)
   - **Note**: Tests automatically translate this to `KIND_CLUSTER_NAME` for the deployment script

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Tests are configured via environment variables:
 - `ARO_REPO_BRANCH` - Branch to use (default: `main`)
 - `ARO_REPO_DIR` - Local repository directory (default: `/tmp/cluster-api-installer-aro`)
 
+### Infrastructure Provider
+
+- `INFRA_PROVIDER` - Infrastructure provider to use (values: `aro`, `rosa`; default: `aro`)
+
 ### Cluster Configuration
 
 - `MANAGEMENT_CLUSTER_NAME` - Management cluster name (default: `capz-tests-stage` for ARO, `capa-tests-stage` for ROSA)

--- a/test/README.md
+++ b/test/README.md
@@ -80,6 +80,10 @@ Tests are configured via environment variables:
 - `ARO_REPO_BRANCH` - Branch to clone (default: `ARO-ASO`)
 - `ARO_REPO_DIR` - Local repository directory (default: `/tmp/cluster-api-installer-aro`)
 
+### Infrastructure Provider
+
+- `INFRA_PROVIDER` - Infrastructure provider to use (values: `aro`, `rosa`; default: `aro`)
+
 ### Cluster Configuration
 
 - `MANAGEMENT_CLUSTER_NAME` - Management cluster name (default: `capz-tests-stage` for ARO, `capa-tests-stage` for ROSA)


### PR DESCRIPTION
## Description

Document the `INFRA_PROVIDER` environment variable across all documentation files.

Fixes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)