### PR TITLE
fix: add xmllint to prerequisites check and GHA workflows

### DIFF
--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -87,7 +87,9 @@ jobs:
         cache: true
 
     - name: Install dependencies
-      run: go mod download
+      run: |
+        sudo apt-get update && sudo apt-get install -y libxml2-utils
+        go mod download
 
     - name: Install OpenShift CLI
       run: |

--- a/.github/workflows/workload-cluster-rosa.yml
+++ b/.github/workflows/workload-cluster-rosa.yml
@@ -91,7 +91,9 @@ jobs:
         cache: true
 
     - name: Install dependencies
-      run: go mod download
+      run: |
+        sudo apt-get update && sudo apt-get install -y libxml2-utils
+        go mod download
 
     - name: Install OpenShift CLI
       run: |

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -23,6 +23,7 @@ func TestCheckDependencies_ToolAvailable(t *testing.T) {
 		"git",
 		"kubectl",
 		"go",
+		"xmllint",
 	}
 
 	// Add provider-specific tools (e.g., "az" for ARO, "aws" for ROSA)
@@ -896,6 +897,10 @@ func getToolInstallInstructions(tool string) string {
 			"  macOS: brew install go\n" +
 			"  Linux: Download from https://go.dev/dl/ and extract to /usr/local\n" +
 			"  All: https://go.dev/doc/install",
+		"xmllint": "Install xmllint (used by generate-summary.sh for JUnit XML parsing):\n" +
+			"  macOS: Pre-installed (part of libxml2)\n" +
+			"  Debian/Ubuntu: sudo apt-get install libxml2-utils\n" +
+			"  Fedora/RHEL: sudo dnf install libxml2",
 		"aws": "Install AWS CLI:\n" +
 			"  macOS: brew install awscli\n" +
 			"  Linux: curl \"https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip\" -o \"awscliv2.zip\" && unzip awscliv2.zip && sudo ./aws/install\n" +


### PR DESCRIPTION
## Description

Add `xmllint` to prerequisites check (phase 01) and install `libxml2-utils` in GHA workflows that run `make test-all`.

The `generate-summary.sh` script requires `xmllint` to parse JUnit XML results, but it was not checked during prerequisites. When missing, all tests pass but `make test-all` fails at summary generation, causing false CI failures (seen in https://github.com/stolostron/capi-tests/actions/runs/22798133065).

Fixes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added verification for xmllint as a required dependency, with installation guidance for Debian/Ubuntu, Fedora/RHEL, and macOS.

* **Chores**
  * Updated build workflows to automatically install required system dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->