### PR TITLE
feat: copy generated YAMLs to results directory for visibility (ARO-25086)

### DIFF
--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -93,6 +93,11 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 					PrintToTTY("  rm -rf %s\n\n", outputDir)
 					t.Logf("Infrastructure already generated at %s, skipping", outputDir)
 					infrastructureGenerationSucceeded = true
+					if err := WriteDeploymentState(config); err != nil {
+						t.Logf("Warning: failed to write deployment state: %v", err)
+					} else {
+						t.Logf("Deployment state saved (namespace: %s)", config.WorkloadClusterNamespace)
+					}
 					copyYAMLsToResultsDir(t, outputDir, expectedFiles)
 					return
 				}


### PR DESCRIPTION
## Description

After YAML generation completes (phase 04), copy `credentials.yaml` and `aro.yaml` to the results directory so they are visible alongside other test artifacts like controller logs and test summaries.

Previously, generated YAMLs were only available in the cluster-api-installer output directory (e.g., `/tmp/cluster-api-installer-aro/rcapd-stage/`), which is outside the test results tree.

JIRA: https://issues.redhat.com/browse/ARO-25086

## Changes Made

- Add `copyYAMLsToResultsDir` helper that copies expected YAML files to the results directory
- Call it from both the generation success path and the idempotent skip path
- Also copies to `results/latest` if it exists (matching the pattern from phase 06 controller log saving)

## Configuration Changes

No new environment variables.

## Additional Notes

Follows the same results directory pattern used by `TestVerification_ControllerLogSummary` in phase 06.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test tooling to collect generated YAML artifacts into centralized test results and optionally mirror them to a "latest" results location. Only expected files are collected; missing files are skipped and I/O issues are logged. Added automatic redaction of sensitive fields in YAML content before publishing. Artifacts are captured both when generation completes and when generation is skipped due to idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->