### PR TITLE
fix: clear GOFLAGS for gotestsum install in OpenShift CI (ARO-24304)

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -47,7 +47,7 @@ RUN curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o 
     rm -rf /tmp/helm.tar.gz /tmp/helm.sha256sum /tmp/linux-amd64
 
 # Install gotestsum for JUnit XML output
-RUN GOBIN=/usr/local/bin go install gotest.tools/gotestsum@${GOTESTSUM_VERSION}
+RUN GOFLAGS='' GOBIN=/usr/local/bin go install gotest.tools/gotestsum@${GOTESTSUM_VERSION}
 
 # Install clusterctl (with checksum verification via hardcoded digest)
 RUN curl -Lo /usr/local/bin/clusterctl "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterctl-linux-amd64" && \


### PR DESCRIPTION
## Description

Fix gotestsum installation failure in OpenShift CI.

## Changes Made

- Add `GOFLAGS=''` to the `go install gotestsum` step in `Dockerfile.prow`
- The base image (`rhel-9-golang-1.24-openshift-4.20`) sets `GOFLAGS=-mod=vendor` globally, which prevents `go install` from fetching external modules (`cannot query module due to -mod=vendor`)
- Clearing `GOFLAGS` for this single step allows the install to proceed without affecting the rest of the build

## Configuration Changes

No configuration changes.

## Additional Notes

Build log from failed rehearsal: `go: gotest.tools/gotestsum@v1.13.0: cannot query module due to -mod=vendor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build consistency by ensuring environment settings do not unexpectedly affect tool installations during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->