### PR TITLE
Fix Bad substitution error in test-all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: test _check-dep _setup _management_cluster _generate-yamls _deploy-crs _verify-workload-cluster _delete-workload-cluster _validate-cleanup test-all _test-all-impl clean clean-all clean-azure help summary
 
+# Use bash for shell commands (required for PIPESTATUS in test-all target)
+SHELL := /bin/bash
+
 # Default values
 # Extract CAPI_USER default from Go config to maintain single source of truth
 CAPI_USER_DEFAULT := $(shell grep 'DefaultCAPIUser = ' test/config.go | grep -o '"[^"]*"' | tr -d '"')


### PR DESCRIPTION
This fixes false failures of Full Cluster Deployment GHA.


## Summary
- The `test-all` Makefile target uses `${PIPESTATUS[0]}` (a bash-only feature), but GNU Make defaults to `/bin/sh` which is `dash` on Ubuntu GitHub Actions runners
- This caused `make test-all` to exit with code 2 (`/bin/sh: 7: Bad substitution`) even when **all tests passed**
- Fix: add `SHELL := /bin/bash` to the Makefile

## Root cause
The `management-cluster-aro.yml` workflow was unaffected because it calls individual Make targets (`_check-dep`, `_setup`, `_management_cluster`) that don't use `PIPESTATUS`. Only the `workload-cluster-aro.yml` workflow (`Full Cluster Deployment`) calls `make test-all` and hits this issue.

Fixes #603

## Test plan
- [ ] Re-run the `Full Cluster Deployment (ARO)` workflow and verify it no longer fails with "Bad substitution"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system shell configuration for improved command execution consistency in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->