### PR TITLE
feat: enable parallel test runs with unique CS_CLUSTER_NAME and Azure resource tagging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,8 +240,26 @@ FORCE=1 make clean-azure
 CS_CLUSTER_NAME=myprefix-stage make clean-azure
 ```
 
+**Tag-Based Cleanup (for parallel runs)**:
+
+All test runs automatically tag Azure resource groups with ownership metadata (`capi-test-user`, `capi-test-env`, `capi-test-run-id`, `capi-test-created-at`). This enables tag-based resource discovery and cleanup:
+
+```bash
+# List all my test resources (dry-run, uses capi-test-user=$USER tag)
+make clean-my-resources
+
+# Find resources by specific tag
+./scripts/cleanup-azure-resources.sh --tag capi-test-user=alice --dry-run
+
+# Delete all resources tagged with a specific user
+./scripts/cleanup-azure-resources.sh --tag capi-test-user=alice --force
+
+# Delete resources from a specific test run
+./scripts/cleanup-azure-resources.sh --tag capi-test-run-id=cate-a1b2c --force
+```
+
 Notes:
-- The resource group name is derived from `${CS_CLUSTER_NAME}-resgroup` where `CS_CLUSTER_NAME` defaults to `${CAPI_USER}-${DEPLOYMENT_ENV}` (e.g., `cate-stage-resgroup`)
+- The resource group name is derived from `${CS_CLUSTER_NAME}-resgroup` where `CS_CLUSTER_NAME` is auto-generated as `${CAPI_USER}-${random5hex}` (e.g., `cate-a1b2c-resgroup`)
 - Resource matching uses `startswith` by default (safer than `contains`). Use `--match-mode contains` for broader search.
 - Uses `az group delete --yes` for synchronous deletion (waits for completion before orphan cleanup)
 - Gracefully skips Azure cleanup if Azure CLI is not installed or not authenticated
@@ -350,11 +368,11 @@ export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
   - **Note**: Tests automatically translate this to `KIND_CLUSTER_NAME` for the deployment script
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests` for ARO, `capa-tests` for ROSA). Keep short as cloud providers may have length limits (e.g., Azure node pools max 15 chars including suffixes)
-- `CS_CLUSTER_NAME` - **C**luster **S**ervice cluster name prefix used for YAML generation and Azure resource naming (default: `${CAPI_USER}-${DEPLOYMENT_ENV}`). The Azure resource group will be named `${CS_CLUSTER_NAME}-resgroup`. This prefix is also used for the ExternalAuth resource ID.
+- `CS_CLUSTER_NAME` - **C**luster **S**ervice cluster name prefix used for YAML generation and Azure resource naming. If not set, auto-generates a unique value: `${CAPI_USER}-${random5hex}` (e.g., `cate-a1b2c`). This enables parallel test runs against the same Azure subscription without resource name collisions. The Azure resource group will be named `${CS_CLUSTER_NAME}-resgroup`. This prefix is also used for the ExternalAuth resource ID (max 15 chars including `-ea` suffix, so CS_CLUSTER_NAME max 12 chars). When resuming a multi-phase test run, the prefix is automatically loaded from the deployment state file.
 - `OCP_VERSION` - OpenShift version (default: `4.21`)
 - `REGION` - Azure region (default: `uksouth`)
-- `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)
-- `CAPI_USER` - User identifier for domain prefix (default: `cate`). Must be short enough that `${CAPI_USER}-${DEPLOYMENT_ENV}` does not exceed 15 characters.
+- `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`). Used in Azure resource tags and domain prefix validation, but not included in the auto-generated `CS_CLUSTER_NAME`.
+- `CAPI_USER` - User identifier for domain prefix (default: `cate`). Used as the base for auto-generated `CS_CLUSTER_NAME` (e.g., `cate-a1b2c`). Must be short enough that `${CAPI_USER}-${DEPLOYMENT_ENV}` does not exceed 15 characters.
 - `WORKLOAD_CLUSTER_NAMESPACE` - Namespace for workload cluster resources (CAPI CRs that create cloud resources). If set, uses the exact value provided (for resume scenarios). If not set, generates a unique namespace per test run using `${WORKLOAD_CLUSTER_NAMESPACE_PREFIX}-${TIMESTAMP}` format (e.g., `capz-test-20260202-135526` for ARO, `capa-test-20260202-135526` for ROSA). This namespace is passed as `$NAMESPACE` to the YAML generation script.
 - `WORKLOAD_CLUSTER_NAMESPACE_PREFIX` - Prefix for auto-generated workload cluster namespace (default: provider-specific — `capz-test` for ARO, `capa-test` for ROSA). Only used when `WORKLOAD_CLUSTER_NAMESPACE` is not set.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test _check-dep _setup _management_cluster _generate-yamls _deploy-crs _verify-workload-cluster _delete-workload-cluster _validate-cleanup test-all _test-all-impl clean clean-all clean-azure help summary scheduled-review
+.PHONY: test _check-dep _setup _management_cluster _generate-yamls _deploy-crs _verify-workload-cluster _delete-workload-cluster _validate-cleanup test-all _test-all-impl clean clean-all clean-azure clean-my-resources help summary scheduled-review
 
 # Use bash for shell commands (required for PIPESTATUS in test-all target)
 SHELL := /bin/bash
@@ -26,10 +26,12 @@ DEPLOYMENT_STATE_FILE := .deployment-state.json
 # even if environment variables or defaults have changed since deployment.
 STATE_RESOURCE_GROUP := $(shell if [ -f $(DEPLOYMENT_STATE_FILE) ]; then cat $(DEPLOYMENT_STATE_FILE) | grep '"resource_group"' | sed 's/.*: *"\([^"]*\)".*/\1/'; fi)
 STATE_MANAGEMENT_CLUSTER := $(shell if [ -f $(DEPLOYMENT_STATE_FILE) ]; then cat $(DEPLOYMENT_STATE_FILE) | grep '"management_cluster_name"' | sed 's/.*: *"\([^"]*\)".*/\1/'; fi)
+STATE_CLUSTER_PREFIX := $(shell if [ -f $(DEPLOYMENT_STATE_FILE) ]; then cat $(DEPLOYMENT_STATE_FILE) | grep '"cluster_name_prefix"' | sed 's/.*: *"\([^"]*\)".*/\1/'; fi)
 
 # Use state file values if available, otherwise use defaults
 CLEANUP_RESOURCE_GROUP := $(if $(STATE_RESOURCE_GROUP),$(STATE_RESOURCE_GROUP),$(AZURE_RESOURCE_GROUP))
 CLEANUP_MANAGEMENT_CLUSTER := $(if $(STATE_MANAGEMENT_CLUSTER),$(STATE_MANAGEMENT_CLUSTER),$(MANAGEMENT_CLUSTER_NAME))
+CLEANUP_CLUSTER_PREFIX := $(if $(STATE_CLUSTER_PREFIX),$(STATE_CLUSTER_PREFIX),$(CS_CLUSTER_NAME))
 
 # Test configuration
 GOTESTSUM_FORMAT ?= testname
@@ -488,17 +490,17 @@ clean: ## Clean up test resources (interactive, use FORCE=1 to skip prompts)
 		fi; \
 		echo ""; \
 		echo "--- Orphaned Azure Resources ---"; \
-		echo "These are resources with prefix '$(CS_CLUSTER_NAME)' that may exist outside the resource group."; \
+		echo "These are resources with prefix '$(CLEANUP_CLUSTER_PREFIX)' that may exist outside the resource group."; \
 		echo ""; \
 		if ! command -v az >/dev/null 2>&1; then \
 			echo "⚠️  Azure CLI (az) not available - skipping orphaned resources cleanup"; \
 		elif ! az account show >/dev/null 2>&1; then \
 			echo "⚠️  Not logged in to Azure - skipping orphaned resources cleanup"; \
 		else \
-			read -p "Search for and delete orphaned Azure resources with prefix '$(CS_CLUSTER_NAME)'? [y/N] " -n 1 -r; \
+			read -p "Search for and delete orphaned Azure resources with prefix '$(CLEANUP_CLUSTER_PREFIX)'? [y/N] " -n 1 -r; \
 			echo ""; \
 			if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
-				./scripts/cleanup-azure-resources.sh --prefix "$(CS_CLUSTER_NAME)" || echo "Orphaned resources cleanup encountered an error"; \
+				./scripts/cleanup-azure-resources.sh --prefix "$(CLEANUP_CLUSTER_PREFIX)" || echo "Orphaned resources cleanup encountered an error"; \
 			else \
 				echo "Skipped orphaned resources cleanup."; \
 				echo "Tip: Run 'make clean-azure' to clean all Azure resources (including orphaned)."; \
@@ -578,21 +580,24 @@ clean-all: ## Clean up ALL test resources without prompting (local + Azure)
 	@echo "=== All Resources Cleaned ==="
 	@echo "======================================="
 
+clean-my-resources: ## List all Azure resources tagged as mine (capi-test-user=$CAPI_USER)
+	@./scripts/cleanup-azure-resources.sh --my-resources
+
 clean-azure: ## Delete all Azure resources (resource group, orphaned resources, AD apps, service principals)
 	@if [ -f "$(DEPLOYMENT_STATE_FILE)" ]; then \
 		echo "📝 Using deployment state from $(DEPLOYMENT_STATE_FILE)"; \
 		echo ""; \
 	fi
 	@if [ "$(FORCE)" = "1" ]; then \
-		./scripts/cleanup-azure-resources.sh --resource-group "$(CLEANUP_RESOURCE_GROUP)" --prefix "$(CS_CLUSTER_NAME)" --force; \
+		./scripts/cleanup-azure-resources.sh --resource-group "$(CLEANUP_RESOURCE_GROUP)" --prefix "$(CLEANUP_CLUSTER_PREFIX)" --force; \
 	else \
-		./scripts/cleanup-azure-resources.sh --resource-group "$(CLEANUP_RESOURCE_GROUP)" --prefix "$(CS_CLUSTER_NAME)"; \
+		./scripts/cleanup-azure-resources.sh --resource-group "$(CLEANUP_RESOURCE_GROUP)" --prefix "$(CLEANUP_CLUSTER_PREFIX)"; \
 	fi
 
 # Internal target: force delete all Azure resources without prompting
 .PHONY: _clean-azure-force
 _clean-azure-force:
-	@./scripts/cleanup-azure-resources.sh --resource-group "$(CLEANUP_RESOURCE_GROUP)" --prefix "$(CS_CLUSTER_NAME)" --force 2>/dev/null || true
+	@./scripts/cleanup-azure-resources.sh --resource-group "$(CLEANUP_RESOURCE_GROUP)" --prefix "$(CLEANUP_CLUSTER_PREFIX)" --force 2>/dev/null || true
 
 # Internal target: conditionally clean Azure resources (only for ARO)
 .PHONY: _clean-azure-conditional

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ _deploy-crs: check-gotestsum
 	if [ $$EXIT_CODE -eq 0 ]; then \
 		echo ""; \
 		echo "--- Phase 2: Monitor deployment ---"; \
-		TEST_RESULTS_DIR=$(CURDIR)/$(RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-monitor.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestDeployment_Monitor|TestDeployment_Wait|TestDeployment_Verify" -timeout $(DEPLOY_CRS_TIMEOUT) || EXIT_CODE=$$?; \
+		TEST_RESULTS_DIR=$(CURDIR)/$(RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-monitor.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestDeployment_Monitor|TestDeployment_Wait|TestDeployment_Verify|TestDeployment_Tag" -timeout $(DEPLOY_CRS_TIMEOUT) || EXIT_CODE=$$?; \
 	fi; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \

--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ When using `INFRA_PROVIDER=rosa`, the following credentials are required:
   - **Note**: Tests automatically translate this to `KIND_CLUSTER_NAME` for the deployment script
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests` for ARO, `capa-tests` for ROSA). Keep short due to cloud provider length limits
-- `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPI_USER}-${DEPLOYMENT_ENV}`). The Azure resource group will be named `${CS_CLUSTER_NAME}-resgroup`.
+- `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation and Azure resource naming. If not set, auto-generates a unique value: `${CAPI_USER}-${random5hex}` (e.g., `cate-a1b2c`) to enable parallel test runs. The Azure resource group will be named `${CS_CLUSTER_NAME}-resgroup`. Max 12 characters (ExternalAuth ID constraint).
 - `OCP_VERSION` - OpenShift version (default: `4.20`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
-- `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)
-- `CAPI_USER` - User identifier for domain prefix (default: `cate`)
+- `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`). Used in Azure resource tags and domain prefix validation.
+- `CAPI_USER` - User identifier and base for auto-generated `CS_CLUSTER_NAME` (default: `cate`)
 - `WORKLOAD_CLUSTER_NAMESPACE` - Namespace for workload cluster resources. If set, uses the exact value provided (for resume scenarios). If not set, auto-generates a unique namespace per test run using `${WORKLOAD_CLUSTER_NAMESPACE_PREFIX}-${TIMESTAMP}` format.
 - `WORKLOAD_CLUSTER_NAMESPACE_PREFIX` - Prefix for auto-generated namespace (default: provider-specific — `capz-test` for ARO, `capa-test` for ROSA). Only used when `WORKLOAD_CLUSTER_NAMESPACE` is not set.
 
