### PR TITLE
fix: remove overly broad auto-generated filter from coderabbit-review

### DIFF
--- a/.claude/commands/coderabbit-review.md
+++ b/.claude/commands/coderabbit-review.md
@@ -254,8 +254,7 @@ After pushing changes, CodeRabbit automatically triggers a review. Poll until it
      .[] |
      select(
        (.comments.nodes[0].body | test("^## Walkthrough"; "m") | not) and
-       (.comments.nodes[0].body | test("^## Summary"; "m") | not) and
-       (.comments.nodes[0].body | test("auto-generated"; "i") | not)
+       (.comments.nodes[0].body | test("^## Summary"; "m") | not)
      )
    ]')
    ```


### PR DESCRIPTION
## Description

Fix the coderabbit-review command that was silently dropping all CodeRabbit inline findings due to an overly broad filter.

## Changes Made

- Removed the `auto-generated` text filter from Step 4 (Fetch and Filter CodeRabbit Findings)
- Every CodeRabbit inline comment contains `<!-- This is an auto-generated comment by CodeRabbit -->` as an HTML footer, so the filter was matching ALL findings and excluding them as non-actionable
- The `Walkthrough` and `Summary` filters are sufficient to exclude non-actionable threads

### Root Cause

This bug caused PR #564 to initially report "0 findings" when CodeRabbit had posted 3 valid findings (missing timeouts on step registry refs). The same bug affected PR #562 where a valid `.PHONY` typo finding was missed.

## Configuration Changes

No new environment variables.

## Additional Notes

This is the second timing/filtering fix to the coderabbit-review command. The first (PR #563) fixed the polling to wait for CodeRabbit's completed review. This fix addresses the filtering logic that runs after polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)