### PR TITLE
chore(ci): fix branch metadata in local ci-operator config

### DIFF
--- a/openshift-ci/ci-operator-config.yaml
+++ b/openshift-ci/ci-operator-config.yaml
@@ -37,6 +37,6 @@ tests:
     workflow: openshift-e2e-azure
   timeout: 4h0m0s
 zz_generated_metadata:
-  branch: configure-prow
+  branch: configure-prow-mgmt
   org: stolostron
   repo: capi-tests


### PR DESCRIPTION
## Description

Fix `zz_generated_metadata.branch` in local ci-operator config reference from `configure-prow` to `configure-prow-mgmt`.

## Changes Made

- Fixed branch metadata to match the actual branch name (`configure-prow-mgmt`)

## Configuration Changes

N/A

## Additional Notes

Trivial change to trigger the presubmit job after openshift/release#76592 was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)