### PR TITLE
feat: add /review-open-prs command for interactive PR review

### DIFF
--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -223,7 +223,7 @@ PRs skipped (draft): #<numbers>
 - **User approval required**: Never post review comments without explicit user approval for each finding.
 - **Skip auto/* branches**: Exclude PRs from branches starting with `auto/` (automated PRs).
 - **Skip self-authored PRs**: Exclude PRs authored by the current GitHub user (determined via `gh api user --jq '.login'`). Posting automated review comments on your own PRs is confusing.
-- **Skip duplicates**: Check existing review comments (Step 3) and skip findings that overlap with already-posted comments.
+- **Skip duplicates**: Check existing review comments (Step 3) and skip findings that target the same file path and line number (within ±3 lines) as an already-posted comment. When in doubt, skip — duplicate comments are worse than missing one.
 - **Rate limiting**: If there are more than 10 open PRs, process the 10 most recently updated first.
 - **Suggestion accuracy**: The `line` number in the review comment must reference the line in the PR diff (the new file version), not the old file. Use `side: "RIGHT"` always.
 - **Minimal fixes**: Suggestion blocks should change only the lines needed. Do not reformat or refactor surrounding code.

--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -232,3 +232,4 @@ PRs skipped (draft): #<numbers>
 - **Suggestion accuracy**: The `line` number in the review comment must reference the line in the PR diff (the new file version), not the old file. Use `side: "RIGHT"` always.
 - **Minimal fixes**: Suggestion blocks should change only the lines needed. Do not reformat or refactor surrounding code.
 - **One review per PR**: Submit all approved findings for a PR as a single batch review, not individual comments.
+- **API pacing**: When posting reviews to multiple PRs, wait 2-3 seconds between API calls to avoid triggering GitHub's secondary rate limits.

--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -51,7 +51,7 @@ Print a short overview table (this is the only "report" output — keep it brief
 |---|-------|----|-----------|------|
 | <number> | <title> | pass/fail | yes/no | +N/-N |
 
-Draft PRs: #<numbers> (skipped from review)
+Skipped: #<numbers> (draft), #<numbers> (auto/* branch), #<numbers> (self-authored)
 ```
 
 ## Phase 2: Analyze Each PR

--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -63,7 +63,7 @@ gh api repos/$OWNER/$REPO/pulls/<number>/comments \
 
 ### Step 4: Run code review
 
-Use the `pr-review-toolkit:code-reviewer` agent (via the Agent tool with `subagent_type: "pr-review-toolkit:code-reviewer"`).
+Use the Agent tool to launch the `pr-review-toolkit:code-reviewer` agent (with `subagent_type: "pr-review-toolkit:code-reviewer"`).
 
 Pass the PR number, full diff, and repository context. Instruct the agent to return findings in this structured format:
 

--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -80,15 +80,16 @@ For each finding, collect:
 - **line**: the line number in the **new version** of the file where the comment should appear
 - **severity**: critical / important / minor
 - **reasoning**: 2-4 sentences explaining the problem
-- **suggestion**: the exact replacement code (for the GitHub suggestion block)
 - **start_line** (optional): if the suggestion spans multiple lines, the starting line number
+
+The agent identifies problems but does **not** generate fixes — that happens in Step 5.
 
 ### Step 5: Generate fix for each finding
 
-For each finding from the code review:
+For each finding from Step 4:
 
 1. Read the relevant file section to understand full context
-2. Write the concrete fix (the replacement code for the suggestion block)
+2. Write the concrete fix (the exact replacement code for the GitHub suggestion block)
 3. Ensure the fix is minimal and correct — change only what's needed
 4. If a finding cannot be fixed mechanically (needs design decisions), mark it as `manual_only: true`
 

--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -25,8 +25,10 @@ Use `$OWNER/$REPO` in all subsequent `gh` and `gh api` commands.
 ```bash
 gh pr list --repo $OWNER/$REPO --state open \
   --json number,title,author,createdAt,updatedAt,isDraft,headRefName,baseRefName,mergeable,reviewDecision,statusCheckRollup,labels,additions,deletions,changedFiles \
-  --jq '.'
+  --jq 'sort_by(.updatedAt) | reverse | .[:10]'
 ```
+
+This fetches the 10 most recently updated PRs. If fewer than 10 are open, all are returned.
 
 If there are no open PRs, print "No open pull requests found." and stop.
 

--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -31,7 +31,7 @@ Use `$OWNER/$REPO` in all subsequent `gh` and `gh api` commands.
 ### Step 1: Fetch all open PRs
 
 ```bash
-gh pr list --repo $OWNER/$REPO --state open \
+gh pr list --repo "$OWNER/$REPO" --state open \
   --json number,title,author,createdAt,updatedAt,isDraft,headRefName,baseRefName,mergeable,reviewDecision,statusCheckRollup,labels,additions,deletions,changedFiles \
   --jq 'sort_by(.updatedAt) | reverse | .[:10]'
 ```
@@ -62,10 +62,10 @@ For each **non-draft** open PR (skip draft PRs, skip branches starting with `aut
 
 ```bash
 # Get the diff
-gh pr diff <number> --repo $OWNER/$REPO
+gh pr diff <number> --repo "$OWNER/$REPO"
 
 # Get the head commit SHA (used later in the review payload)
-COMMIT_SHA=$(gh pr view <number> --repo $OWNER/$REPO --json headRefOid --jq '.headRefOid')
+COMMIT_SHA=$(gh pr view <number> --repo "$OWNER/$REPO" --json headRefOid --jq '.headRefOid')
 
 # Check existing review comments to avoid duplicates
 gh api repos/$OWNER/$REPO/pulls/<number>/comments \

--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -8,12 +8,22 @@ Review all open PRs in the repository. For each PR: analyze the code, generate f
 present them to the user for approval, and post approved findings as inline GitHub review comments
 with suggestion blocks.
 
+## Step 0: Determine repository context
+
+```bash
+REPO_INFO=$(gh repo view --json owner,name)
+OWNER=$(echo "$REPO_INFO" | jq -r '.owner.login')
+REPO=$(echo "$REPO_INFO" | jq -r '.name')
+```
+
+Use `$OWNER/$REPO` in all subsequent `gh` and `gh api` commands.
+
 ## Phase 1: Discover and Summarize
 
 ### Step 1: Fetch all open PRs
 
 ```bash
-gh pr list --repo stolostron/capi-tests --state open \
+gh pr list --repo $OWNER/$REPO --state open \
   --json number,title,author,createdAt,updatedAt,isDraft,headRefName,baseRefName,mergeable,reviewDecision,statusCheckRollup,labels,additions,deletions,changedFiles \
   --jq '.'
 ```
@@ -42,10 +52,10 @@ For each **non-draft** open PR (skip draft PRs, skip branches starting with `aut
 
 ```bash
 # Get the diff
-gh pr diff <number> --repo stolostron/capi-tests
+gh pr diff <number> --repo $OWNER/$REPO
 
 # Check existing review comments to avoid duplicates
-gh api repos/stolostron/capi-tests/pulls/<number>/comments \
+gh api repos/$OWNER/$REPO/pulls/<number>/comments \
   --jq '[.[] | {path: .path, line: .line, body: .body}]'
 ```
 
@@ -178,7 +188,7 @@ REVIEW_FILE=$(mktemp)
 cat > "$REVIEW_FILE" << 'REVIEW_JSON'
 <json content>
 REVIEW_JSON
-gh api repos/stolostron/capi-tests/pulls/<number>/reviews \
+gh api repos/$OWNER/$REPO/pulls/<number>/reviews \
   --method POST --input "$REVIEW_FILE"
 rm -f "$REVIEW_FILE"
 ```

--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -56,7 +56,7 @@ Draft PRs: #<numbers> (skipped from review)
 
 ## Phase 2: Analyze Each PR
 
-For each **non-draft** open PR (skip draft PRs, skip branches starting with `auto/`):
+For each **non-draft** open PR (skip draft PRs, skip branches starting with `auto/`, skip PRs authored by the current user):
 
 ### Step 3: Fetch diff and existing reviews
 
@@ -222,6 +222,7 @@ PRs skipped (draft): #<numbers>
 - **Local analysis, remote output**: All code analysis happens locally. GitHub is only used to fetch diffs and post reviews.
 - **User approval required**: Never post review comments without explicit user approval for each finding.
 - **Skip auto/* branches**: Exclude PRs from branches starting with `auto/` (automated PRs).
+- **Skip self-authored PRs**: Exclude PRs authored by the current GitHub user (determined via `gh api user --jq '.login'`). Posting automated review comments on your own PRs is confusing.
 - **Skip duplicates**: Check existing review comments (Step 3) and skip findings that overlap with already-posted comments.
 - **Rate limiting**: If there are more than 10 open PRs, process the 10 most recently updated first.
 - **Suggestion accuracy**: The `line` number in the review comment must reference the line in the PR diff (the new file version), not the old file. Use `side: "RIGHT"` always.

--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -64,6 +64,9 @@ For each **non-draft** open PR (skip draft PRs, skip branches starting with `aut
 # Get the diff
 gh pr diff <number> --repo $OWNER/$REPO
 
+# Get the head commit SHA (used later in the review payload)
+COMMIT_SHA=$(gh pr view <number> --repo $OWNER/$REPO --json headRefOid --jq '.headRefOid')
+
 # Check existing review comments to avoid duplicates
 gh api repos/$OWNER/$REPO/pulls/<number>/comments \
   --jq '[.[] | {path: .path, line: .line, body: .body}]'
@@ -155,6 +158,7 @@ The JSON body for the review:
 
 ```json
 {
+  "commit_id": "<COMMIT_SHA from Step 3>",
   "event": "COMMENT",
   "body": "Automated code review — <N> suggestions. Apply individually or batch-apply in the Files changed tab.",
   "comments": [

--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -228,7 +228,7 @@ PRs skipped (draft): #<numbers>
 - **Skip auto/* branches**: Exclude PRs from branches starting with `auto/` (automated PRs).
 - **Skip self-authored PRs**: Exclude PRs authored by the current GitHub user (determined via `gh api user --jq '.login'`). Posting automated review comments on your own PRs is confusing.
 - **Skip duplicates**: Check existing review comments (Step 3) and skip findings that target the same file path and line number (within ±3 lines) as an already-posted comment. When in doubt, skip — duplicate comments are worse than missing one.
-- **Rate limiting**: If there are more than 10 open PRs, process the 10 most recently updated first.
+- **Batch size**: Process at most 10 PRs per invocation (the 10 most recently updated). This is a scope cap, not API rate limiting.
 - **Suggestion accuracy**: The `line` number in the review comment must reference the line in the PR diff (the new file version), not the old file. Use `side: "RIGHT"` always.
 - **Minimal fixes**: Suggestion blocks should change only the lines needed. Do not reformat or refactor surrounding code.
 - **One review per PR**: Submit all approved findings for a PR as a single batch review, not individual comments.

--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -8,6 +8,14 @@ Review all open PRs in the repository. For each PR: analyze the code, generate f
 present them to the user for approval, and post approved findings as inline GitHub review comments
 with suggestion blocks.
 
+## Usage
+
+```
+/review-open-prs
+```
+
+No arguments needed. Reviews all open non-draft PRs in the current repository (up to 10 most recently updated).
+
 ## Step 0: Determine repository context
 
 ```bash

--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -128,13 +128,7 @@ For each PR with approved findings, submit a **single batch review** using the G
 
 Each approved finding becomes an inline review comment with a suggestion block:
 
-```bash
-gh api repos/stolostron/capi-tests/pulls/<number>/reviews \
-  --method POST \
-  -f event="COMMENT" \
-  -f body="Automated review: <N> findings" \
-  --input <json-file>
-```
+Build the full JSON payload (see below) and post via `--input` to avoid shell escaping issues:
 
 The JSON body for the review:
 

--- a/.claude/commands/review-open-prs.md
+++ b/.claude/commands/review-open-prs.md
@@ -1,0 +1,214 @@
+---
+description: Review all open PRs — analyze, present findings with fixes, post approved ones as GitHub suggestion comments
+---
+
+# Review All Open Pull Requests
+
+Review all open PRs in the repository. For each PR: analyze the code, generate findings with fixes,
+present them to the user for approval, and post approved findings as inline GitHub review comments
+with suggestion blocks.
+
+## Phase 1: Discover and Summarize
+
+### Step 1: Fetch all open PRs
+
+```bash
+gh pr list --repo stolostron/capi-tests --state open \
+  --json number,title,author,createdAt,updatedAt,isDraft,headRefName,baseRefName,mergeable,reviewDecision,statusCheckRollup,labels,additions,deletions,changedFiles \
+  --jq '.'
+```
+
+If there are no open PRs, print "No open pull requests found." and stop.
+
+### Step 2: Print compact status table
+
+Print a short overview table (this is the only "report" output — keep it brief):
+
+```markdown
+# Open PRs — <date>
+
+| # | Title | CI | Mergeable | Size |
+|---|-------|----|-----------|------|
+| <number> | <title> | pass/fail | yes/no | +N/-N |
+
+Draft PRs: #<numbers> (skipped from review)
+```
+
+## Phase 2: Analyze Each PR
+
+For each **non-draft** open PR (skip draft PRs, skip branches starting with `auto/`):
+
+### Step 3: Fetch diff and existing reviews
+
+```bash
+# Get the diff
+gh pr diff <number> --repo stolostron/capi-tests
+
+# Check existing review comments to avoid duplicates
+gh api repos/stolostron/capi-tests/pulls/<number>/comments \
+  --jq '[.[] | {path: .path, line: .line, body: .body}]'
+```
+
+### Step 4: Run code review
+
+Use the `pr-review-toolkit:code-reviewer` agent (via the Agent tool with `subagent_type: "pr-review-toolkit:code-reviewer"`).
+
+Pass the PR number, full diff, and repository context. Instruct the agent to return findings in this structured format:
+
+For each finding, collect:
+- **file**: exact file path (relative to repo root)
+- **line**: the line number in the **new version** of the file where the comment should appear
+- **severity**: critical / important / minor
+- **reasoning**: 2-4 sentences explaining the problem
+- **suggestion**: the exact replacement code (for the GitHub suggestion block)
+- **start_line** (optional): if the suggestion spans multiple lines, the starting line number
+
+### Step 5: Generate fix for each finding
+
+For each finding from the code review:
+
+1. Read the relevant file section to understand full context
+2. Write the concrete fix (the replacement code for the suggestion block)
+3. Ensure the fix is minimal and correct — change only what's needed
+4. If a finding cannot be fixed mechanically (needs design decisions), mark it as `manual_only: true`
+
+## Phase 3: User Approval
+
+### Step 6: Present findings one by one
+
+For each PR, present its findings to the user sequentially. For each finding, print:
+
+```
+────────────────────────────────────────
+PR #<number> — Finding <N>/<total> [<severity>]
+File: <path>:<line>
+────────────────────────────────────────
+
+<reasoning — 2-4 sentences explaining the problem>
+
+Suggested change:
+  <show the current code and the proposed replacement as a diff>
+
+────────────────────────────────────────
+```
+
+Then ask: **"Accept, skip, or stop reviewing this PR? (a/s/stop)"**
+
+- **accept** — Add this finding to the list of approved findings
+- **skip** — Do not include this finding
+- **stop** — Stop reviewing this PR, move to next PR
+
+For findings marked `manual_only: true`, present the reasoning but note:
+"(No auto-fix — requires manual implementation. Accept to post as a comment without suggestion block.)"
+
+### Step 7: Confirm before posting
+
+After reviewing all findings for a PR, show a summary:
+
+```
+PR #<number>: <accepted>/<total> findings accepted
+
+Accepted:
+  1. [critical] <path>:<line> — <one-line summary>
+  3. [important] <path>:<line> — <one-line summary>
+
+Skipped:
+  2. [minor] <path>:<line> — <one-line summary>
+
+Post these as a GitHub review? (yes/no)
+```
+
+Wait for user confirmation before posting.
+
+## Phase 4: Post to GitHub
+
+### Step 8: Submit batch review
+
+For each PR with approved findings, submit a **single batch review** using the GitHub API.
+
+Each approved finding becomes an inline review comment with a suggestion block:
+
+```bash
+gh api repos/stolostron/capi-tests/pulls/<number>/reviews \
+  --method POST \
+  -f event="COMMENT" \
+  -f body="Automated review: <N> findings" \
+  --input <json-file>
+```
+
+The JSON body for the review:
+
+```json
+{
+  "event": "COMMENT",
+  "body": "Automated code review — <N> suggestions. Apply individually or batch-apply in the Files changed tab.",
+  "comments": [
+    {
+      "path": "<file-path>",
+      "line": <line-number>,
+      "side": "RIGHT",
+      "body": "**<severity>**: <reasoning>\n\n```suggestion\n<replacement-code>\n```"
+    }
+  ]
+}
+```
+
+For multi-line suggestions, include `start_line` and `start_side`:
+
+```json
+{
+  "path": "<file-path>",
+  "line": <end-line>,
+  "start_line": <start-line>,
+  "side": "RIGHT",
+  "start_side": "RIGHT",
+  "body": "**<severity>**: <reasoning>\n\n```suggestion\n<replacement-code>\n```"
+}
+```
+
+For `manual_only` findings (no auto-fix), omit the suggestion block:
+
+```json
+{
+  "path": "<file-path>",
+  "line": <line-number>,
+  "side": "RIGHT",
+  "body": "**<severity>**: <reasoning>\n\n_No auto-fix available — requires manual implementation._"
+}
+```
+
+**Important**: Write the JSON to a temp file and pass via `--input` to avoid shell escaping issues:
+
+```bash
+REVIEW_FILE=$(mktemp)
+cat > "$REVIEW_FILE" << 'REVIEW_JSON'
+<json content>
+REVIEW_JSON
+gh api repos/stolostron/capi-tests/pulls/<number>/reviews \
+  --method POST --input "$REVIEW_FILE"
+rm -f "$REVIEW_FILE"
+```
+
+### Step 9: Final summary
+
+After posting all reviews, print:
+
+```
+Done. Posted reviews:
+  PR #<number>: <N> suggestions posted
+  PR #<number>: <N> suggestions posted
+  PR #<number>: no findings — clean
+
+PRs skipped (draft): #<numbers>
+```
+
+## Important Guidelines
+
+- **Local analysis, remote output**: All code analysis happens locally. GitHub is only used to fetch diffs and post reviews.
+- **User approval required**: Never post review comments without explicit user approval for each finding.
+- **Skip auto/* branches**: Exclude PRs from branches starting with `auto/` (automated PRs).
+- **Skip duplicates**: Check existing review comments (Step 3) and skip findings that overlap with already-posted comments.
+- **Rate limiting**: If there are more than 10 open PRs, process the 10 most recently updated first.
+- **Suggestion accuracy**: The `line` number in the review comment must reference the line in the PR diff (the new file version), not the old file. Use `side: "RIGHT"` always.
+- **Minimal fixes**: Suggestion blocks should change only the lines needed. Do not reformat or refactor surrounding code.
+- **One review per PR**: Submit all approved findings for a PR as a single batch review, not individual comments.


### PR DESCRIPTION
## Description

Add `/review-open-prs` Claude Code command for interactive review of all open PRs.

## Changes Made

- Add `.claude/commands/review-open-prs.md` — a four-phase workflow:
  1. **Discover** — fetch all open PRs, print compact status table
  2. **Analyze** — run code review agent on each non-draft PR, generate findings with fixes
  3. **Approve** — present each finding locally (reasoning + diff), user accepts or skips
  4. **Post** — submit approved findings as a single GitHub batch review with inline suggestion blocks

### Flow

```
┌─────────────────────────────────────┐
│  1. Fetch PR diff from GitHub       │  (gh pr diff)
│  2. Analyze locally                 │  (code-reviewer agent)
│  3. Generate fix for each finding   │  (local — code + reasoning)
├─────────────────────────────────────┤
│  4. Present finding #1 to user      │  ← terminal
│     - reasoning                     │
│     - code diff                     │
│     User: yes / no                  │
│                                     │
│  5. Present finding #2 to user      │
│     User: yes / no                  │
│     ...                             │
├─────────────────────────────────────┤
│  6. Post accepted findings as ONE   │  (gh api — single batch review)
│     GitHub PR review with inline    │
│     suggestion blocks               │
└─────────────────────────────────────┘
```

## Additional Notes

- Analysis is fully local — GitHub is only used for input (fetching diffs) and output (posting reviews)
- Findings are posted as inline comments with `suggestion` blocks, enabling one-click "Apply suggestion" in the Files changed tab
- User must approve each finding before anything is posted — no automated comments
- Draft PR — design is still being refined

🤖 Generated with [Claude Code](https://claude.com/claude-code)