### PR TITLE
fix: clear GOFLAGS for gotestsum install in Makefile (ARO-24304)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -598,7 +598,7 @@ check-prereq: ## Check if required tools are installed
 install-gotestsum: ## Install gotestsum for test summaries
 	@echo "Installing gotestsum v1.13.0..."
 	@command -v go >/dev/null 2>&1 || (echo "Error: go is required to install gotestsum. Install Go from https://golang.org/dl/" && exit 1)
-	@go install gotest.tools/gotestsum@v1.13.0
+	@GOFLAGS='' go install gotest.tools/gotestsum@v1.13.0
 	@echo "gotestsum installed successfully to $(GOBIN)/gotestsum"
 	@if ! echo ":$$PATH:" | grep -q ":$(GOBIN):"; then \
 		echo ""; \


### PR DESCRIPTION
## Description

Fix gotestsum installation failure in OpenShift CI when `make test` runs inside the container.

## Changes Made

- Add `GOFLAGS=''` to the `go install gotestsum` command in the `install-gotestsum` Makefile target
- The OpenShift CI base image sets `GOFLAGS=-mod=vendor` globally, which prevents `go install` from fetching external modules
- This is the companion fix to PR #555 which fixed the same issue in `Dockerfile.prow`

## Configuration Changes

No configuration changes.

## Additional Notes

PR #555 fixed `Dockerfile.prow` (image build succeeds), but `make test` inside the container also calls `go install gotestsum` via the `check-gotestsum` target, hitting the same `-mod=vendor` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process reliability to prevent environment flags from interfering with test tool installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->