### PR TITLE
fix: make entire /go directory writable for OpenShift CI (ARO-24304)

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -49,8 +49,8 @@ RUN curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o 
 # Install gotestsum for JUnit XML output
 RUN GOFLAGS='' GOBIN=/usr/local/bin go install gotest.tools/gotestsum@${GOTESTSUM_VERSION}
 
-# Ensure Go cache is writable for arbitrary UIDs (OpenShift CI runs as random non-root user)
-RUN mkdir -p /go/.cache && chmod -R 777 /go/.cache
+# Ensure Go directories are writable for arbitrary UIDs (OpenShift CI runs as random non-root user)
+RUN chmod -R 777 /go
 
 # Install clusterctl (with checksum verification via hardcoded digest)
 RUN curl -Lo /usr/local/bin/clusterctl "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterctl-linux-amd64" && \


### PR DESCRIPTION
## Description

Fix Go module cache permission error in OpenShift CI.

## Changes Made

- Replace `chmod -R 777 /go/.cache` with `chmod -R 777 /go` in `Dockerfile.prow`
- PR #558 fixed `/go/.cache`, but `/go/pkg/mod/cache/` also needs write access
- Making the entire `/go` tree writable covers all Go directories at once

## Configuration Changes

No configuration changes.

## Additional Notes

Error from CI: `mkdir /go/pkg/mod/cache/download/gopkg.in: permission denied`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal infrastructure updates with no user-facing changes.

* **Chores**
  * Updated build environment configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->