### PR TITLE
fix: make Go cache writable for OpenShift CI arbitrary UIDs (ARO-24304)

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -49,6 +49,9 @@ RUN curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o 
 # Install gotestsum for JUnit XML output
 RUN GOFLAGS='' GOBIN=/usr/local/bin go install gotest.tools/gotestsum@${GOTESTSUM_VERSION}
 
+# Ensure Go cache is writable for arbitrary UIDs (OpenShift CI runs as random non-root user)
+RUN mkdir -p /go/.cache && chmod -R 777 /go/.cache
+
 # Install clusterctl (with checksum verification via hardcoded digest)
 RUN curl -Lo /usr/local/bin/clusterctl "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterctl-linux-amd64" && \
     echo "${CLUSTERCTL_SHA256}  /usr/local/bin/clusterctl" | sha256sum -c && \


### PR DESCRIPTION
## Description

Fix Go build cache permission error in OpenShift CI.

## Changes Made

- Add `mkdir -p /go/.cache && chmod -R 777 /go/.cache` in `Dockerfile.prow`
- OpenShift CI runs containers as a random non-root UID, but the Go cache created during Docker build is owned by root and not writable

## Configuration Changes

No configuration changes.

## Additional Notes

Error from CI: `open /go/.cache/71/...-d: permission denied`

This is a standard pattern for OpenShift CI Dockerfiles — directories that need write access at runtime must be made world-writable since the container UID is unpredictable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved Docker build compatibility with CI/CD environments
  * Ensured proper executable permissions for binary tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->