### PR TITLE
fix: add podman and oc CLI to Dockerfile.prow for CI tests (ARO-24304)

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -9,6 +9,14 @@ ARG CLUSTERCTL_VERSION=v1.12.3
 ARG CLUSTERCTL_SHA256=9b75287b15656a62ece65c8ad7491412cebfd30c78e085a9d61396a50df17349
 ARG GOTESTSUM_VERSION=v1.13.0
 
+# Install podman (docker alternative) and OpenShift CLI
+ARG OC_VERSION=latest
+RUN dnf install -y podman && dnf clean all
+RUN curl -fsSL "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz" -o /tmp/oc.tar.gz && \
+    tar xz -C /usr/local/bin -f /tmp/oc.tar.gz oc && \
+    chmod +x /usr/local/bin/oc && \
+    rm -f /tmp/oc.tar.gz
+
 # Install Azure CLI from Microsoft repo and other tools
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
     printf '%s\n' \


### PR DESCRIPTION
## Description

Add missing tools (`podman`, `oc`) to the CI image so check-dependencies tests pass.

## Changes Made

- Install `podman` via dnf (accepted as docker alternative by the tests)
- Install `oc` CLI from the OpenShift mirror (`openshift-client-linux.tar.gz`)
- Extract only `oc` from the tarball to avoid overwriting the version-pinned `kubectl`

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `OC_VERSION` (build ARG) | OpenShift CLI version to install | `latest` |

## Additional Notes

The check-dependencies tests require `docker` (or `podman`) and `oc`. These were missing from the CI image, causing test failures:
- `TestCheckDependencies_ToolAvailable/docker` - FAIL
- `TestCheckDependencies_ToolAvailable/oc` - FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added podman installation support to the build environment as an alternative to Docker for container operations.
  * Added OpenShift CLI client tooling to the build environment with configurable version selection, enabling OpenShift cluster management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->