### PR TITLE
fix(ci): align Go test timeout with deployment timeout

### DIFF
--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -217,6 +217,8 @@ jobs:
       # Azure credentials and config are set at job level (see env: above)
       env:
         DEPLOYMENT_TIMEOUT: "${{ env.TEST_TIMEOUT_MINUTES }}m"
+        DEPLOY_CRS_TIMEOUT: "${{ env.TEST_TIMEOUT_MINUTES }}m"
+        DELETION_TIMEOUT: "${{ env.TEST_TIMEOUT_MINUTES }}m"
       run: make test-all
       continue-on-error: true
       id: phase3

--- a/.github/workflows/workload-cluster-rosa.yml
+++ b/.github/workflows/workload-cluster-rosa.yml
@@ -217,6 +217,8 @@ jobs:
       # AWS credentials and config are set at job level (see env: above)
       env:
         DEPLOYMENT_TIMEOUT: "${{ env.TEST_TIMEOUT_MINUTES }}m"
+        DEPLOY_CRS_TIMEOUT: "${{ env.TEST_TIMEOUT_MINUTES }}m"
+        DELETION_TIMEOUT: "${{ env.TEST_TIMEOUT_MINUTES }}m"
       run: make test-all
       continue-on-error: true
       id: phase3


### PR DESCRIPTION
The GHA failure still could be a real failure imho.


## Description

Fix Go test binary timeout killing deployment tests before `DEPLOYMENT_TIMEOUT` is reached.

Both ARO and ROSA full cluster workflows failed because the Go `-timeout` flag
(`DEPLOY_CRS_TIMEOUT=60m` Makefile default) was shorter than the deployment
timeout (`DEPLOYMENT_TIMEOUT=120m` set in workflows). The test process was
killed at 60m while clusters were still provisioning (~49% progress).

## Changes Made

- Set `DEPLOY_CRS_TIMEOUT` and `DELETION_TIMEOUT` env vars in both workflow files to match `TEST_TIMEOUT_MINUTES` (120m)
- These override the Makefile defaults (60m) via `?=` precedence

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `DEPLOY_CRS_TIMEOUT` | Go test binary timeout for deploy CRs phase | `60m` (Makefile), now `120m` in workflows |
| `DELETION_TIMEOUT` | Go test binary timeout for deletion phase | `60m` (Makefile), now `120m` in workflows |

## Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended timeout configuration for test execution across Azure Red Hat OpenShift and Red Hat OpenShift Service on AWS deployment workflows to improve test reliability and reduce timeout-related failures during cluster testing phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->