### PR TITLE
fix: clear GOFLAGS globally in Makefile for OpenShift CI (ARO-24304)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,9 @@ LATEST_RESULTS_DIR := results/latest
 # Terminal output capture file
 TERMINAL_OUTPUT_FILE := terminal-output.log
 
+# Clear GOFLAGS to prevent inheriting -mod=vendor from CI base images (e.g., OpenShift CI)
+export GOFLAGS=
+
 # Determine Go binary installation path
 # Prefer GOBIN if set, otherwise use GOPATH/bin, with fallback to $HOME/go/bin
 GOBIN := $(shell if [ -n "$$(go env GOBIN 2>/dev/null)" ]; then go env GOBIN; else echo "$$(go env GOPATH 2>/dev/null || echo "$$HOME/go")/bin"; fi)
@@ -598,7 +601,7 @@ check-prereq: ## Check if required tools are installed
 install-gotestsum: ## Install gotestsum for test summaries
 	@echo "Installing gotestsum v1.13.0..."
 	@command -v go >/dev/null 2>&1 || (echo "Error: go is required to install gotestsum. Install Go from https://golang.org/dl/" && exit 1)
-	@GOFLAGS='' go install gotest.tools/gotestsum@v1.13.0
+	@go install gotest.tools/gotestsum@v1.13.0
 	@echo "gotestsum installed successfully to $(GOBIN)/gotestsum"
 	@if ! echo ":$$PATH:" | grep -q ":$(GOBIN):"; then \
 		echo ""; \


### PR DESCRIPTION
## Description

Fix `go test` vendor consistency error in OpenShift CI by clearing `GOFLAGS` globally in the Makefile.

## Changes Made

- Add `export GOFLAGS=` at the top of the Makefile to clear any inherited `GOFLAGS` (e.g., `-mod=vendor` from CI base images)
- Revert per-target `GOFLAGS=''` from PR #556 since the global export covers all targets

## Configuration Changes

No configuration changes.

## Additional Notes

The OpenShift CI base image sets `GOFLAGS=-mod=vendor` globally. PR #555 fixed this for `go install` in Dockerfile.prow, PR #556 fixed it for `go install` in the Makefile, but `go test` (invoked by `gotestsum`) also inherited the flag, causing:

```
go: inconsistent vendoring in /go/src/github.com/stolostron/capi-tests:
    gopkg.in/yaml.v3@v3.0.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
```

Clearing `GOFLAGS` globally at the Makefile level is the definitive fix that covers all Go commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build process configuration for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->