@@ -312,6 +312,7 @@ These targets are called by `make test-all` but can be run individually for debu
 | `make clean-all` | Delete ALL resources without prompting (local + Azure) |
 | `FORCE=1 make clean` | Same as `make clean-all` |
 | `make clean-azure` | Delete all Azure resources (RG, orphaned resources, AD apps, SPs) |
+| `make clean-my-resources` | List all Azure resources tagged as mine (dry-run) |
 
 #### Setup and Prerequisites
 
@@ -417,7 +418,37 @@ For automated workflows (CI/CD, scripts) or quick full resets, use:
 - Uses synchronous `--yes` deletion (waits for completion before orphan cleanup)
 - Gracefully skips if Azure CLI is not installed or not logged in
 - Checks if resource group exists before attempting deletion
-- The resource group name is derived from `${CAPI_USER}-${DEPLOYMENT_ENV}-resgroup` (default: `cate-stage-resgroup`)
+- The resource group name is derived from `${CS_CLUSTER_NAME}-resgroup` (auto-generated, e.g., `cate-a1b2c-resgroup`)
+
+**Tag-Based Cleanup (for parallel runs)**: All test runs automatically tag Azure resources with ownership metadata. Use tag-based queries to find and clean up resources:
+
+```bash
+make clean-my-resources                                          # List all my test resources (dry-run)
+./scripts/cleanup-azure-resources.sh --tag capi-test-user=alice  # Find resources by user
+./scripts/cleanup-azure-resources.sh --tag capi-test-user=alice --force  # Delete by tag
+```
+
+## Parallel Runs
+
+Multiple users (or CI jobs) can run the test suite simultaneously against the same Azure subscription. Each test run automatically generates a unique `CS_CLUSTER_NAME` (e.g., `cate-a1b2c`) to avoid resource collisions.
+
+**How it works**:
+- `CS_CLUSTER_NAME` is auto-generated as `${CAPI_USER}-${random5hex}` (e.g., `cate-a1b2c`)
+- Each run creates its own Azure resource group (e.g., `cate-a1b2c-resgroup`)
+- All Azure resources are tagged with `capi-test-user`, `capi-test-env`, `capi-test-run-id`, and `capi-test-created-at`
+- The deployment state file (`.deployment-state.json`) tracks the generated prefix for cleanup
+
+**Recommended setup for each user**:
+```bash
+export CAPI_USER=alice     # Use your own short identifier (max ~6 chars)
+make test-all              # CS_CLUSTER_NAME auto-generated as alice-xxxxx
+```
+
+**Cleanup after parallel runs**:
+```bash
+make clean-my-resources    # List all my tagged Azure resources
+make clean-azure           # Clean resources from the current deployment state
+```
 
 ## Integration with cluster-api-installer
 

