### PR TITLE
ci: set TEST_RESULTS_DIR in Prow step for artifact collection

### DIFF
--- a/openshift-ci/step-registry/capz-test-check-dependencies-commands.sh
+++ b/openshift-ci/step-registry/capz-test-check-dependencies-commands.sh
@@ -9,6 +9,8 @@ go install gotest.tools/gotestsum@v1.13.0
 export PATH="${GOBIN:-$(go env GOPATH)/bin}:${PATH}"
 
 # Run Phase 01: Check Dependencies
-# Produces JUnit XML in ${ARTIFACT_DIR} for Prow to collect
-gotestsum --junitfile="${ARTIFACT_DIR}/junit-check-dep.xml" -- \
+# TEST_RESULTS_DIR tells the Go test code to write artifacts (commands.log, etc.) to ARTIFACT_DIR
+# JUnit XML is written directly via --junitfile flag
+# Both are collected by Prow from ARTIFACT_DIR
+TEST_RESULTS_DIR="${ARTIFACT_DIR}" gotestsum --junitfile="${ARTIFACT_DIR}/junit-check-dep.xml" -- \
   -v ./test -count=1 -run TestCheckDependencies


### PR DESCRIPTION
## Description

The Prow check-dependencies step was not collecting test artifacts because `TEST_RESULTS_DIR` was not set. Without it, the Go test code writes artifacts (`commands.log`, etc.) to a local `results/` directory inside the container that Prow never uploads to GCS.

The `artifacts/check-dependencies/capz-test-check-dependencies/` directory in the Prow job was empty despite successful test execution.

## Changes Made

- Set `TEST_RESULTS_DIR="${ARTIFACT_DIR}"` in the Prow step script so the Go test code writes all artifacts directly to the Prow artifact directory

## Configuration Changes

No new environment variables. This uses the existing `TEST_RESULTS_DIR` env var (already supported by `GetResultsDir()` in `test/helpers.go`) and Prow-provided `ARTIFACT_DIR`.

## Additional Notes

Verified against the green Prow run: the `artifacts/check-dependencies/capz-test-check-dependencies/` directory was created but empty. After this change, `commands.log` and other test artifacts will be written there for Prow to collect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test infrastructure configuration to properly align artifact output directories, ensuring test results are collected and stored correctly during validation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->