### PR TITLE
fix(ci): add diagnostics on controller timeout

### DIFF
--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -613,15 +613,15 @@ func TestKindCluster_CAPIControllerReady(t *testing.T) {
 
 			// Dump diagnostic info to help identify the root cause
 			PrintToTTY("=== Diagnostic: pod status in %s ===\n", config.CAPINamespace)
-			if podOutput, podErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, "get", "pods", "-o", "wide"); podErr == nil {
+			if podOutput, podErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, "--request-timeout=30s", "get", "pods", "-o", "wide"); podErr == nil {
 				PrintToTTY("%s\n", podOutput)
 			}
 			PrintToTTY("=== Diagnostic: pod descriptions in %s ===\n", config.CAPINamespace)
-			if descOutput, descErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, "describe", "pods"); descErr == nil {
+			if descOutput, descErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, "--request-timeout=30s", "describe", "pods"); descErr == nil {
 				PrintToTTY("%s\n", descOutput)
 			}
 			PrintToTTY("=== Diagnostic: events in %s ===\n", config.CAPINamespace)
-			if evtOutput, evtErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, "get", "events", "--sort-by=.lastTimestamp"); evtErr == nil {
+			if evtOutput, evtErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, "--request-timeout=30s", "get", "events", "--sort-by=.lastTimestamp"); evtErr == nil {
 				PrintToTTY("%s\n", evtOutput)
 			}
 
@@ -713,15 +713,15 @@ func TestKindCluster_InfraControllersReady(t *testing.T) {
 
 						// Dump diagnostic info to help identify the root cause
 						PrintToTTY("=== Diagnostic: pod status in %s ===\n", ctrl.Namespace)
-						if podOutput, podErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, "get", "pods", "-o", "wide"); podErr == nil {
+						if podOutput, podErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, "--request-timeout=30s", "get", "pods", "-o", "wide"); podErr == nil {
 							PrintToTTY("%s\n", podOutput)
 						}
 						PrintToTTY("=== Diagnostic: pod descriptions in %s ===\n", ctrl.Namespace)
-						if descOutput, descErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, "describe", "pods"); descErr == nil {
+						if descOutput, descErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, "--request-timeout=30s", "describe", "pods"); descErr == nil {
 							PrintToTTY("%s\n", descOutput)
 						}
 						PrintToTTY("=== Diagnostic: events in %s ===\n", ctrl.Namespace)
-						if evtOutput, evtErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, "get", "events", "--sort-by=.lastTimestamp"); evtErr == nil {
+						if evtOutput, evtErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, "--request-timeout=30s", "get", "events", "--sort-by=.lastTimestamp"); evtErr == nil {
 							PrintToTTY("%s\n", evtOutput)
 						}
 


### PR DESCRIPTION
## Description

Add diagnostic output (kubectl describe pods, get events) on controller timeout
to help identify root causes in CI runs.

Cherry-picked from the `configure-prow` branch (commit 80eea1a).

## Changes Made

- Add `kubectl get pods -o wide`, `kubectl describe pods`, and `kubectl get events` diagnostics to CAPI controller timeout block
- Add the same diagnostics to infrastructure controller timeout block
- Replace manual troubleshooting steps with live diagnostic output

## Configuration Changes

No configuration changes.

## Additional Notes

When a controller times out, the diagnostic info is now printed directly in the test output instead of suggesting manual commands to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved diagnostic output for timeout-related test failures, now including detailed pod status and event logs to enhance troubleshooting and error identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->