--- a/scripts/cleanup-azure-resources.sh
+++ b/scripts/cleanup-azure-resources.sh
@@ -714,42 +714,44 @@ main() {
         fi
 
         # Find Azure AD Applications and Service Principals with matching tags.
-        # AD app tags are string arrays with "key:value" format (not ARM key=value).
         # Microsoft Graph doesn't support server-side tag filtering via OData, so we use
-        # the capi-test-run-id tag value (which equals CS_CLUSTER_NAME) as a displayName
-        # prefix filter (fast, server-side) and then verify tags client-side.
+        # displayName prefix filters (fast, server-side) derived from resource group names.
+        # For capi-test-run-id tags, the value is the prefix directly.
+        # For other tags (like capi-test-user), we extract prefixes from all matched RGs
+        # to handle multiple test runs by the same user.
         local tag_key="${TAG_FILTER%%=*}"
         local tag_value="${TAG_FILTER#*=}"
-        local ad_tag_string="${tag_key}:${tag_value}"
 
-        # For capi-test-run-id tags, we can use the value directly as a prefix filter
-        # For other tags (like capi-test-user), we need the prefix from resource group names
-        local ad_prefix=""
+        local ad_prefixes=()
         if [[ "$tag_key" == "capi-test-run-id" ]]; then
-            ad_prefix="${tag_value}"
+            ad_prefixes+=("${tag_value}")
         elif [[ "$rg_count" -gt 0 ]]; then
-            # Extract prefix from first resource group name (strip -resgroup suffix)
-            ad_prefix=$(echo "$rgs_json" | jq -r '.[0].name' | sed 's/-resgroup$//')
+            # Extract distinct prefixes from all matched resource groups (strip -resgroup suffix)
+            while IFS= read -r rg_prefix; do
+                ad_prefixes+=("$rg_prefix")
+            done < <(echo "$rgs_json" | jq -r '.[].name' | sed 's/-resgroup$//' | sort -u)
         fi
 
-        if [[ -n "$ad_prefix" ]]; then
-            echo ""
-            local apps_json
-            apps_json=$(find_ad_applications "$ad_prefix")
+        if [[ ${#ad_prefixes[@]} -gt 0 ]]; then
+            for ad_prefix in "${ad_prefixes[@]}"; do
+                echo ""
+                local apps_json
+                apps_json=$(find_ad_applications "$ad_prefix")
 
-            if display_ad_applications "$apps_json"; then
-                found_any=true
-                delete_ad_applications "$apps_json"
-            fi
+                if display_ad_applications "$apps_json"; then
+                    found_any=true
+                    delete_ad_applications "$apps_json"
+                fi
 
-            echo ""
-            local sps_json
-            sps_json=$(find_service_principals "$ad_prefix")
+                echo ""
+                local sps_json
+                sps_json=$(find_service_principals "$ad_prefix")
 
-            if display_service_principals "$sps_json"; then
-                found_any=true
-                delete_service_principals "$sps_json"
-            fi
+                if display_service_principals "$sps_json"; then
+                    found_any=true
+                    delete_service_principals "$sps_json"
+                fi
+            done
         else
             echo ""
             print_info "No AD Application/Service Principal prefix available for tag '${TAG_FILTER}'"

--- a/scripts/cleanup-azure-resources.sh
+++ b/scripts/cleanup-azure-resources.sh
@@ -269,7 +269,7 @@ find_ad_applications() {
     if [[ $? -ne 0 ]]; then
         print_error "Failed to list Azure AD Applications with prefix '${prefix}'" >&2
         echo "[]"
-        return
+        return 1
     fi
     echo "$apps_json"
 }
@@ -288,7 +288,7 @@ find_service_principals() {
     if [[ $? -ne 0 ]]; then
         print_error "Failed to list Service Principals with prefix '${prefix}'" >&2
         echo "[]"
-        return
+        return 1
     fi
     echo "$sps_json"
 }
@@ -739,7 +739,11 @@ main() {
             for ad_prefix in "${ad_prefixes[@]}"; do
                 echo ""
                 local apps_json
-                apps_json=$(find_ad_applications "$ad_prefix")
+                if ! apps_json=$(find_ad_applications "$ad_prefix"); then
+                    print_warning "Skipping AD Application cleanup for prefix '${ad_prefix}' due to query failure"
+                    apps_json="[]"
+                    query_failed=true
+                fi
 
                 if display_ad_applications "$apps_json"; then
                     found_any=true
@@ -748,7 +752,11 @@ main() {
 
                 echo ""
                 local sps_json
-                sps_json=$(find_service_principals "$ad_prefix")
+                if ! sps_json=$(find_service_principals "$ad_prefix"); then
+                    print_warning "Skipping Service Principal cleanup for prefix '${ad_prefix}' due to query failure"
+                    sps_json="[]"
+                    query_failed=true
+                fi
 
                 if display_service_principals "$sps_json"; then
                     found_any=true
@@ -803,7 +811,7 @@ main() {
     # Find and cleanup Azure AD Applications
     echo ""
     local apps_json
-    apps_json=$(find_ad_applications "$PREFIX")
+    apps_json=$(find_ad_applications "$PREFIX") || true
 
     if display_ad_applications "$apps_json"; then
         found_any=true
@@ -813,7 +821,7 @@ main() {
     # Find and cleanup Service Principals
     echo ""
     local sps_json
-    sps_json=$(find_service_principals "$PREFIX")
+    sps_json=$(find_service_principals "$PREFIX") || true
 
     if display_service_principals "$sps_json"; then
         found_any=true

--- a/scripts/cleanup-azure-resources.sh
+++ b/scripts/cleanup-azure-resources.sh
@@ -18,6 +18,8 @@
 #   --prefix PREFIX        Resource name prefix to search for (default: CS_CLUSTER_NAME, else CAPI_USER-DEPLOYMENT_ENV, else cate)
 #   --resource-group RG    Also delete this Azure resource group
 #   --match-mode MODE      How to match resource names: 'startswith' (default, safer) or 'contains' (broader)
+#   --my-resources         Find all resources tagged with capi-test-user=$USER (dry-run)
+#   --tag KEY=VALUE        Find resources by Azure tag (e.g., 'capi-test-user=alice')
 #   --dry-run              Show what would be deleted without actually deleting
 #   --force                Skip confirmation prompts
 #   --help                 Show this help message
@@ -34,6 +36,8 @@
 #   ./scripts/cleanup-azure-resources.sh --resource-group myapp-resgroup --prefix myapp
 #   CS_CLUSTER_NAME=cate-stage ./scripts/cleanup-azure-resources.sh
 #   ./scripts/cleanup-azure-resources.sh --prefix cate --match-mode contains  # broader search
+#   ./scripts/cleanup-azure-resources.sh --my-resources                       # find all my test resources
+#   ./scripts/cleanup-azure-resources.sh --tag capi-test-user=alice --force   # delete by tag
 
 set -euo pipefail
 
@@ -49,6 +53,7 @@ else
 fi
 RESOURCE_GROUP=""
 MATCH_MODE="startswith"
+TAG_FILTER=""
 DRY_RUN=false
 FORCE=false
 
@@ -102,6 +107,27 @@ while [[ $# -gt 0 ]]; do
             fi
             shift 2
             ;;
+        --tag)
+            if [[ $# -lt 2 ]]; then
+                print_error "Missing value for --tag"
+                exit 1
+            fi
+            TAG_FILTER="$2"
+            if [[ ! "$TAG_FILTER" =~ ^[a-zA-Z0-9_-]+=.+$ ]]; then
+                print_error "Invalid tag format '${TAG_FILTER}': expected KEY=VALUE (e.g., 'capi-test-user=alice')"
+                exit 1
+            fi
+            shift 2
+            ;;
+        --my-resources)
+            if [[ -z "${USER:-}" ]]; then
+                print_error "USER environment variable is not set"
+                exit 1
+            fi
+            TAG_FILTER="capi-test-user=${USER}"
+            DRY_RUN=true
+            shift
+            ;;
         --dry-run)
             DRY_RUN=true
             shift
@@ -120,9 +146,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Validate prefix to prevent OData filter injection
+# Validate prefix to prevent OData filter injection (skip when using tag mode only)
 # Must be lowercase alphanumeric with optional hyphens, starting with alphanumeric
-if [[ ! "$PREFIX" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+if [[ -z "$TAG_FILTER" ]] && [[ ! "$PREFIX" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
     print_error "Invalid prefix '${PREFIX}': must be lowercase alphanumeric with hyphens, starting with alphanumeric"
     exit 1
 fi
@@ -256,6 +282,44 @@ find_service_principals() {
         return
     fi
     echo "$sps_json"
+}
+
+# Find resources by Azure tag
+find_resources_by_tag() {
+    local tag_filter="$1"
+    local tag_key="${tag_filter%%=*}"
+    local tag_value="${tag_filter#*=}"
+
+    print_info "Searching for Azure resources with tag '${tag_key}=${tag_value}'..." >&2
+
+    local query="Resources | where tags['${tag_key}'] == '${tag_value}' | project id, name, type, resourceGroup, subscriptionId | order by resourceGroup asc, type asc, name asc"
+
+    local resources_json
+    resources_json=$(az graph query -q "$query" -o json 2>/dev/null)
+    if [[ $? -ne 0 ]]; then
+        print_error "Failed to search for resources with tag '${tag_filter}'" >&2
+        echo '{"data": []}'
+        return
+    fi
+    echo "$resources_json"
+}
+
+# Find resource groups by Azure tag
+find_resource_groups_by_tag() {
+    local tag_filter="$1"
+    local tag_key="${tag_filter%%=*}"
+    local tag_value="${tag_filter#*=}"
+
+    print_info "Searching for resource groups with tag '${tag_key}=${tag_value}'..." >&2
+
+    local rgs_json
+    rgs_json=$(az group list --tag "${tag_key}=${tag_value}" --query "[].{name: name, location: location}" -o json 2>/dev/null)
+    if [[ $? -ne 0 ]]; then
+        print_error "Failed to search for resource groups with tag '${tag_filter}'" >&2
+        echo "[]"
+        return
+    fi
+    echo "$rgs_json"
 }
 
 # Parse and display resources
@@ -579,8 +643,13 @@ main() {
     echo "=== Azure Resource Cleanup ==="
     echo "========================================"
     echo ""
-    print_info "Resource prefix: ${PREFIX}"
-    print_info "Match mode: ${MATCH_MODE}"
+
+    if [[ -n "$TAG_FILTER" ]]; then
+        print_info "Tag filter: ${TAG_FILTER}"
+    else
+        print_info "Resource prefix: ${PREFIX}"
+        print_info "Match mode: ${MATCH_MODE}"
+    fi
     if [[ -n "$RESOURCE_GROUP" ]]; then
         print_info "Resource group: ${RESOURCE_GROUP}"
     fi
@@ -593,6 +662,93 @@ main() {
     echo ""
 
     local found_any=false
+
+    # Tag-based cleanup mode
+    if [[ -n "$TAG_FILTER" ]]; then
+        # Find tagged resource groups
+        local rgs_json
+        rgs_json=$(find_resource_groups_by_tag "$TAG_FILTER")
+
+        local rg_count
+        rg_count=$(echo "$rgs_json" | jq -r 'length // 0')
+
+        if [[ "$rg_count" -gt 0 ]]; then
+            found_any=true
+            echo ""
+            print_warning "Found ${rg_count} resource group(s) with tag '${TAG_FILTER}':"
+            echo ""
+            echo "$rgs_json" | jq -r '.[] | "  \(.name) (\(.location))"'
+            echo ""
+
+            for rg_name in $(echo "$rgs_json" | jq -r '.[].name'); do
+                delete_resource_group "$rg_name"
+            done
+        fi
+
+        # Find tagged ARM resources (orphans that survive RG deletion)
+        local resources_json
+        resources_json=$(find_resources_by_tag "$TAG_FILTER")
+
+        if display_resources "$resources_json"; then
+            found_any=true
+            delete_resources "$resources_json"
+        fi
+
+        # Find Azure AD Applications and Service Principals with matching tags.
+        # AD app tags are string arrays with "key:value" format (not ARM key=value).
+        # Microsoft Graph doesn't support server-side tag filtering via OData, so we use
+        # the capi-test-run-id tag value (which equals CS_CLUSTER_NAME) as a displayName
+        # prefix filter (fast, server-side) and then verify tags client-side.
+        local tag_key="${TAG_FILTER%%=*}"
+        local tag_value="${TAG_FILTER#*=}"
+        local ad_tag_string="${tag_key}:${tag_value}"
+
+        # For capi-test-run-id tags, we can use the value directly as a prefix filter
+        # For other tags (like capi-test-user), we need the prefix from resource group names
+        local ad_prefix=""
+        if [[ "$tag_key" == "capi-test-run-id" ]]; then
+            ad_prefix="${tag_value}"
+        elif [[ "$rg_count" -gt 0 ]]; then
+            # Extract prefix from first resource group name (strip -resgroup suffix)
+            ad_prefix=$(echo "$rgs_json" | jq -r '.[0].name' | sed 's/-resgroup$//')
+        fi
+
+        if [[ -n "$ad_prefix" ]]; then
+            echo ""
+            local apps_json
+            apps_json=$(find_ad_applications "$ad_prefix")
+
+            if display_ad_applications "$apps_json"; then
+                found_any=true
+                delete_ad_applications "$apps_json"
+            fi
+
+            echo ""
+            local sps_json
+            sps_json=$(find_service_principals "$ad_prefix")
+
+            if display_service_principals "$sps_json"; then
+                found_any=true
+                delete_service_principals "$sps_json"
+            fi
+        else
+            echo ""
+            print_info "No AD Application/Service Principal prefix available for tag '${TAG_FILTER}'"
+            print_info "Tip: Use --tag capi-test-run-id=<prefix> to search AD objects by prefix"
+        fi
+
+        if [[ "$found_any" == "false" ]]; then
+            print_success "No resources found with tag '${TAG_FILTER}'"
+        fi
+
+        echo ""
+        echo "========================================"
+        echo "=== Cleanup Complete ==="
+        echo "========================================"
+        return
+    fi
+
+    # Prefix-based cleanup mode (original behavior)
 
     # Delete resource group if specified (do this first)
     if [[ -n "$RESOURCE_GROUP" ]]; then

--- a/scripts/cleanup-azure-resources.sh
+++ b/scripts/cleanup-azure-resources.sh
@@ -115,8 +115,8 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             TAG_FILTER="$2"
-            if [[ ! "$TAG_FILTER" =~ ^[a-zA-Z0-9_-]+=[a-zA-Z0-9_.@:/-]+$ ]]; then
-                print_error "Invalid tag format '${TAG_FILTER}': expected KEY=VALUE with alphanumeric, hyphens, dots, @, colons, slashes (e.g., 'capi-test-user=alice')"
+            if [[ ! "$TAG_FILTER" =~ ^[a-zA-Z0-9_-]+=[a-zA-Z0-9_.@:/+-]+$ ]]; then
+                print_error "Invalid tag format '${TAG_FILTER}': expected KEY=VALUE with alphanumeric, hyphens, dots, @, colons, slashes, plus (e.g., 'capi-test-user=alice')"
                 exit 1
             fi
             shift 2

--- a/scripts/cleanup-azure-resources.sh
+++ b/scripts/cleanup-azure-resources.sh
@@ -124,7 +124,7 @@ while [[ $# -gt 0 ]]; do
         --my-resources)
             # Use CAPI_USER to match the tag set by the Go test suite (config.go).
             # Fall back to USER (OS login) if CAPI_USER is not set.
-            local my_user="${CAPI_USER:-${USER:-}}"
+            my_user="${CAPI_USER:-${USER:-}}"
             if [[ -z "$my_user" ]]; then
                 print_error "Neither CAPI_USER nor USER environment variable is set"
                 exit 1

--- a/scripts/cleanup-azure-resources.sh
+++ b/scripts/cleanup-azure-resources.sh
@@ -19,7 +19,7 @@
 #                          Note: The Go test suite auto-generates CS_CLUSTER_NAME as CAPI_USER-<random>; this fallback is for standalone script usage.
 #   --resource-group RG    Also delete this Azure resource group
 #   --match-mode MODE      How to match resource names: 'startswith' (default, safer) or 'contains' (broader)
-#   --my-resources         Find all resources tagged with capi-test-user=$USER (dry-run)
+#   --my-resources         Find all resources tagged with capi-test-user=$CAPI_USER (or $USER fallback) (dry-run)
 #   --tag KEY=VALUE        Find resources by Azure tag (e.g., 'capi-test-user=alice')
 #   --dry-run              Show what would be deleted without actually deleting
 #   --force                Skip confirmation prompts
@@ -122,15 +122,18 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --my-resources)
-            if [[ -z "${USER:-}" ]]; then
-                print_error "USER environment variable is not set"
+            # Use CAPI_USER to match the tag set by the Go test suite (config.go).
+            # Fall back to USER (OS login) if CAPI_USER is not set.
+            local my_user="${CAPI_USER:-${USER:-}}"
+            if [[ -z "$my_user" ]]; then
+                print_error "Neither CAPI_USER nor USER environment variable is set"
                 exit 1
             fi
-            if [[ ! "${USER}" =~ ^[a-zA-Z0-9_.@/-]+$ ]]; then
-                print_error "USER '${USER}' contains disallowed characters for tag value"
+            if [[ ! "$my_user" =~ ^[a-zA-Z0-9_.@/-]+$ ]]; then
+                print_error "User identifier '$my_user' contains disallowed characters for tag value"
                 exit 1
             fi
-            TAG_FILTER="capi-test-user=${USER}"
+            TAG_FILTER="capi-test-user=${my_user}"
             DRY_RUN=true
             shift
             ;;

--- a/scripts/cleanup-azure-resources.sh
+++ b/scripts/cleanup-azure-resources.sh
@@ -299,12 +299,14 @@ find_resources_by_tag() {
     local query="Resources | where tags['${tag_key}'] == '${tag_value}' | project id, name, type, resourceGroup, subscriptionId | order by resourceGroup asc, type asc, name asc"
 
     local resources_json
-    resources_json=$(az graph query -q "$query" -o json 2>/dev/null)
-    if [[ $? -ne 0 ]]; then
-        print_error "Failed to search for resources with tag '${tag_filter}'" >&2
-        echo '{"data": []}'
-        return
+    local az_stderr
+    az_stderr=$(mktemp)
+    if ! resources_json=$(az graph query -q "$query" -o json 2>"$az_stderr"); then
+        print_error "Failed to search for resources with tag '${tag_filter}': $(cat "$az_stderr")" >&2
+        rm -f "$az_stderr"
+        return 1
     fi
+    rm -f "$az_stderr"
     echo "$resources_json"
 }
 
@@ -317,12 +319,14 @@ find_resource_groups_by_tag() {
     print_info "Searching for resource groups with tag '${tag_key}=${tag_value}'..." >&2
 
     local rgs_json
-    rgs_json=$(az group list --tag "${tag_key}=${tag_value}" --query "[].{name: name, location: location}" -o json 2>/dev/null)
-    if [[ $? -ne 0 ]]; then
-        print_error "Failed to search for resource groups with tag '${tag_filter}'" >&2
-        echo "[]"
-        return
+    local az_stderr
+    az_stderr=$(mktemp)
+    if ! rgs_json=$(az group list --tag "${tag_key}=${tag_value}" --query "[].{name: name, location: location}" -o json 2>"$az_stderr"); then
+        print_error "Failed to search for resource groups with tag '${tag_filter}': $(cat "$az_stderr")" >&2
+        rm -f "$az_stderr"
+        return 1
     fi
+    rm -f "$az_stderr"
     echo "$rgs_json"
 }
 
@@ -671,7 +675,10 @@ main() {
     if [[ -n "$TAG_FILTER" ]]; then
         # Find tagged resource groups
         local rgs_json
-        rgs_json=$(find_resource_groups_by_tag "$TAG_FILTER")
+        if ! rgs_json=$(find_resource_groups_by_tag "$TAG_FILTER"); then
+            print_warning "Skipping resource group cleanup due to query failure"
+            rgs_json="[]"
+        fi
 
         local rg_count
         rg_count=$(echo "$rgs_json" | jq -r 'length // 0')
@@ -691,7 +698,10 @@ main() {
 
         # Find tagged ARM resources (orphans that survive RG deletion)
         local resources_json
-        resources_json=$(find_resources_by_tag "$TAG_FILTER")
+        if ! resources_json=$(find_resources_by_tag "$TAG_FILTER"); then
+            print_warning "Skipping ARM resource cleanup due to query failure"
+            resources_json='{"data": []}'
+        fi
 
         if display_resources "$resources_json"; then
             found_any=true

--- a/scripts/cleanup-azure-resources.sh
+++ b/scripts/cleanup-azure-resources.sh
@@ -15,7 +15,8 @@
 #   ./scripts/cleanup-azure-resources.sh [OPTIONS]
 #
 # Options:
-#   --prefix PREFIX        Resource name prefix to search for (default: CS_CLUSTER_NAME, else CAPI_USER-DEPLOYMENT_ENV, else cate)
+#   --prefix PREFIX        Resource name prefix to search for (default: CS_CLUSTER_NAME env var, else CAPI_USER-DEPLOYMENT_ENV, else cate)
+#                          Note: The Go test suite auto-generates CS_CLUSTER_NAME as CAPI_USER-<random>; this fallback is for standalone script usage.
 #   --resource-group RG    Also delete this Azure resource group
 #   --match-mode MODE      How to match resource names: 'startswith' (default, safer) or 'contains' (broader)
 #   --my-resources         Find all resources tagged with capi-test-user=$USER (dry-run)
@@ -25,9 +26,10 @@
 #   --help                 Show this help message
 #
 # Environment variables:
-#   CS_CLUSTER_NAME    Full cluster name prefix (e.g., 'cate-stage') - preferred, most specific
+#   CS_CLUSTER_NAME    Full cluster name prefix (e.g., 'cate-a1b2c') - preferred, most specific.
+#                      The Go test suite auto-generates this as CAPI_USER-<5hex> for parallel runs.
 #   CAPI_USER          User prefix for resource names (e.g., 'cate') - fallback if CS_CLUSTER_NAME not set
-#   DEPLOYMENT_ENV     Deployment environment (default: 'stage') - combined with CAPI_USER as fallback
+#   DEPLOYMENT_ENV     Deployment environment (default: 'stage') - combined with CAPI_USER as standalone fallback
 #   AZURE_SUBSCRIPTION_ID  Azure subscription ID to search in
 #
 # Examples:

--- a/scripts/cleanup-azure-resources.sh
+++ b/scripts/cleanup-azure-resources.sh
@@ -113,8 +113,8 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             TAG_FILTER="$2"
-            if [[ ! "$TAG_FILTER" =~ ^[a-zA-Z0-9_-]+=.+$ ]]; then
-                print_error "Invalid tag format '${TAG_FILTER}': expected KEY=VALUE (e.g., 'capi-test-user=alice')"
+            if [[ ! "$TAG_FILTER" =~ ^[a-zA-Z0-9_-]+=[a-zA-Z0-9_.@:/-]+$ ]]; then
+                print_error "Invalid tag format '${TAG_FILTER}': expected KEY=VALUE with alphanumeric, hyphens, dots, @, colons, slashes (e.g., 'capi-test-user=alice')"
                 exit 1
             fi
             shift 2
@@ -122,6 +122,10 @@ while [[ $# -gt 0 ]]; do
         --my-resources)
             if [[ -z "${USER:-}" ]]; then
                 print_error "USER environment variable is not set"
+                exit 1
+            fi
+            if [[ ! "${USER}" =~ ^[a-zA-Z0-9_.@/-]+$ ]]; then
+                print_error "USER '${USER}' contains disallowed characters for tag value"
                 exit 1
             fi
             TAG_FILTER="capi-test-user=${USER}"

--- a/scripts/cleanup-azure-resources.sh
+++ b/scripts/cleanup-azure-resources.sh
@@ -44,7 +44,7 @@
 set -euo pipefail
 
 # Default values
-# Prefer CS_CLUSTER_NAME (e.g., cate-stage) for more specific matching.
+# Prefer CS_CLUSTER_NAME (e.g., cate-a1b2c) for more specific matching.
 # Fall back to CAPI_USER-DEPLOYMENT_ENV, then 'cate' as final fallback.
 if [[ -n "${CS_CLUSTER_NAME:-}" ]]; then
     PREFIX="${CS_CLUSTER_NAME}"

--- a/scripts/cleanup-azure-resources.sh
+++ b/scripts/cleanup-azure-resources.sh
@@ -675,6 +675,7 @@ main() {
     echo ""
 
     local found_any=false
+    local query_failed=false
 
     # Tag-based cleanup mode
     if [[ -n "$TAG_FILTER" ]]; then
@@ -683,6 +684,7 @@ main() {
         if ! rgs_json=$(find_resource_groups_by_tag "$TAG_FILTER"); then
             print_warning "Skipping resource group cleanup due to query failure"
             rgs_json="[]"
+            query_failed=true
         fi
 
         local rg_count
@@ -706,6 +708,7 @@ main() {
         if ! resources_json=$(find_resources_by_tag "$TAG_FILTER"); then
             print_warning "Skipping ARM resource cleanup due to query failure"
             resources_json='{"data": []}'
+            query_failed=true
         fi
 
         if display_resources "$resources_json"; then
@@ -759,13 +762,21 @@ main() {
         fi
 
         if [[ "$found_any" == "false" ]]; then
-            print_success "No resources found with tag '${TAG_FILTER}'"
+            if [[ "$query_failed" == "true" ]]; then
+                print_error "Some queries failed — results may be incomplete"
+            else
+                print_success "No resources found with tag '${TAG_FILTER}'"
+            fi
         fi
 
         echo ""
         echo "========================================"
         echo "=== Cleanup Complete ==="
         echo "========================================"
+
+        if [[ "$query_failed" == "true" ]]; then
+            exit 1
+        fi
         return
     fi
 

--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -283,8 +283,13 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 			t.Logf("Deployment state saved (namespace: %s)", config.WorkloadClusterNamespace)
 		}
 
-		// Tag Azure resource group for parallel run cleanup queries
-		tagAzureResourceGroup(t, config)
+		// Tag Azure resource group for parallel run cleanup queries.
+		// Resource group may not exist yet (created by CAPI during deployment),
+		// so failure here is expected — Phase 05 will retry after deployment.
+		if len(config.AzureResourceTags) > 0 && CommandExists("az") {
+			PrintToTTY("🏷️  Tagging resource group %s-resgroup...\n", config.ClusterNamePrefix)
+			TagAzureResourceGroup(t, config)
+		}
 
 		// Copy generated YAMLs to results directory for visibility
 		copyYAMLsToResultsDir(t, outputDir, expectedFiles)
@@ -391,42 +396,6 @@ func redactSecrets(content []byte) ([]byte, bool) {
 	}
 
 	return []byte(strings.Join(result, "---")), redacted
-}
-
-// tagAzureResourceGroup applies Azure resource tags to the resource group for parallel run
-// cleanup and ownership tracking. Tags enable queries like "find all my test resources"
-// via Azure Resource Graph. Non-fatal: failures are logged as warnings.
-func tagAzureResourceGroup(t *testing.T, config *TestConfig) {
-	t.Helper()
-
-	if len(config.AzureResourceTags) == 0 {
-		return
-	}
-
-	if !CommandExists("az") {
-		t.Log("Azure CLI not available, skipping resource group tagging")
-		return
-	}
-
-	resourceGroup := fmt.Sprintf("%s-resgroup", config.ClusterNamePrefix)
-
-	// Build tag arguments: key1=value1 key2=value2 ...
-	var tagPairs []string
-	for k, v := range config.AzureResourceTags {
-		tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", k, v))
-	}
-
-	args := []string{"group", "update", "--name", resourceGroup, "--tags"}
-	args = append(args, tagPairs...)
-
-	PrintToTTY("🏷️  Tagging resource group %s...\n", resourceGroup)
-	if _, err := RunCommandQuiet(t, "az", args...); err != nil {
-		// Resource group may not exist yet (created by CAPI during deployment, not during YAML generation)
-		t.Logf("Note: could not tag resource group %s (may not exist yet): %v", resourceGroup, err)
-		t.Log("Tags will need to be applied manually after deployment creates the resource group")
-	} else {
-		t.Logf("Tagged resource group %s with %d tags", resourceGroup, len(tagPairs))
-	}
 }
 
 // TestInfrastructure_VerifyCredentialsYAML verifies credentials.yaml exists and is valid

--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -282,6 +283,9 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 			t.Logf("Deployment state saved (namespace: %s)", config.WorkloadClusterNamespace)
 		}
 
+		// Tag Azure resource group for parallel run cleanup queries
+		tagAzureResourceGroup(t, config)
+
 		// Copy generated YAMLs to results directory for visibility
 		copyYAMLsToResultsDir(t, outputDir, expectedFiles)
 	}
@@ -387,6 +391,42 @@ func redactSecrets(content []byte) ([]byte, bool) {
 	}
 
 	return []byte(strings.Join(result, "---")), redacted
+}
+
+// tagAzureResourceGroup applies Azure resource tags to the resource group for parallel run
+// cleanup and ownership tracking. Tags enable queries like "find all my test resources"
+// via Azure Resource Graph. Non-fatal: failures are logged as warnings.
+func tagAzureResourceGroup(t *testing.T, config *TestConfig) {
+	t.Helper()
+
+	if len(config.AzureResourceTags) == 0 {
+		return
+	}
+
+	if !CommandExists("az") {
+		t.Log("Azure CLI not available, skipping resource group tagging")
+		return
+	}
+
+	resourceGroup := fmt.Sprintf("%s-resgroup", config.ClusterNamePrefix)
+
+	// Build tag arguments: key1=value1 key2=value2 ...
+	var tagPairs []string
+	for k, v := range config.AzureResourceTags {
+		tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	args := []string{"group", "update", "--name", resourceGroup, "--tags"}
+	args = append(args, tagPairs...)
+
+	PrintToTTY("🏷️  Tagging resource group %s...\n", resourceGroup)
+	if _, err := RunCommandQuiet(t, "az", args...); err != nil {
+		// Resource group may not exist yet (created by CAPI during deployment, not during YAML generation)
+		t.Logf("Note: could not tag resource group %s (may not exist yet): %v", resourceGroup, err)
+		t.Log("Tags will need to be applied manually after deployment creates the resource group")
+	} else {
+		t.Logf("Tagged resource group %s with %d tags", resourceGroup, len(tagPairs))
+	}
 }
 
 // TestInfrastructure_VerifyCredentialsYAML verifies credentials.yaml exists and is valid

--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -288,7 +287,9 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 		// so failure here is expected — Phase 05 will retry after deployment.
 		if len(config.AzureResourceTags) > 0 && CommandExists("az") {
 			PrintToTTY("🏷️  Tagging resource group %s-resgroup...\n", config.ClusterNamePrefix)
-			TagAzureResourceGroup(t, config)
+			if err := TagAzureResourceGroup(t, config); err != nil {
+				t.Logf("Resource group tagging deferred (RG may not exist yet, Phase 05 will retry): %v", err)
+			}
 		}
 
 		// Copy generated YAMLs to results directory for visibility

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1270,11 +1270,7 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 
 	PrintToTTY("Tagging resource group %s-resgroup...\n", config.ClusterNamePrefix)
 	TagAzureResourceGroup(t, config)
-
-	// Tag Azure AD Applications matching our prefix
 	tagAzureADApplications(t, config)
-
-	// Tag Service Principals matching our prefix
 	tagAzureServicePrincipals(t, config)
 
 	PrintToTTY("✅ Azure resource tagging completed\n\n")

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1267,8 +1267,8 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 
 	PrintToTTY("\n=== Tagging Azure Resources ===\n")
 
-	// Tag resource group
-	tagAzureResourceGroupDeploy(t, config)
+	PrintToTTY("Tagging resource group %s-resgroup...\n", config.ClusterNamePrefix)
+	TagAzureResourceGroup(t, config)
 
 	// Tag Azure AD Applications matching our prefix
 	tagAzureADApplications(t, config)
@@ -1277,28 +1277,6 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 	tagAzureServicePrincipals(t, config)
 
 	PrintToTTY("✅ Azure resource tagging completed\n\n")
-}
-
-// tagAzureResourceGroupDeploy tags the resource group with ownership metadata.
-func tagAzureResourceGroupDeploy(t *testing.T, config *TestConfig) {
-	t.Helper()
-
-	resourceGroup := fmt.Sprintf("%s-resgroup", config.ClusterNamePrefix)
-
-	var tagPairs []string
-	for k, v := range config.AzureResourceTags {
-		tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", k, v))
-	}
-
-	args := []string{"group", "update", "--name", resourceGroup, "--tags"}
-	args = append(args, tagPairs...)
-
-	PrintToTTY("Tagging resource group %s...\n", resourceGroup)
-	if _, err := RunCommandQuiet(t, "az", args...); err != nil {
-		t.Logf("Warning: could not tag resource group %s: %v", resourceGroup, err)
-	} else {
-		t.Logf("Tagged resource group %s with %d tags", resourceGroup, len(tagPairs))
-	}
 }
 
 // tagAzureADApplications finds and tags Azure AD Applications matching our prefix.

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1268,7 +1268,9 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 	PrintToTTY("\n=== Tagging Azure Resources ===\n")
 
 	PrintToTTY("Tagging resource group %s-resgroup...\n", config.ClusterNamePrefix)
-	TagAzureResourceGroup(t, config)
+	if err := TagAzureResourceGroup(t, config); err != nil {
+		t.Errorf("Failed to tag resource group post-deployment (RG should exist): %v", err)
+	}
 	tagAzureADApplications(t, config)
 	tagAzureServicePrincipals(t, config)
 

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1287,6 +1287,7 @@ func tagAzureADApplications(t *testing.T, config *TestConfig) {
 
 	// Find AD apps matching our prefix
 	output, err := RunCommandQuiet(t, "az", "ad", "app", "list",
+		"--only-show-errors",
 		"--filter", fmt.Sprintf("startswith(displayName, '%s')", prefix),
 		"--query", "[].{appId: appId, displayName: displayName}",
 		"-o", "json")
@@ -1336,6 +1337,7 @@ func tagAzureServicePrincipals(t *testing.T, config *TestConfig) {
 
 	// Find SPs matching our prefix
 	output, err := RunCommandQuiet(t, "az", "ad", "sp", "list",
+		"--only-show-errors",
 		"--filter", fmt.Sprintf("startswith(displayName, '%s')", prefix),
 		"--query", "[].{id: id, displayName: displayName}",
 		"-o", "json")

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1251,17 +1251,17 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 	config := NewTestConfig()
 
 	if len(config.AzureResourceTags) == 0 {
-		t.Skip("No Azure resource tags configured")
+		t.Skipf("No Azure resource tags configured")
 		return
 	}
 
 	if !CommandExists("az") {
-		t.Skip("Azure CLI not available, skipping resource tagging")
+		t.Skipf("Azure CLI not available, skipping resource tagging")
 		return
 	}
 
 	if config.InfraProviderName != "aro" {
-		t.Skip("Azure resource tagging only applies to ARO provider")
+		t.Skipf("Azure resource tagging only applies to ARO provider")
 		return
 	}
 

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1311,10 +1311,7 @@ func tagAzureADApplications(t *testing.T, config *TestConfig) {
 	}
 
 	// Build tag strings for AD apps (string array format: "key:value")
-	var tagStrings []string
-	for k, v := range config.AzureResourceTags {
-		tagStrings = append(tagStrings, fmt.Sprintf("%s:%s", k, v))
-	}
+	tagStrings := sortedTagPairs(config.AzureResourceTags, ":")
 
 	for _, app := range apps {
 		args := []string{"ad", "app", "update", "--id", app.AppID, "--set", fmt.Sprintf("tags=%s", toJSONArray(tagStrings))}
@@ -1358,10 +1355,7 @@ func tagAzureServicePrincipals(t *testing.T, config *TestConfig) {
 	}
 
 	// Build tag strings for SPs (string array format: "key:value")
-	var tagStrings []string
-	for k, v := range config.AzureResourceTags {
-		tagStrings = append(tagStrings, fmt.Sprintf("%s:%s", k, v))
-	}
+	tagStrings = sortedTagPairs(config.AzureResourceTags, ":")
 
 	for _, sp := range sps {
 		args := []string{"ad", "sp", "update", "--id", sp.ID, "--set", fmt.Sprintf("tags=%s", toJSONArray(tagStrings))}

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1309,9 +1308,14 @@ func tagAzureADApplications(t *testing.T, config *TestConfig) {
 
 	// Build tag strings for AD apps (string array format: "key:value")
 	tagStrings := sortedTagPairs(config.AzureResourceTags, ":")
+	tagsJSON, err := toJSONArray(tagStrings)
+	if err != nil {
+		t.Logf("Warning: %v — skipping AD Application tagging", err)
+		return
+	}
 
 	for _, app := range apps {
-		args := []string{"ad", "app", "update", "--id", app.AppID, "--set", fmt.Sprintf("tags=%s", toJSONArray(tagStrings))}
+		args := []string{"ad", "app", "update", "--id", app.AppID, "--set", fmt.Sprintf("tags=%s", tagsJSON)}
 		if _, err := RunCommandQuiet(t, "az", args...); err != nil {
 			t.Logf("Warning: could not tag AD Application %s (%s): %v", app.DisplayName, app.AppID, err)
 		} else {
@@ -1353,9 +1357,14 @@ func tagAzureServicePrincipals(t *testing.T, config *TestConfig) {
 
 	// Build tag strings for SPs (string array format: "key:value")
 	tagStrings := sortedTagPairs(config.AzureResourceTags, ":")
+	tagsJSON, err := toJSONArray(tagStrings)
+	if err != nil {
+		t.Logf("Warning: %v — skipping Service Principal tagging", err)
+		return
+	}
 
 	for _, sp := range sps {
-		args := []string{"ad", "sp", "update", "--id", sp.ID, "--set", fmt.Sprintf("tags=%s", toJSONArray(tagStrings))}
+		args := []string{"ad", "sp", "update", "--id", sp.ID, "--set", fmt.Sprintf("tags=%s", tagsJSON)}
 		if _, err := RunCommandQuiet(t, "az", args...); err != nil {
 			t.Logf("Warning: could not tag Service Principal %s (%s): %v", sp.DisplayName, sp.ID, err)
 		} else {
@@ -1366,11 +1375,10 @@ func tagAzureServicePrincipals(t *testing.T, config *TestConfig) {
 }
 
 // toJSONArray converts a string slice to a JSON array string.
-func toJSONArray(items []string) string {
+func toJSONArray(items []string) (string, error) {
 	data, err := json.Marshal(items)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to marshal tag array: %v\n", err)
-		return "[]"
+		return "", fmt.Errorf("failed to marshal tag array: %w", err)
 	}
-	return string(data)
+	return string(data), nil
 }

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1242,3 +1242,157 @@ func TestDeployment_VerifyClusterInfrastructureReady(t *testing.T) {
 		time.Sleep(pollInterval)
 	}
 }
+
+// TestDeployment_TagAzureResources tags all Azure resources created by the deployment
+// with ownership metadata for parallel run cleanup. Tags the resource group (ARM tags)
+// and Azure AD Applications/Service Principals (Microsoft Graph tags).
+// Non-fatal: failures are logged as warnings since tagging is for cleanup convenience only.
+func TestDeployment_TagAzureResources(t *testing.T) {
+	config := NewTestConfig()
+
+	if len(config.AzureResourceTags) == 0 {
+		t.Skip("No Azure resource tags configured")
+		return
+	}
+
+	if !CommandExists("az") {
+		t.Skip("Azure CLI not available, skipping resource tagging")
+		return
+	}
+
+	if config.InfraProviderName != "aro" {
+		t.Skip("Azure resource tagging only applies to ARO provider")
+		return
+	}
+
+	PrintToTTY("\n=== Tagging Azure Resources ===\n")
+
+	// Tag resource group
+	tagAzureResourceGroupDeploy(t, config)
+
+	// Tag Azure AD Applications matching our prefix
+	tagAzureADApplications(t, config)
+
+	// Tag Service Principals matching our prefix
+	tagAzureServicePrincipals(t, config)
+
+	PrintToTTY("✅ Azure resource tagging completed\n\n")
+}
+
+// tagAzureResourceGroupDeploy tags the resource group with ownership metadata.
+func tagAzureResourceGroupDeploy(t *testing.T, config *TestConfig) {
+	t.Helper()
+
+	resourceGroup := fmt.Sprintf("%s-resgroup", config.ClusterNamePrefix)
+
+	var tagPairs []string
+	for k, v := range config.AzureResourceTags {
+		tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	args := []string{"group", "update", "--name", resourceGroup, "--tags"}
+	args = append(args, tagPairs...)
+
+	PrintToTTY("Tagging resource group %s...\n", resourceGroup)
+	if _, err := RunCommandQuiet(t, "az", args...); err != nil {
+		t.Logf("Warning: could not tag resource group %s: %v", resourceGroup, err)
+	} else {
+		t.Logf("Tagged resource group %s with %d tags", resourceGroup, len(tagPairs))
+	}
+}
+
+// tagAzureADApplications finds and tags Azure AD Applications matching our prefix.
+// AD Application tags are string arrays (not key-value pairs), so we add strings
+// in the format "key:value" (e.g., "capi-test-user:cate").
+func tagAzureADApplications(t *testing.T, config *TestConfig) {
+	t.Helper()
+
+	prefix := config.ClusterNamePrefix
+
+	// Find AD apps matching our prefix
+	output, err := RunCommandQuiet(t, "az", "ad", "app", "list",
+		"--filter", fmt.Sprintf("startswith(displayName, '%s')", prefix),
+		"--query", "[].{appId: appId, displayName: displayName}",
+		"-o", "json")
+	if err != nil {
+		t.Logf("Warning: could not list AD Applications: %v", err)
+		return
+	}
+
+	var apps []struct {
+		AppID       string `json:"appId"`
+		DisplayName string `json:"displayName"`
+	}
+	if err := json.Unmarshal([]byte(output), &apps); err != nil || len(apps) == 0 {
+		t.Log("No Azure AD Applications found to tag")
+		return
+	}
+
+	// Build tag strings for AD apps (string array format: "key:value")
+	var tagStrings []string
+	for k, v := range config.AzureResourceTags {
+		tagStrings = append(tagStrings, fmt.Sprintf("%s:%s", k, v))
+	}
+
+	for _, app := range apps {
+		args := []string{"ad", "app", "update", "--id", app.AppID, "--set", fmt.Sprintf("tags=%s", toJSONArray(tagStrings))}
+		if _, err := RunCommandQuiet(t, "az", args...); err != nil {
+			t.Logf("Warning: could not tag AD Application %s (%s): %v", app.DisplayName, app.AppID, err)
+		} else {
+			PrintToTTY("  Tagged AD Application: %s\n", app.DisplayName)
+		}
+	}
+	t.Logf("Tagged %d Azure AD Application(s)", len(apps))
+}
+
+// tagAzureServicePrincipals finds and tags Service Principals matching our prefix.
+// SP tags use the same string array format as AD Applications.
+func tagAzureServicePrincipals(t *testing.T, config *TestConfig) {
+	t.Helper()
+
+	prefix := config.ClusterNamePrefix
+
+	// Find SPs matching our prefix
+	output, err := RunCommandQuiet(t, "az", "ad", "sp", "list",
+		"--filter", fmt.Sprintf("startswith(displayName, '%s')", prefix),
+		"--query", "[].{id: id, displayName: displayName}",
+		"-o", "json")
+	if err != nil {
+		t.Logf("Warning: could not list Service Principals: %v", err)
+		return
+	}
+
+	var sps []struct {
+		ID          string `json:"id"`
+		DisplayName string `json:"displayName"`
+	}
+	if err := json.Unmarshal([]byte(output), &sps); err != nil || len(sps) == 0 {
+		t.Log("No Service Principals found to tag")
+		return
+	}
+
+	// Build tag strings for SPs (string array format: "key:value")
+	var tagStrings []string
+	for k, v := range config.AzureResourceTags {
+		tagStrings = append(tagStrings, fmt.Sprintf("%s:%s", k, v))
+	}
+
+	for _, sp := range sps {
+		args := []string{"ad", "sp", "update", "--id", sp.ID, "--set", fmt.Sprintf("tags=%s", toJSONArray(tagStrings))}
+		if _, err := RunCommandQuiet(t, "az", args...); err != nil {
+			t.Logf("Warning: could not tag Service Principal %s (%s): %v", sp.DisplayName, sp.ID, err)
+		} else {
+			PrintToTTY("  Tagged Service Principal: %s\n", sp.DisplayName)
+		}
+	}
+	t.Logf("Tagged %d Service Principal(s)", len(sps))
+}
+
+// toJSONArray converts a string slice to a JSON array string for use with az CLI --set.
+func toJSONArray(items []string) string {
+	data, err := json.Marshal(items)
+	if err != nil {
+		return "[]"
+	}
+	return string(data)
+}

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1352,7 +1352,7 @@ func tagAzureServicePrincipals(t *testing.T, config *TestConfig) {
 	}
 
 	// Build tag strings for SPs (string array format: "key:value")
-	tagStrings = sortedTagPairs(config.AzureResourceTags, ":")
+	tagStrings := sortedTagPairs(config.AzureResourceTags, ":")
 
 	for _, sp := range sps {
 		args := []string{"ad", "sp", "update", "--id", sp.ID, "--set", fmt.Sprintf("tags=%s", toJSONArray(tagStrings))}

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1323,7 +1323,11 @@ func tagAzureADApplications(t *testing.T, config *TestConfig) {
 		AppID       string `json:"appId"`
 		DisplayName string `json:"displayName"`
 	}
-	if err := json.Unmarshal([]byte(output), &apps); err != nil || len(apps) == 0 {
+	if err := json.Unmarshal([]byte(output), &apps); err != nil {
+		t.Logf("Warning: failed to parse AD Applications JSON output: %v", err)
+		return
+	}
+	if len(apps) == 0 {
 		t.Log("No Azure AD Applications found to tag")
 		return
 	}
@@ -1366,7 +1370,11 @@ func tagAzureServicePrincipals(t *testing.T, config *TestConfig) {
 		ID          string `json:"id"`
 		DisplayName string `json:"displayName"`
 	}
-	if err := json.Unmarshal([]byte(output), &sps); err != nil || len(sps) == 0 {
+	if err := json.Unmarshal([]byte(output), &sps); err != nil {
+		t.Logf("Warning: failed to parse Service Principals JSON output: %v", err)
+		return
+	}
+	if len(sps) == 0 {
 		t.Log("No Service Principals found to tag")
 		return
 	}

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1368,10 +1369,11 @@ func tagAzureServicePrincipals(t *testing.T, config *TestConfig) {
 	t.Logf("Tagged %d Service Principal(s)", len(sps))
 }
 
-// toJSONArray converts a string slice to a JSON array string for use with az CLI --set.
+// toJSONArray converts a string slice to a JSON array string.
 func toJSONArray(items []string) string {
 	data, err := json.Marshal(items)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to marshal tag array: %v\n", err)
 		return "[]"
 	}
 	return string(data)

--- a/test/config.go
+++ b/test/config.go
@@ -354,10 +354,11 @@ func getClusterNamePrefix(capiUser string) string {
 				AzureResourceTags map[string]string `json:"azure_resource_tags,omitempty"`
 			}
 			if unmarshalErr := json.Unmarshal(data, &state); unmarshalErr != nil {
-				fmt.Fprintf(os.Stderr, "ERROR: deployment state file %s exists but cannot be parsed: %v\n", stateFilePath, unmarshalErr)
-				fmt.Fprintf(os.Stderr, "Generating a new prefix would orphan Azure resources from the previous run.\n")
-				fmt.Fprintf(os.Stderr, "Delete the file to start fresh, or fix the JSON to resume.\n")
-				os.Exit(1)
+				errMsg := fmt.Sprintf("deployment state file %s exists but cannot be parsed: %v\n"+
+					"Generating a new prefix would orphan Azure resources from the previous run.\n"+
+					"Delete the file to start fresh, or fix the JSON to resume.", stateFilePath, unmarshalErr)
+				configError = &errMsg
+				return
 			} else if state.ClusterNamePrefix != "" {
 				clusterNamePrefix = state.ClusterNamePrefix
 				cachedAzureResourceTags = state.AzureResourceTags

--- a/test/config.go
+++ b/test/config.go
@@ -353,8 +353,10 @@ func getClusterNamePrefix(capiUser string) string {
 				AzureResourceTags map[string]string `json:"azure_resource_tags,omitempty"`
 			}
 			if unmarshalErr := json.Unmarshal(data, &state); unmarshalErr != nil {
-				fmt.Fprintf(os.Stderr, "Warning: deployment state file %s exists but cannot be parsed: %v\n", stateFilePath, unmarshalErr)
-				fmt.Fprintf(os.Stderr, "Generating new cluster name prefix instead of resuming previous run\n")
+				fmt.Fprintf(os.Stderr, "ERROR: deployment state file %s exists but cannot be parsed: %v\n", stateFilePath, unmarshalErr)
+				fmt.Fprintf(os.Stderr, "Generating a new prefix would orphan Azure resources from the previous run.\n")
+				fmt.Fprintf(os.Stderr, "Delete the file to start fresh, or fix the JSON to resume.\n")
+				os.Exit(1)
 			} else if state.ClusterNamePrefix != "" {
 				clusterNamePrefix = state.ClusterNamePrefix
 				cachedAzureResourceTags = state.AzureResourceTags

--- a/test/config.go
+++ b/test/config.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -238,6 +240,9 @@ var (
 
 	workloadClusterNamespace     string
 	workloadClusterNamespaceOnce sync.Once
+
+	clusterNamePrefix     string
+	clusterNamePrefixOnce sync.Once
 )
 
 // getDefaultRepoDir returns the default repository directory path.
@@ -312,6 +317,62 @@ func getWorkloadClusterNamespace(defaultPrefix string) string {
 	return workloadClusterNamespace
 }
 
+// getClusterNamePrefix returns the CS_CLUSTER_NAME value, generating a unique one if not explicitly set.
+// When CS_CLUSTER_NAME is not set, a unique prefix is generated: ${CAPI_USER}-${random5hex}
+// (e.g., "cate-a1b2c"). This enables parallel test runs against the same Azure subscription
+// without resource name collisions.
+//
+// Resolution order:
+// 1. CS_CLUSTER_NAME env var (explicit override)
+// 2. Existing deployment state file in RepoDir (auto-resume from previous run)
+// 3. Generate unique prefix: ${CAPI_USER}-${random5hex}
+//
+// The auto-resume from deployment state ensures that subsequent test phases
+// (run as separate go test invocations) use the same prefix as the initial phase.
+func getClusterNamePrefix(capiUser string) string {
+	clusterNamePrefixOnce.Do(func() {
+		// Check if explicitly provided
+		if prefix := os.Getenv("CS_CLUSTER_NAME"); prefix != "" {
+			clusterNamePrefix = prefix
+			return
+		}
+
+		// Check for existing deployment state file in RepoDir
+		// This handles the case where a previous test invocation already generated
+		// a unique prefix and we need to reuse it for subsequent phases
+		repoDir := getDefaultRepoDir()
+		stateFilePath := filepath.Join(repoDir, ".deployment-state.json")
+		// #nosec G304 - path constructed from repo directory and fixed filename (.deployment-state.json)
+		if data, err := os.ReadFile(stateFilePath); err == nil {
+			var state struct {
+				ClusterNamePrefix string `json:"cluster_name_prefix"`
+			}
+			if err := json.Unmarshal(data, &state); err == nil && state.ClusterNamePrefix != "" {
+				clusterNamePrefix = state.ClusterNamePrefix
+				return
+			}
+		}
+
+		// Generate unique prefix: ${CAPI_USER}-${random5hex}
+		runID := generateRunID(5)
+		clusterNamePrefix = fmt.Sprintf("%s-%s", capiUser, runID)
+	})
+
+	return clusterNamePrefix
+}
+
+// generateRunID creates a random hex string of the specified length.
+// Uses crypto/rand for unpredictable values. Falls back to timestamp-based
+// suffix if crypto/rand fails.
+func generateRunID(length int) string {
+	bytes := make([]byte, (length+1)/2)
+	if _, err := rand.Read(bytes); err != nil {
+		// Fallback to timestamp-based suffix
+		return fmt.Sprintf("%05x", time.Now().UnixNano()%0xFFFFF)
+	}
+	return hex.EncodeToString(bytes)[:length]
+}
+
 // TestConfig holds configuration for CAPI tests
 type TestConfig struct {
 	// Repository configuration
@@ -329,8 +390,10 @@ type TestConfig struct {
 	AzureSubscriptionName    string // Azure subscription name (from AZURE_SUBSCRIPTION_NAME env var)
 	Environment              string
 	CAPIUser                 string // User identifier for CAPI resources (from CAPI_USER env var)
-	WorkloadClusterNamespace string // Namespace for workload cluster resources on management cluster (unique per test run)
-	TestLabelPrefix          string // Provider-specific label prefix for test namespaces (e.g., "capz-test" for ARO, "capa-test" for ROSA)
+	WorkloadClusterNamespace string            // Namespace for workload cluster resources on management cluster (unique per test run)
+	TestLabelPrefix          string            // Provider-specific label prefix for test namespaces (e.g., "capz-test" for ARO, "capa-test" for ROSA)
+	TestRunID                string            // Unique run identifier (5 hex chars) for parallel run isolation
+	AzureResourceTags        map[string]string // Azure tags applied to all created resources for cleanup queries
 	CAPINamespace            string // Namespace for CAPI controller (default: "capi-system", or "multicluster-engine" when USE_K8S=true)
 	CAPZNamespace            string // Namespace for CAPZ/ASO controllers (default: "capz-system", or "multicluster-engine" when USE_K8S=true)
 
@@ -530,6 +593,24 @@ func NewTestConfig() *TestConfig {
 
 	// Resolve CAPI_USER
 	capiUser := getCAPIUser()
+	environment := GetEnvOrDefault("DEPLOYMENT_ENV", DefaultDeploymentEnv)
+
+	// Resolve CS_CLUSTER_NAME with auto-uniqueness for parallel runs
+	prefix := getClusterNamePrefix(capiUser)
+
+	// Extract run ID from the generated prefix (the part after the user prefix)
+	testRunID := ""
+	if userPrefix := capiUser + "-"; strings.HasPrefix(prefix, userPrefix) {
+		testRunID = strings.TrimPrefix(prefix, userPrefix)
+	}
+
+	// Build Azure resource tags for cleanup and ownership tracking
+	azureTags := map[string]string{
+		"capi-test-user":       capiUser,
+		"capi-test-env":        environment,
+		"capi-test-run-id":     prefix,
+		"capi-test-created-at": time.Now().Format(time.RFC3339),
+	}
 
 	return &TestConfig{
 		// Repository defaults
@@ -540,15 +621,17 @@ func NewTestConfig() *TestConfig {
 		// Cluster defaults
 		ManagementClusterName:    GetEnvOrDefault("MANAGEMENT_CLUSTER_NAME", defaultMgmtCluster),
 		WorkloadClusterName:      GetEnvOrDefault("WORKLOAD_CLUSTER_NAME", defaultWorkloadCluster),
-		ClusterNamePrefix:        GetEnvOrDefault("CS_CLUSTER_NAME", fmt.Sprintf("%s-%s", capiUser, GetEnvOrDefault("DEPLOYMENT_ENV", DefaultDeploymentEnv))),
-		NamePrefix:               GetEnvOrDefault("NAME_PREFIX", ""), // Optional; set by capz-test-env.sh in CI
+		ClusterNamePrefix:        prefix,
+		NamePrefix:               GetEnvOrDefault("NAME_PREFIX", ""),
 		OCPVersion:               GetEnvOrDefault("OCP_VERSION", "4.20"),
 		Region:                   GetEnvOrDefault(regionEnvVar, defaultRegion),
 		AzureSubscriptionName:    os.Getenv("AZURE_SUBSCRIPTION_NAME"),
-		Environment:              GetEnvOrDefault("DEPLOYMENT_ENV", DefaultDeploymentEnv),
+		Environment:              environment,
 		CAPIUser:                 capiUser,
 		WorkloadClusterNamespace: getWorkloadClusterNamespace(testLabelPrefix),
 		TestLabelPrefix:          testLabelPrefix,
+		TestRunID:                testRunID,
+		AzureResourceTags:        azureTags,
 		CAPINamespace:            getControllerNamespace("CAPI_NAMESPACE", "capi-system"),
 		CAPZNamespace:            providerNamespace,
 

--- a/test/config.go
+++ b/test/config.go
@@ -413,7 +413,7 @@ type TestConfig struct {
 	CAPIUser                 string // User identifier for CAPI resources (from CAPI_USER env var)
 	WorkloadClusterNamespace string            // Namespace for workload cluster resources on management cluster (unique per test run)
 	TestLabelPrefix          string            // Provider-specific label prefix for test namespaces (e.g., "capz-test" for ARO, "capa-test" for ROSA)
-	TestRunID                string            // Unique run identifier (5 hex chars) for parallel run isolation
+	TestRunID                string            // Unique run identifier (5 hex chars) for parallel run isolation. Empty when CS_CLUSTER_NAME is explicitly set.
 	AzureResourceTags        map[string]string // Azure tags applied to all created resources for cleanup queries
 	CAPINamespace            string // Namespace for CAPI controller (default: "capi-system", or "multicluster-engine" when USE_K8S=true)
 	CAPZNamespace            string // Namespace for CAPZ/ASO controllers (default: "capz-system", or "multicluster-engine" when USE_K8S=true)

--- a/test/config.go
+++ b/test/config.go
@@ -245,7 +245,8 @@ var (
 	clusterNamePrefixOnce sync.Once
 
 	// cachedAzureResourceTags holds tags loaded from the deployment state file on resume.
-	// nil means no cached tags (first run or explicit CS_CLUSTER_NAME).
+	// nil means tags were not loaded from state (fresh run or explicit CS_CLUSTER_NAME),
+	// so fresh tags will be generated.
 	cachedAzureResourceTags map[string]string
 )
 
@@ -413,7 +414,7 @@ type TestConfig struct {
 	CAPIUser                 string // User identifier for CAPI resources (from CAPI_USER env var)
 	WorkloadClusterNamespace string            // Namespace for workload cluster resources on management cluster (unique per test run)
 	TestLabelPrefix          string            // Provider-specific label prefix for test namespaces (e.g., "capz-test" for ARO, "capa-test" for ROSA)
-	TestRunID                string            // Unique run identifier (5 hex chars) for parallel run isolation. Empty when CS_CLUSTER_NAME is explicitly set.
+	TestRunID                string            // Unique run identifier extracted from ClusterNamePrefix (the part after CAPI_USER-). Empty when prefix does not start with CAPI_USER-.
 	AzureResourceTags        map[string]string // Azure tags applied to all created resources for cleanup queries
 	CAPINamespace            string // Namespace for CAPI controller (default: "capi-system", or "multicluster-engine" when USE_K8S=true)
 	CAPZNamespace            string // Namespace for CAPZ/ASO controllers (default: "capz-system", or "multicluster-engine" when USE_K8S=true)

--- a/test/config.go
+++ b/test/config.go
@@ -381,15 +381,13 @@ func getClusterNamePrefix(capiUser string) string {
 }
 
 // generateRunID creates a random hex string of the specified length.
-// Uses crypto/rand for unpredictable values. Falls back to timestamp-based
-// suffix if crypto/rand fails.
+// Uses crypto/rand for unpredictable values. Panics if crypto/rand fails,
+// as this indicates a serious system issue (e.g., /dev/urandom unavailable)
+// and a timestamp fallback would undermine parallel-run uniqueness.
 func generateRunID(length int) string {
 	bytes := make([]byte, (length+1)/2)
 	if _, err := rand.Read(bytes); err != nil {
-		// Fallback to timestamp-based suffix; mask to length hex digits
-		fmt.Fprintf(os.Stderr, "Warning: crypto/rand failed (%v), falling back to timestamp-based run ID\n", err)
-		mask := int64(1)<<(length*4) - 1
-		return fmt.Sprintf("%0*x", length, time.Now().UnixNano()&mask)
+		panic(fmt.Sprintf("crypto/rand.Read failed: %v — cannot generate unique run ID for parallel safety", err))
 	}
 	return hex.EncodeToString(bytes)[:length]
 }

--- a/test/config.go
+++ b/test/config.go
@@ -386,8 +386,10 @@ func getClusterNamePrefix(capiUser string) string {
 func generateRunID(length int) string {
 	bytes := make([]byte, (length+1)/2)
 	if _, err := rand.Read(bytes); err != nil {
-		// Fallback to timestamp-based suffix
-		return fmt.Sprintf("%05x", time.Now().UnixNano()%0xFFFFF)
+		// Fallback to timestamp-based suffix; mask to length hex digits
+		fmt.Fprintf(os.Stderr, "Warning: crypto/rand failed (%v), falling back to timestamp-based run ID\n", err)
+		mask := int64(1)<<(length*4) - 1
+		return fmt.Sprintf("%0*x", length, time.Now().UnixNano()&mask)
 	}
 	return hex.EncodeToString(bytes)[:length]
 }

--- a/test/config.go
+++ b/test/config.go
@@ -347,10 +347,15 @@ func getClusterNamePrefix(capiUser string) string {
 			var state struct {
 				ClusterNamePrefix string `json:"cluster_name_prefix"`
 			}
-			if err := json.Unmarshal(data, &state); err == nil && state.ClusterNamePrefix != "" {
+			if unmarshalErr := json.Unmarshal(data, &state); unmarshalErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: deployment state file %s exists but cannot be parsed: %v\n", stateFilePath, unmarshalErr)
+				fmt.Fprintf(os.Stderr, "Generating new cluster name prefix instead of resuming previous run\n")
+			} else if state.ClusterNamePrefix != "" {
 				clusterNamePrefix = state.ClusterNamePrefix
 				return
 			}
+		} else if !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "Warning: cannot read deployment state file %s: %v\n", stateFilePath, err)
 		}
 
 		// Generate unique prefix: ${CAPI_USER}-${random5hex}

--- a/test/config.go
+++ b/test/config.go
@@ -243,6 +243,10 @@ var (
 
 	clusterNamePrefix     string
 	clusterNamePrefixOnce sync.Once
+
+	// cachedAzureResourceTags holds tags loaded from the deployment state file on resume.
+	// nil means no cached tags (first run or explicit CS_CLUSTER_NAME).
+	cachedAzureResourceTags map[string]string
 )
 
 // getDefaultRepoDir returns the default repository directory path.
@@ -345,13 +349,15 @@ func getClusterNamePrefix(capiUser string) string {
 		// #nosec G304 - path constructed from repo directory and fixed filename (.deployment-state.json)
 		if data, err := os.ReadFile(stateFilePath); err == nil {
 			var state struct {
-				ClusterNamePrefix string `json:"cluster_name_prefix"`
+				ClusterNamePrefix string            `json:"cluster_name_prefix"`
+				AzureResourceTags map[string]string `json:"azure_resource_tags,omitempty"`
 			}
 			if unmarshalErr := json.Unmarshal(data, &state); unmarshalErr != nil {
 				fmt.Fprintf(os.Stderr, "Warning: deployment state file %s exists but cannot be parsed: %v\n", stateFilePath, unmarshalErr)
 				fmt.Fprintf(os.Stderr, "Generating new cluster name prefix instead of resuming previous run\n")
 			} else if state.ClusterNamePrefix != "" {
 				clusterNamePrefix = state.ClusterNamePrefix
+				cachedAzureResourceTags = state.AzureResourceTags
 				return
 			}
 		} else if !os.IsNotExist(err) {
@@ -617,12 +623,16 @@ func NewTestConfig() *TestConfig {
 		testRunID = strings.TrimPrefix(prefix, userPrefix)
 	}
 
-	// Build Azure resource tags for cleanup and ownership tracking
-	azureTags := map[string]string{
-		"capi-test-user":       capiUser,
-		"capi-test-env":        environment,
-		"capi-test-run-id":     prefix,
-		"capi-test-created-at": time.Now().Format(time.RFC3339),
+	// Build Azure resource tags for cleanup and ownership tracking.
+	// On resume, use cached tags from the deployment state to preserve the original created-at timestamp.
+	azureTags := cachedAzureResourceTags
+	if azureTags == nil {
+		azureTags = map[string]string{
+			"capi-test-user":       capiUser,
+			"capi-test-env":        environment,
+			"capi-test-run-id":     prefix,
+			"capi-test-created-at": time.Now().Format(time.RFC3339),
+		}
 	}
 
 	return &TestConfig{

--- a/test/config.go
+++ b/test/config.go
@@ -354,6 +354,14 @@ func getClusterNamePrefix(capiUser string) string {
 		}
 
 		// Generate unique prefix: ${CAPI_USER}-${random5hex}
+		// CAPI_USER must be short enough that the result fits within MaxClusterNamePrefixLength (12).
+		// With 5 hex chars + hyphen, CAPI_USER can be at most 6 chars (6 + 1 + 5 = 12).
+		maxUserLen := MaxClusterNamePrefixLength - 1 - 5 // hyphen + 5 hex chars
+		if len(capiUser) > maxUserLen {
+			fmt.Fprintf(os.Stderr, "Warning: CAPI_USER %q is %d chars, exceeds max %d for auto-generated CS_CLUSTER_NAME (max %d chars). Truncating.\n",
+				capiUser, len(capiUser), maxUserLen, MaxClusterNamePrefixLength)
+			capiUser = capiUser[:maxUserLen]
+		}
 		runID := generateRunID(5)
 		clusterNamePrefix = fmt.Sprintf("%s-%s", capiUser, runID)
 	})

--- a/test/config.go
+++ b/test/config.go
@@ -336,7 +336,7 @@ func getWorkloadClusterNamespace(defaultPrefix string) string {
 func getClusterNamePrefix(capiUser string) string {
 	clusterNamePrefixOnce.Do(func() {
 		// Check if explicitly provided
-		if prefix := os.Getenv("CS_CLUSTER_NAME"); prefix != "" {
+		if prefix := GetEnvOrDefault("CS_CLUSTER_NAME", ""); prefix != "" {
 			clusterNamePrefix = prefix
 			return
 		}

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2639,6 +2639,28 @@ func WriteDeploymentState(config *TestConfig) error {
 	return nil
 }
 
+// TagAzureResourceGroup applies Azure resource tags to the resource group.
+// Non-fatal: failures are logged as warnings since tagging is for cleanup convenience only.
+func TagAzureResourceGroup(t *testing.T, config *TestConfig) {
+	t.Helper()
+
+	resourceGroup := fmt.Sprintf("%s-resgroup", config.ClusterNamePrefix)
+
+	var tagPairs []string
+	for k, v := range config.AzureResourceTags {
+		tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	args := []string{"group", "update", "--name", resourceGroup, "--tags"}
+	args = append(args, tagPairs...)
+
+	if _, err := RunCommandQuiet(t, "az", args...); err != nil {
+		t.Logf("Warning: could not tag resource group %s: %v", resourceGroup, err)
+	} else {
+		t.Logf("Tagged resource group %s with %d tags", resourceGroup, len(tagPairs))
+	}
+}
+
 // ReadDeploymentState reads the deployment state from the state file.
 // Returns nil if the file doesn't exist (no deployment has been recorded).
 func ReadDeploymentState() (*DeploymentState, error) {

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2594,14 +2594,16 @@ func ExtractNamespaceFromYAML(filePath string) (string, error) {
 // This is written to a state file during deployment and read during cleanup
 // to ensure the cleanup targets the correct Azure resources.
 type DeploymentState struct {
-	ResourceGroup            string `json:"resource_group"`
-	ManagementClusterName    string `json:"management_cluster_name"`
-	WorkloadClusterName      string `json:"workload_cluster_name"`
-	WorkloadClusterNamespace string `json:"workload_cluster_namespace"`
-	ClusterNamePrefix        string `json:"cluster_name_prefix"`
-	Region                   string `json:"region"`
-	User                     string `json:"user"`
-	Environment              string `json:"environment"`
+	ResourceGroup            string            `json:"resource_group"`
+	ManagementClusterName    string            `json:"management_cluster_name"`
+	WorkloadClusterName      string            `json:"workload_cluster_name"`
+	WorkloadClusterNamespace string            `json:"workload_cluster_namespace"`
+	ClusterNamePrefix        string            `json:"cluster_name_prefix"`
+	Region                   string            `json:"region"`
+	User                     string            `json:"user"`
+	Environment              string            `json:"environment"`
+	TestRunID                string            `json:"test_run_id,omitempty"`
+	AzureResourceTags        map[string]string `json:"azure_resource_tags,omitempty"`
 }
 
 // DeploymentStateFile is the path to the deployment state file.
@@ -2621,6 +2623,8 @@ func WriteDeploymentState(config *TestConfig) error {
 		Region:                   config.Region,
 		User:                     config.CAPIUser,
 		Environment:              config.Environment,
+		TestRunID:                config.TestRunID,
+		AzureResourceTags:        config.AzureResourceTags,
 	}
 
 	data, err := json.MarshalIndent(state, "", "  ")

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -2646,10 +2647,7 @@ func TagAzureResourceGroup(t *testing.T, config *TestConfig) {
 
 	resourceGroup := fmt.Sprintf("%s-resgroup", config.ClusterNamePrefix)
 
-	var tagPairs []string
-	for k, v := range config.AzureResourceTags {
-		tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", k, v))
-	}
+	tagPairs := sortedTagPairs(config.AzureResourceTags, "=")
 
 	args := []string{"group", "update", "--name", resourceGroup, "--tags"}
 	args = append(args, tagPairs...)
@@ -2659,6 +2657,22 @@ func TagAzureResourceGroup(t *testing.T, config *TestConfig) {
 	} else {
 		t.Logf("Tagged resource group %s with %d tags", resourceGroup, len(tagPairs))
 	}
+}
+
+// sortedTagPairs converts a tag map to a sorted slice of "key<sep>value" strings.
+// Deterministic ordering ensures reproducible CLI arguments and test logs.
+func sortedTagPairs(tags map[string]string, sep string) []string {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]string, 0, len(tags))
+	for _, k := range keys {
+		pairs = append(pairs, fmt.Sprintf("%s%s%s", k, sep, tags[k]))
+	}
+	return pairs
 }
 
 // ReadDeploymentState reads the deployment state from the state file.

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2641,8 +2641,8 @@ func WriteDeploymentState(config *TestConfig) error {
 }
 
 // TagAzureResourceGroup applies Azure resource tags to the resource group.
-// Non-fatal: failures are logged as warnings since tagging is for cleanup convenience only.
-func TagAzureResourceGroup(t *testing.T, config *TestConfig) {
+// Returns an error if tagging fails, allowing callers to decide severity.
+func TagAzureResourceGroup(t *testing.T, config *TestConfig) error {
 	t.Helper()
 
 	resourceGroup := fmt.Sprintf("%s-resgroup", config.ClusterNamePrefix)
@@ -2653,10 +2653,10 @@ func TagAzureResourceGroup(t *testing.T, config *TestConfig) {
 	args = append(args, tagPairs...)
 
 	if _, err := RunCommandQuiet(t, "az", args...); err != nil {
-		t.Logf("Warning: could not tag resource group %s: %v", resourceGroup, err)
-	} else {
-		t.Logf("Tagged resource group %s with %d tags", resourceGroup, len(tagPairs))
+		return fmt.Errorf("could not tag resource group %s: %w", resourceGroup, err)
 	}
+	t.Logf("Tagged resource group %s with %d tags", resourceGroup, len(tagPairs))
+	return nil
 }
 
 // sortedTagPairs converts a tag map to a sorted slice of "key<sep>value" strings.


### PR DESCRIPTION
## Description

Enable parallel test runs against the same Azure subscription by making `CS_CLUSTER_NAME` automatically unique per run and adding Azure resource tags for cleanup. Also adds the `/ai-review` slash command for automated AI code review processing.

## Changes Made

### Parallel Run Support
- Auto-generate unique `CS_CLUSTER_NAME` as `${CAPI_USER}-${random5hex}` (e.g., `cate-a1b2c`) when not explicitly set
- Resume auto-generated prefix from deployment state file across sequential test phases
- Tag Azure resource groups with ownership metadata (`capi-test-user`, `capi-test-env`, `capi-test-run-id`, `capi-test-created-at`)
- Remove Azure AD Application and Service Principal cleanup (they are pre-existing and shared across runs)

### Tag-Based Cleanup
- Add `--my-resources` and `--tag KEY=VALUE` flags to cleanup script for tag-based resource discovery
- Add `make clean-my-resources` target to list all tagged test resources
- Replace prefix-based AD app/SP lookup with tag-based Azure Resource Graph queries
- Propagate query failures to `query_failed` for reliable exit codes
- Update Makefile to use deployment state file for cleanup prefix (`CLEANUP_CLUSTER_PREFIX`)

### Slash Commands
- Add `/ai-review` command — full pipeline for processing CodeRabbit and Qodo findings with individual commits per fix

### Error Handling
- Replace `os.Exit(1)` with `configError` pattern for corrupt deployment state files
- Add `--only-show-errors` to `az ad` commands to prevent stderr pollution breaking JSON parsing
- Use `t.Skipf()` consistently for prerequisite checks

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `CS_CLUSTER_NAME` | Now auto-generates unique value if not set | `${CAPI_USER}-${random5hex}` |
| `DEPLOYMENT_ENV` | No longer part of auto-generated CS_CLUSTER_NAME (used in tags only) | `stage` |

## Additional Notes

- Backward compatible: explicitly setting `CS_CLUSTER_NAME` bypasses auto-generation
- Old deployment state files without `test_run_id`/`azure_resource_tags` still parse correctly (`omitempty`)
- ExternalAuth ID constraint (15 chars max) is satisfied: `cate-a1b2c-ea` = 13 chars
- Tagging is test-side only — cluster-api-installer does not need changes since tags are applied after resource group creation via `az group update --tags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)