### PR TITLE
fix: copy Azure CLI repo to ART wrapper directory for OpenShift CI (ARO-24304)

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -19,7 +19,9 @@ RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
       'gpgcheck=1' \
       'gpgkey=https://packages.microsoft.com/keys/microsoft.asc' \
       > /etc/yum.repos.d/azure-cli.repo && \
-    cp /etc/yum.repos.d/azure-cli.repo /etc/yum.repos.art/ci/ 2>/dev/null || true && \
+    if [ -d /etc/yum.repos.art/ci ]; then \
+      cp /etc/yum.repos.d/azure-cli.repo /etc/yum.repos.art/ci/; \
+    fi && \
     dnf install -y azure-cli jq && dnf clean all
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Description

Fix Azure CLI installation failure in OpenShift CI caused by ART yum/dnf wrapper.

## Changes Made

- Copy azure-cli.repo to `/etc/yum.repos.art/ci/` (ART wrapper's repo directory) in addition to `/etc/yum.repos.d/`
- Use `2>/dev/null || true` so the copy is a no-op on local builds where the ART directory doesn't exist
- Previous commits on this branch: switch from packages-microsoft-prod RPM to direct yum repo, use printf instead of echo -e

## Configuration Changes

No configuration changes.

## Additional Notes

The ART yum/dnf wrapper in OpenShift CI overrides dnf's repo directory to `/etc/yum.repos.art/ci/`, completely ignoring `/etc/yum.repos.d/`. This means the azure-cli repo file was never read by dnf during CI builds. Verification: push to main, then retrigger rehearsal on openshift/release PR #75733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build process now preserves the package repository configuration to an alternate CI-aware location when present, ensuring the container's package source is available during image creation and improving build compatibility in CI environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->