### PR TITLE
ci: enable automated triggers for GHA deployment workflows

### DIFF
--- a/.github/workflows/management-cluster-aro.yml
+++ b/.github/workflows/management-cluster-aro.yml
@@ -4,13 +4,34 @@ name: Management Cluster (ARO)
 # This workflow deploys a Kind cluster with CAPI/CAPZ/ASO controllers and validates setup.
 # Does NOT provision ARO HCP workload clusters.
 #
-# Manual-only trigger. Requires:
+# Triggers:
+#   - Pull requests (pre-merge validation)
+#   - Push to main (post-merge validation)
+#   - Manual dispatch
+#
+# Requires:
 #   - Repository secret: QUAY_AUTH
 #
 # Compare with cluster-aro.yml:
 #   - management-cluster-aro.yml (this file): Quick validation, Kind + controllers only
 #   - cluster-aro.yml: Full deployment including ARO HCP workload cluster provisioning
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'test/**'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/management-cluster-aro.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'test/**'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/management-cluster-aro.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/management-cluster-rosa.yml
+++ b/.github/workflows/management-cluster-rosa.yml
@@ -4,13 +4,34 @@ name: Management Cluster (ROSA)
 # This workflow deploys a Kind cluster with CAPI/CAPA controllers and validates setup.
 # Does NOT provision ROSA workload clusters.
 #
-# Manual-only trigger. Requires:
+# Triggers:
+#   - Pull requests (pre-merge validation)
+#   - Push to main (post-merge validation)
+#   - Manual dispatch
+#
+# Requires:
 #   - Repository secret: QUAY_AUTH
 #
 # Compare with cluster-rosa.yml:
 #   - management-cluster-rosa.yml (this file): Quick validation, Kind + controllers only
 #   - cluster-rosa.yml: Full deployment including ROSA workload cluster provisioning
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'test/**'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/management-cluster-rosa.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'test/**'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/management-cluster-rosa.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -3,7 +3,11 @@ name: Full Cluster Deployment (ARO)
 # Full end-to-end cluster deployment workflow (management cluster + workload cluster).
 # This workflow deploys a Kind management cluster and provisions an ARO HCP workload cluster.
 #
-# Manual-only trigger. Requires:
+# Triggers:
+#   - Nightly at 2:00 AM UTC (only when code changed since last successful run)
+#   - Manual dispatch
+#
+# Requires:
 #   - Environment (aro-stage) with:
 #     - Variables: AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, REGION, DEPLOYMENT_ENV
 #     - Secret: AZURE_CLIENT_SECRET
@@ -13,6 +17,8 @@ name: Full Cluster Deployment (ARO)
 #   - management-cluster-aro.yml: Quick validation, Kind + controllers only (no workload cluster)
 #   - cluster-aro.yml (this file): Full deployment including workload cluster provisioning
 on:
+  schedule:
+    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       environment:
@@ -40,11 +46,50 @@ env:
   CAPI_USER: mv2
 
 jobs:
+  check-changes:
+    name: Check for code changes
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || true
+    outputs:
+      has_changes: ${{ github.event_name != 'schedule' || steps.check.outputs.has_changes == 'true' }}
+    steps:
+    - name: Check for changes since last successful run
+      id: check
+      if: github.event_name == 'schedule'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        WORKFLOW_FILE: workload-cluster-aro.yml
+        REPO: ${{ github.repository }}
+      run: |
+        LAST_SUCCESS_SHA=$(gh run list \
+          --workflow "$WORKFLOW_FILE" \
+          --repo "$REPO" \
+          --status success \
+          --json headSha \
+          --jq '.[0].headSha // empty' 2>/dev/null || true)
+
+        if [ -z "$LAST_SUCCESS_SHA" ]; then
+          echo "No previous successful run found — running workflow"
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        CURRENT_SHA="${{ github.sha }}"
+        if [ "$LAST_SUCCESS_SHA" = "$CURRENT_SHA" ]; then
+          echo "No new commits since last successful run ($LAST_SUCCESS_SHA)"
+          echo "has_changes=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "New commits detected: $LAST_SUCCESS_SHA..$CURRENT_SHA"
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+        fi
+
   management-cluster:
     name: Full Cluster (ARO/CAPZ)
