### PR TITLE
fix: install libxml2-utils in management cluster GHA workflows

### DIFF
--- a/.github/workflows/management-cluster-aro.yml
+++ b/.github/workflows/management-cluster-aro.yml
@@ -55,7 +55,9 @@ jobs:
         cache: true
 
     - name: Install dependencies
-      run: go mod download
+      run: |
+        sudo apt-get update && sudo apt-get install -y libxml2-utils
+        go mod download
 
     - name: Install OpenShift CLI
       run: |

--- a/.github/workflows/management-cluster-rosa.yml
+++ b/.github/workflows/management-cluster-rosa.yml
@@ -53,7 +53,9 @@ jobs:
         cache: true
 
     - name: Install dependencies
-      run: go mod download
+      run: |
+        sudo apt-get update && sudo apt-get install -y libxml2-utils
+        go mod download
 
     - name: Install OpenShift CLI
       run: |


### PR DESCRIPTION
## Description

Install `libxml2-utils` (provides `xmllint`) in the management cluster GHA workflows.

PR #567 added `xmllint` as a prerequisite and installed `libxml2-utils` in the workload cluster workflows, but missed the management cluster workflows. Without this, `make test-all` fails at summary generation in management cluster CI runs.

Follow-up to #567.

## Changes Made

- Install `libxml2-utils` in `management-cluster-aro.yml`
- Install `libxml2-utils` in `management-cluster-rosa.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configurations to include system package installations prior to dependency resolution, improving build environment preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->