### PR TITLE
fix(ci): ensure labels exist before creating GitHub issues on failure

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -91,6 +91,10 @@ jobs:
           echo "---" >> issue_body.md
           echo "*This issue was automatically created by the CI workflow*" >> issue_body.md
 
+          # Ensure labels exist (gh issue create fails if label is missing)
+          gh label create "automated" --force 2>/dev/null || true
+          gh label create "test-failure" --color "d93f0b" --force 2>/dev/null || true
+
           # Create the issue
           gh issue create \
             --title "[$WORKFLOW_NAME] Workflow failed on ${{ github.ref_name }}" \

--- a/.github/workflows/management-cluster-aro.yml
+++ b/.github/workflows/management-cluster-aro.yml
@@ -311,6 +311,10 @@ jobs:
           echo "---" >> issue_body.md
           echo "*This issue was automatically created by the CI workflow*" >> issue_body.md
 
+          # Ensure labels exist (gh issue create fails if label is missing)
+          gh label create "automated" --force 2>/dev/null || true
+          gh label create "test-failure" --color "d93f0b" --force 2>/dev/null || true
+
           gh issue create \
             --title "[$WORKFLOW_NAME] Workflow failed on $REF_NAME" \
             --body-file issue_body.md \

--- a/.github/workflows/management-cluster-rosa.yml
+++ b/.github/workflows/management-cluster-rosa.yml
@@ -311,6 +311,10 @@ jobs:
           echo "---" >> issue_body.md
           echo "*This issue was automatically created by the CI workflow*" >> issue_body.md
 
+          # Ensure labels exist (gh issue create fails if label is missing)
+          gh label create "automated" --force 2>/dev/null || true
+          gh label create "test-failure" --color "d93f0b" --force 2>/dev/null || true
+
           gh issue create \
             --title "[$WORKFLOW_NAME] Workflow failed on $REF_NAME" \
             --body-file issue_body.md \

--- a/.github/workflows/test-setup.yml
+++ b/.github/workflows/test-setup.yml
@@ -79,6 +79,10 @@ jobs:
           echo "---" >> issue_body.md
           echo "*This issue was automatically created by the CI workflow*" >> issue_body.md
 
+          # Ensure labels exist (gh issue create fails if label is missing)
+          gh label create "automated" --force 2>/dev/null || true
+          gh label create "test-failure" --color "d93f0b" --force 2>/dev/null || true
+
           # Create the issue
           gh issue create \
             --title "[$WORKFLOW_NAME] Workflow failed on ${{ github.ref_name }}" \

--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -343,6 +343,10 @@ jobs:
           echo "---" >> issue_body.md
           echo "*This issue was automatically created by the CI workflow*" >> issue_body.md
 
+          # Ensure labels exist (gh issue create fails if label is missing)
+          gh label create "automated" --force 2>/dev/null || true
+          gh label create "test-failure" --color "d93f0b" --force 2>/dev/null || true
+
           gh issue create \
             --title "[$WORKFLOW_NAME] Workflow failed on $REF_NAME" \
             --body-file issue_body.md \

--- a/.github/workflows/workload-cluster-rosa.yml
+++ b/.github/workflows/workload-cluster-rosa.yml
@@ -343,6 +343,10 @@ jobs:
           echo "---" >> issue_body.md
           echo "*This issue was automatically created by the CI workflow*" >> issue_body.md
 
+          # Ensure labels exist (gh issue create fails if label is missing)
+          gh label create "automated" --force 2>/dev/null || true
+          gh label create "test-failure" --color "d93f0b" --force 2>/dev/null || true
+
           gh issue create \
             --title "[$WORKFLOW_NAME] Workflow failed on $REF_NAME" \
             --body-file issue_body.md \


### PR DESCRIPTION
## Description

Fix the "Create GitHub issue on failure" step that was silently failing across all 6 CI workflows because the `test-failure` label did not exist in the repository.

## Changes Made

- Add `gh label create --force` calls before `gh issue create` in all 6 workflow files (check-dependencies, test-setup, management-cluster-aro/rosa, workload-cluster-aro/rosa)
- Created the missing `test-failure` label in the repository

## Configuration Changes

No new environment variables.

## Additional Notes

**Root cause**: `gh issue create --label "test-failure"` fails if the label doesn't exist — unlike the GitHub web UI which auto-creates labels. The `automated` label existed but `test-failure` did not, causing the issue creation step to fail (confirmed in runs [#22798133065](https://github.com/stolostron/capi-tests/actions/runs/22798133065) and [#22903576697](https://github.com/stolostron/capi-tests/actions/runs/22903576697)).

**Fix approach**: `gh label create --force` is idempotent — it creates the label if missing or silently succeeds if it already exists. This makes the workflows self-healing regardless of label state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automation workflows to ensure required labels are available during issue creation, preventing potential failures due to missing labels across multiple workflow configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->