+    needs: check-changes
+    if: needs.check-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 240  # 2x TEST_TIMEOUT_MINUTES (120m * 2)
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.environment || 'aro-stage' }}
     env:
       # Environment-specific Azure credentials and config
       AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}

--- a/.github/workflows/workload-cluster-rosa.yml
+++ b/.github/workflows/workload-cluster-rosa.yml
@@ -3,7 +3,11 @@ name: Full Cluster Deployment (ROSA)
 # Full end-to-end cluster deployment workflow (management cluster + workload cluster).
 # This workflow deploys a Kind management cluster and provisions a ROSA workload cluster.
 #
-# Manual-only trigger. Requires:
+# Triggers:
+#   - Nightly at 2:00 AM UTC (only when code changed since last successful run)
+#   - Manual dispatch
+#
+# Requires:
 #   - Environment (rosa-stage) with:
 #     - Variables: AWS_REGION, OCM_API_URL, OCM_CLIENT_ID
 #     - Secrets: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, OCM_CLIENT_SECRET
@@ -13,6 +17,8 @@ name: Full Cluster Deployment (ROSA)
 #   - management-cluster-rosa.yml: Quick validation, Kind + controllers only (no workload cluster)
 #   - cluster-rosa.yml (this file): Full deployment including workload cluster provisioning
 on:
+  schedule:
+    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       environment:
@@ -39,11 +45,50 @@ env:
   CAPI_USER: mv2
 
 jobs:
+  check-changes:
+    name: Check for code changes
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || true
+    outputs:
+      has_changes: ${{ github.event_name != 'schedule' || steps.check.outputs.has_changes == 'true' }}
+    steps:
+    - name: Check for changes since last successful run
+      id: check
+      if: github.event_name == 'schedule'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        WORKFLOW_FILE: workload-cluster-rosa.yml
+        REPO: ${{ github.repository }}
+      run: |
+        LAST_SUCCESS_SHA=$(gh run list \
+          --workflow "$WORKFLOW_FILE" \
+          --repo "$REPO" \
+          --status success \
+          --json headSha \
+          --jq '.[0].headSha // empty' 2>/dev/null || true)
+
+        if [ -z "$LAST_SUCCESS_SHA" ]; then
+          echo "No previous successful run found — running workflow"
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        CURRENT_SHA="${{ github.sha }}"
+        if [ "$LAST_SUCCESS_SHA" = "$CURRENT_SHA" ]; then
+          echo "No new commits since last successful run ($LAST_SUCCESS_SHA)"
+          echo "has_changes=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "New commits detected: $LAST_SUCCESS_SHA..$CURRENT_SHA"
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+        fi
+
   management-cluster:
     name: Full Cluster (ROSA/CAPA)
+    needs: check-changes
+    if: needs.check-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 240  # 2x TEST_TIMEOUT_MINUTES (120m * 2)
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.environment || 'rosa-stage' }}
     env:
       # Environment-specific AWS credentials and config
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Description

Enable automated triggers for GHA deployment workflows: management cluster workflows run on PRs and push to main, workload cluster workflows run nightly at 2 AM UTC with change detection.

## Changes Made

- Add `pull_request` and `push` triggers (with path filters) to management-cluster-aro.yml and management-cluster-rosa.yml
- Add `schedule` trigger (cron `0 2 * * *`) to workload-cluster-aro.yml and workload-cluster-rosa.yml
- Add `check-changes` job to workload cluster workflows that skips nightly runs when no code changed since last successful run
- Default `environment` input for scheduled runs (no `inputs` available on schedule trigger)

## Configuration Changes

No new environment variables.

## Additional Notes

- Path filters on management cluster PRs: `test/**`, `Makefile`, `go.mod`, `go.sum`, and the workflow file itself
- Change detection uses `gh run list` to compare HEAD against last successful run SHA
- Manual dispatch (`workflow_dispatch`) is preserved on all workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Management cluster workflows now trigger automatically on pull requests and pushes to main branch with targeted path filters for test files, Makefile, and dependencies
- Workload cluster workflows now include scheduled nightly execution at 2:00 AM UTC alongside manual triggers
- Introduced change detection logic to control workflow execution based on detected code modifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->