### PR TITLE
feat: validate NAME_PREFIX length for ARO HCP node pool naming

### DIFF
--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -693,6 +693,22 @@ func TestCheckDependencies_NamingConstraints(t *testing.T) {
 				externalAuthID, len(externalAuthID), MaxExternalAuthIDLength)
 		}
 	})
+
+	// Validate NAME_PREFIX: ${NAME_PREFIX}-mp1 ≤ 15 chars (ARO HCP node pool limit)
+	t.Run("NamePrefix", func(t *testing.T) {
+		if config.NamePrefix == "" {
+			t.Skip("NAME_PREFIX not set (optional for local runs)")
+			return
+		}
+		if err := ValidateNamePrefix(config.NamePrefix); err != nil {
+			t.Errorf("NAME_PREFIX validation failed:\n%v", err)
+		} else {
+			nodePoolName := config.NamePrefix + NodePoolSuffix
+			t.Logf("NAME_PREFIX '%s' (%d chars) is valid — node pool '%s' (%d chars, max: %d)",
+				config.NamePrefix, len(config.NamePrefix),
+				nodePoolName, len(nodePoolName), MaxNodePoolNameLength)
+		}
+	})
 }
 
 // TestCheckDependencies_DockerCredentialHelper checks that any Docker credential helpers

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -694,7 +694,6 @@ func TestCheckDependencies_NamingConstraints(t *testing.T) {
 		}
 	})
 
-	// Validate NAME_PREFIX: ${NAME_PREFIX}-mp1 ≤ 15 chars (ARO HCP node pool limit)
 	t.Run("NamePrefix", func(t *testing.T) {
 		if config.NamePrefix == "" {
 			t.Skip("NAME_PREFIX not set (optional for local runs)")

--- a/test/config.go
+++ b/test/config.go
@@ -323,6 +323,7 @@ type TestConfig struct {
 	ManagementClusterName    string
 	WorkloadClusterName      string
 	ClusterNamePrefix        string // Used as CS_CLUSTER_NAME for YAML generation; resource group becomes ${ClusterNamePrefix}-resgroup
+	NamePrefix               string // NAME_PREFIX used for Azure resource naming (Key Vault, node pools); passed to YAML generation
 	OCPVersion               string
 	Region                   string
 	AzureSubscriptionName    string // Azure subscription name (from AZURE_SUBSCRIPTION_NAME env var)
@@ -540,6 +541,7 @@ func NewTestConfig() *TestConfig {
 		ManagementClusterName:    GetEnvOrDefault("MANAGEMENT_CLUSTER_NAME", defaultMgmtCluster),
 		WorkloadClusterName:      GetEnvOrDefault("WORKLOAD_CLUSTER_NAME", defaultWorkloadCluster),
 		ClusterNamePrefix:        GetEnvOrDefault("CS_CLUSTER_NAME", fmt.Sprintf("%s-%s", capiUser, GetEnvOrDefault("DEPLOYMENT_ENV", DefaultDeploymentEnv))),
+		NamePrefix:               os.Getenv("NAME_PREFIX"), // Optional; set by capz-test-env.sh in CI
 		OCPVersion:               GetEnvOrDefault("OCP_VERSION", "4.20"),
 		Region:                   GetEnvOrDefault(regionEnvVar, defaultRegion),
 		AzureSubscriptionName:    os.Getenv("AZURE_SUBSCRIPTION_NAME"),

--- a/test/config.go
+++ b/test/config.go
@@ -541,7 +541,7 @@ func NewTestConfig() *TestConfig {
 		ManagementClusterName:    GetEnvOrDefault("MANAGEMENT_CLUSTER_NAME", defaultMgmtCluster),
 		WorkloadClusterName:      GetEnvOrDefault("WORKLOAD_CLUSTER_NAME", defaultWorkloadCluster),
 		ClusterNamePrefix:        GetEnvOrDefault("CS_CLUSTER_NAME", fmt.Sprintf("%s-%s", capiUser, GetEnvOrDefault("DEPLOYMENT_ENV", DefaultDeploymentEnv))),
-		NamePrefix:               os.Getenv("NAME_PREFIX"), // Optional; set by capz-test-env.sh in CI
+		NamePrefix:               GetEnvOrDefault("NAME_PREFIX", ""), // Optional; set by capz-test-env.sh in CI
 		OCPVersion:               GetEnvOrDefault("OCP_VERSION", "4.20"),
 		Region:                   GetEnvOrDefault(regionEnvVar, defaultRegion),
 		AzureSubscriptionName:    os.Getenv("AZURE_SUBSCRIPTION_NAME"),

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1709,16 +1709,21 @@ const NodePoolSuffix = "-mp1"
 // This ensures the resulting node pool name (${NAME_PREFIX}-mp1) stays within limits.
 const MaxNamePrefixLength = MaxNodePoolNameLength - len(NodePoolSuffix) // 11
 
-// ValidateNamePrefix checks if the NAME_PREFIX length is within the allowed limit
-// for ARO HCP node pool naming. The node pool Azure name is constructed as
-// ${NAME_PREFIX}-mp1 and must not exceed 15 characters.
+// aroHCPNodePoolNameRegex is the Azure-enforced pattern for ARO HCP node pool names.
+// Names must be 3-15 chars, start with a letter, end with alphanumeric, and contain
+// only letters, digits, and hyphens.
+var aroHCPNodePoolNameRegex = regexp.MustCompile(`^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$`)
+
+// ValidateNamePrefix checks if the NAME_PREFIX is valid for ARO HCP node pool naming.
+// The node pool Azure name is constructed as ${NAME_PREFIX}-mp1 and must not exceed
+// 15 characters and must match the ARO HCP naming pattern.
 // Returns nil if NAME_PREFIX is empty (not set), as it's optional for local runs.
 func ValidateNamePrefix(namePrefix string) error {
 	if namePrefix == "" {
 		return nil
 	}
+	nodePoolName := namePrefix + NodePoolSuffix
 	if len(namePrefix) > MaxNamePrefixLength {
-		nodePoolName := namePrefix + NodePoolSuffix
 		return fmt.Errorf(
 			"NAME_PREFIX '%s' (%d chars) exceeds maximum length of %d characters\n"+
 				"  Node pool name would be '%s' (%d chars), exceeding ARO HCP limit of %d chars\n"+
@@ -1727,6 +1732,13 @@ func ValidateNamePrefix(namePrefix string) error {
 			namePrefix, len(namePrefix), MaxNamePrefixLength,
 			nodePoolName, len(nodePoolName), MaxNodePoolNameLength,
 			MaxNamePrefixLength)
+	}
+	if !aroHCPNodePoolNameRegex.MatchString(nodePoolName) {
+		return fmt.Errorf(
+			"NAME_PREFIX '%s' creates invalid node pool name '%s'\n"+
+				"  ARO HCP node pool names must match: ^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$\n"+
+				"  Suggestion: start with a letter and use only letters, numbers, and '-'",
+			namePrefix, nodePoolName)
 	}
 	return nil
 }

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1696,6 +1696,41 @@ func ValidateDomainPrefix(user, environment string) error {
 	return nil
 }
 
+// MaxNodePoolNameLength is the maximum allowed length for ARO HCP node pool names.
+// Azure enforces this via the regex ^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$ (3-15 chars).
+const MaxNodePoolNameLength = 15
+
+// NodePoolSuffix is the suffix appended to NAME_PREFIX to form the node pool Azure name.
+// The machine pool name is typically constructed as ${NAME_PREFIX}-mp1 by cluster-api-installer.
+const NodePoolSuffix = "-mp1"
+
+// MaxNamePrefixLength is the maximum allowed length for NAME_PREFIX,
+// calculated as MaxNodePoolNameLength minus the length of NodePoolSuffix.
+// This ensures the resulting node pool name (${NAME_PREFIX}-mp1) stays within limits.
+const MaxNamePrefixLength = MaxNodePoolNameLength - len(NodePoolSuffix) // 11
+
+// ValidateNamePrefix checks if the NAME_PREFIX length is within the allowed limit
+// for ARO HCP node pool naming. The node pool Azure name is constructed as
+// ${NAME_PREFIX}-mp1 and must not exceed 15 characters.
+// Returns nil if NAME_PREFIX is empty (not set), as it's optional for local runs.
+func ValidateNamePrefix(namePrefix string) error {
+	if namePrefix == "" {
+		return nil
+	}
+	if len(namePrefix) > MaxNamePrefixLength {
+		nodePoolName := namePrefix + NodePoolSuffix
+		return fmt.Errorf(
+			"NAME_PREFIX '%s' (%d chars) exceeds maximum length of %d characters\n"+
+				"  Node pool name would be '%s' (%d chars), exceeding ARO HCP limit of %d chars\n"+
+				"  ARO HCP node pool names must match: ^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$\n"+
+				"  Suggestion: Use a shorter NAME_PREFIX (max %d chars)",
+			namePrefix, len(namePrefix), MaxNamePrefixLength,
+			nodePoolName, len(nodePoolName), MaxNodePoolNameLength,
+			MaxNamePrefixLength)
+	}
+	return nil
+}
+
 // RFC1123NameRegex is a regex for RFC 1123 subdomain name validation.
 // Names must consist of lowercase alphanumeric characters or '-', and must start
 // and end with an alphanumeric character.

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1696,28 +1696,20 @@ func ValidateDomainPrefix(user, environment string) error {
 	return nil
 }
 
-// MaxNodePoolNameLength is the maximum allowed length for ARO HCP node pool names.
-// Azure enforces this via the regex ^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$ (3-15 chars).
+// Azure enforces ARO HCP node pool names via ^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$ (3-15 chars).
 const MaxNodePoolNameLength = 15
 
-// NodePoolSuffix is the suffix appended to NAME_PREFIX to form the node pool Azure name.
-// The machine pool name is typically constructed as ${NAME_PREFIX}-mp1 by cluster-api-installer.
+// NodePoolSuffix is appended to NAME_PREFIX to form the node pool name (${NAME_PREFIX}-mp1).
 const NodePoolSuffix = "-mp1"
 
-// MaxNamePrefixLength is the maximum allowed length for NAME_PREFIX,
-// calculated as MaxNodePoolNameLength minus the length of NodePoolSuffix.
-// This ensures the resulting node pool name (${NAME_PREFIX}-mp1) stays within limits.
+// MaxNamePrefixLength ensures ${NAME_PREFIX}-mp1 stays within MaxNodePoolNameLength.
 const MaxNamePrefixLength = MaxNodePoolNameLength - len(NodePoolSuffix) // 11
 
 // aroHCPNodePoolNameRegex is the Azure-enforced pattern for ARO HCP node pool names.
-// Names must be 3-15 chars, start with a letter, end with alphanumeric, and contain
-// only letters, digits, and hyphens.
 var aroHCPNodePoolNameRegex = regexp.MustCompile(`^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$`)
 
-// ValidateNamePrefix checks if the NAME_PREFIX is valid for ARO HCP node pool naming.
-// The node pool Azure name is constructed as ${NAME_PREFIX}-mp1 and must not exceed
-// 15 characters and must match the ARO HCP naming pattern.
-// Returns nil if NAME_PREFIX is empty (not set), as it's optional for local runs.
+// ValidateNamePrefix checks if NAME_PREFIX produces a valid ARO HCP node pool name
+// when combined with NodePoolSuffix. Returns nil if namePrefix is empty (optional).
 func ValidateNamePrefix(namePrefix string) error {
 	if namePrefix == "" {
 		return nil

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3566,6 +3566,23 @@ func ValidateAllConfigurations(t *testing.T, config *TestConfig) []ConfigValidat
 			result.IsValid = true
 		}
 		results = append(results, result)
+
+		// Validate NAME_PREFIX length (optional — only when set)
+		if config.NamePrefix != "" {
+			nodePoolName := config.NamePrefix + NodePoolSuffix
+			result = ConfigValidationResult{
+				Variable:   "NAME_PREFIX (node pool name)",
+				Value:      nodePoolName,
+				IsCritical: true,
+			}
+			if err := ValidateNamePrefix(config.NamePrefix); err != nil {
+				result.IsValid = false
+				result.Error = err
+			} else {
+				result.IsValid = true
+			}
+			results = append(results, result)
+		}
 	}
 
 	// Validate timeout values

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -1596,8 +1596,8 @@ func TestValidateNamePrefix(t *testing.T) {
 		},
 		{
 			name:        "exactly 11 chars - at limit",
-			namePrefix:  "12345678901",
-			expectError: false, // "12345678901" + "-mp1" = 15 chars
+			namePrefix:  "a1234567890",
+			expectError: false, // "a1234567890" + "-mp1" = 15 chars
 		},
 		{
 			name:        "short prefix",
@@ -1606,14 +1606,14 @@ func TestValidateNamePrefix(t *testing.T) {
 		},
 		{
 			name:        "10 chars",
-			namePrefix:  "1234567890",
-			expectError: false, // "1234567890" + "-mp1" = 14 chars
+			namePrefix:  "a123456789",
+			expectError: false, // "a123456789" + "-mp1" = 14 chars
 		},
-		// Invalid cases
+		// Invalid - length
 		{
 			name:        "12 chars - one over limit",
-			namePrefix:  "123456789012",
-			expectError: true, // "123456789012" + "-mp1" = 16 chars
+			namePrefix:  "a12345678901",
+			expectError: true, // "a12345678901" + "-mp1" = 16 chars
 		},
 		{
 			name:        "15 chars - typical CI failure",
@@ -1622,8 +1622,19 @@ func TestValidateNamePrefix(t *testing.T) {
 		},
 		{
 			name:        "20 chars - way over",
-			namePrefix:  "12345678901234567890",
+			namePrefix:  "abcdefghijklmnopqrst",
 			expectError: true,
+		},
+		// Invalid - regex pattern
+		{
+			name:        "starts with digit",
+			namePrefix:  "1abc",
+			expectError: true, // "1abc-mp1" does not start with a letter
+		},
+		{
+			name:        "contains underscore",
+			namePrefix:  "ct_ab",
+			expectError: true, // "ct_ab-mp1" contains underscore
 		},
 	}
 
@@ -1673,13 +1684,13 @@ func TestValidateNamePrefix_Constants(t *testing.T) {
 	}
 
 	// Test boundary: exactly at the limit should pass
-	err := ValidateNamePrefix("12345678901") // 11 chars
+	err := ValidateNamePrefix("a1234567890") // 11 chars, starts with letter
 	if err != nil {
 		t.Errorf("ValidateNamePrefix with 11 chars should pass, got error: %v", err)
 	}
 
 	// Test boundary: one char over should fail
-	err = ValidateNamePrefix("123456789012") // 12 chars
+	err = ValidateNamePrefix("a12345678901") // 12 chars
 	if err == nil {
 		t.Error("ValidateNamePrefix with 12 chars should fail, got nil")
 	}

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -1582,6 +1582,109 @@ func TestValidateExternalAuthID_Constants(t *testing.T) {
 	}
 }
 
+func TestValidateNamePrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		namePrefix  string
+		expectError bool
+	}{
+		// Valid cases
+		{
+			name:        "empty - not set",
+			namePrefix:  "",
+			expectError: false,
+		},
+		{
+			name:        "exactly 11 chars - at limit",
+			namePrefix:  "12345678901",
+			expectError: false, // "12345678901" + "-mp1" = 15 chars
+		},
+		{
+			name:        "short prefix",
+			namePrefix:  "ct-ab12",
+			expectError: false, // "ct-ab12" + "-mp1" = 11 chars
+		},
+		{
+			name:        "10 chars",
+			namePrefix:  "1234567890",
+			expectError: false, // "1234567890" + "-mp1" = 14 chars
+		},
+		// Invalid cases
+		{
+			name:        "12 chars - one over limit",
+			namePrefix:  "123456789012",
+			expectError: true, // "123456789012" + "-mp1" = 16 chars
+		},
+		{
+			name:        "15 chars - typical CI failure",
+			namePrefix:  "capz-tests-25b0",
+			expectError: true, // "capz-tests-25b0" + "-mp1" = 19 chars
+		},
+		{
+			name:        "20 chars - way over",
+			namePrefix:  "12345678901234567890",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNamePrefix(tt.namePrefix)
+			if tt.expectError {
+				if err == nil {
+					nodePoolName := tt.namePrefix + NodePoolSuffix
+					t.Errorf("ValidateNamePrefix(%q) expected error for node pool name %q (%d chars), got nil",
+						tt.namePrefix, nodePoolName, len(nodePoolName))
+				} else {
+					for _, msg := range []string{"NAME_PREFIX", "node pool", "ARO HCP"} {
+						if !strings.Contains(err.Error(), msg) {
+							t.Errorf("ValidateNamePrefix(%q) error = %q, expected to contain %q",
+								tt.namePrefix, err.Error(), msg)
+						}
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("ValidateNamePrefix(%q) unexpected error: %v",
+						tt.namePrefix, err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateNamePrefix_Constants(t *testing.T) {
+	if MaxNodePoolNameLength != 15 {
+		t.Errorf("MaxNodePoolNameLength = %d, expected 15", MaxNodePoolNameLength)
+	}
+
+	if NodePoolSuffix != "-mp1" {
+		t.Errorf("NodePoolSuffix = %q, expected \"-mp1\"", NodePoolSuffix)
+	}
+
+	if MaxNamePrefixLength != 11 {
+		t.Errorf("MaxNamePrefixLength = %d, expected 11 (15 - 4)", MaxNamePrefixLength)
+	}
+
+	// Verify the relationship: MaxNamePrefixLength + len(suffix) == MaxNodePoolNameLength
+	if MaxNamePrefixLength+len(NodePoolSuffix) != MaxNodePoolNameLength {
+		t.Errorf("MaxNamePrefixLength (%d) + len(NodePoolSuffix) (%d) != MaxNodePoolNameLength (%d)",
+			MaxNamePrefixLength, len(NodePoolSuffix), MaxNodePoolNameLength)
+	}
+
+	// Test boundary: exactly at the limit should pass
+	err := ValidateNamePrefix("12345678901") // 11 chars
+	if err != nil {
+		t.Errorf("ValidateNamePrefix with 11 chars should pass, got error: %v", err)
+	}
+
+	// Test boundary: one char over should fail
+	err = ValidateNamePrefix("123456789012") // 12 chars
+	if err == nil {
+		t.Error("ValidateNamePrefix with 12 chars should fail, got nil")
+	}
+}
+
 func TestIsRetryableKubectlError(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -1587,54 +1587,80 @@ func TestValidateNamePrefix(t *testing.T) {
 		name        string
 		namePrefix  string
 		expectError bool
+		errorSubstr string // distinguishes length vs regex error path
 	}{
 		// Valid cases
 		{
-			name:        "empty - not set",
-			namePrefix:  "",
-			expectError: false,
+			name:       "empty - not set",
+			namePrefix: "",
 		},
 		{
-			name:        "exactly 11 chars - at limit",
-			namePrefix:  "a1234567890",
-			expectError: false, // "a1234567890" + "-mp1" = 15 chars
+			name:       "single char - minimum valid",
+			namePrefix: "a", // "a-mp1" = 5 chars
 		},
 		{
-			name:        "short prefix",
-			namePrefix:  "ct-ab12",
-			expectError: false, // "ct-ab12" + "-mp1" = 11 chars
+			name:       "short prefix",
+			namePrefix: "ct-ab12", // "ct-ab12-mp1" = 11 chars
 		},
 		{
-			name:        "10 chars",
-			namePrefix:  "a123456789",
-			expectError: false, // "a123456789" + "-mp1" = 14 chars
+			name:       "10 chars",
+			namePrefix: "a123456789", // "a123456789-mp1" = 14 chars
+		},
+		{
+			name:       "exactly 11 chars - at limit",
+			namePrefix: "a1234567890", // "a1234567890-mp1" = 15 chars
+		},
+		{
+			name:       "uppercase letters allowed",
+			namePrefix: "CapzTest", // "CapzTest-mp1" = 12 chars, regex allows [a-zA-Z]
+		},
+		{
+			name:       "trailing hyphen in prefix",
+			namePrefix: "ct-ab-", // "ct-ab--mp1" = 10 chars, double-hyphen is valid per Azure regex
 		},
 		// Invalid - length
 		{
 			name:        "12 chars - one over limit",
-			namePrefix:  "a12345678901",
-			expectError: true, // "a12345678901" + "-mp1" = 16 chars
+			namePrefix:  "a12345678901", // "a12345678901-mp1" = 16 chars
+			expectError: true,
+			errorSubstr: "exceeds maximum length",
 		},
 		{
 			name:        "15 chars - typical CI failure",
-			namePrefix:  "capz-tests-25b0",
-			expectError: true, // "capz-tests-25b0" + "-mp1" = 19 chars
+			namePrefix:  "capz-tests-25b0", // "capz-tests-25b0-mp1" = 19 chars
+			expectError: true,
+			errorSubstr: "exceeds maximum length",
 		},
 		{
 			name:        "20 chars - way over",
 			namePrefix:  "abcdefghijklmnopqrst",
 			expectError: true,
+			errorSubstr: "exceeds maximum length",
 		},
 		// Invalid - regex pattern
 		{
 			name:        "starts with digit",
-			namePrefix:  "1abc",
-			expectError: true, // "1abc-mp1" does not start with a letter
+			namePrefix:  "1abc", // "1abc-mp1" does not start with a letter
+			expectError: true,
+			errorSubstr: "invalid node pool name",
+		},
+		{
+			name:        "starts with hyphen",
+			namePrefix:  "-abc", // "-abc-mp1" first char is hyphen, not letter
+			expectError: true,
+			errorSubstr: "invalid node pool name",
 		},
 		{
 			name:        "contains underscore",
-			namePrefix:  "ct_ab",
-			expectError: true, // "ct_ab-mp1" contains underscore
+			namePrefix:  "ct_ab", // "ct_ab-mp1" contains underscore
+			expectError: true,
+			errorSubstr: "invalid node pool name",
+		},
+		{
+			name:        "contains dot",
+			namePrefix:  "ct.ab", // "ct.ab-mp1" dot not in allowed chars
+			expectError: true,
+			errorSubstr: "invalid node pool name",
 		},
 	}
 
@@ -1647,11 +1673,9 @@ func TestValidateNamePrefix(t *testing.T) {
 					t.Errorf("ValidateNamePrefix(%q) expected error for node pool name %q (%d chars), got nil",
 						tt.namePrefix, nodePoolName, len(nodePoolName))
 				} else {
-					for _, msg := range []string{"NAME_PREFIX", "node pool", "ARO HCP"} {
-						if !strings.Contains(err.Error(), msg) {
-							t.Errorf("ValidateNamePrefix(%q) error = %q, expected to contain %q",
-								tt.namePrefix, err.Error(), msg)
-						}
+					if !strings.Contains(err.Error(), tt.errorSubstr) {
+						t.Errorf("ValidateNamePrefix(%q) error = %q, expected to contain %q",
+							tt.namePrefix, err.Error(), tt.errorSubstr)
 					}
 				}
 			} else {
@@ -1681,18 +1705,6 @@ func TestValidateNamePrefix_Constants(t *testing.T) {
 	if MaxNamePrefixLength+len(NodePoolSuffix) != MaxNodePoolNameLength {
 		t.Errorf("MaxNamePrefixLength (%d) + len(NodePoolSuffix) (%d) != MaxNodePoolNameLength (%d)",
 			MaxNamePrefixLength, len(NodePoolSuffix), MaxNodePoolNameLength)
-	}
-
-	// Test boundary: exactly at the limit should pass
-	err := ValidateNamePrefix("a1234567890") // 11 chars, starts with letter
-	if err != nil {
-		t.Errorf("ValidateNamePrefix with 11 chars should pass, got error: %v", err)
-	}
-
-	// Test boundary: one char over should fail
-	err = ValidateNamePrefix("a12345678901") // 12 chars
-	if err == nil {
-		t.Error("ValidateNamePrefix with 12 chars should fail, got nil")
 	}
 }
 


### PR DESCRIPTION
## Description

Validate NAME_PREFIX length to prevent ARO HCP node pool naming failures.

Fixes ARO-24304

## Changes Made

- Add `NamePrefix` field to `TestConfig`, read from `NAME_PREFIX` env var
- Add `ValidateNamePrefix()` helper with constants for ARO HCP node pool limits (max 15 chars)
- Add NAME_PREFIX validation to phase 1 (check dependencies) `NamingConstraints` test
- Add table-driven unit tests and boundary tests for the validation

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `NAME_PREFIX` | Azure resource naming prefix (Key Vault, node pools) | empty (optional) |

## Additional Notes

ARO HCP node pool names must match `^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$` (3-15 chars). The node pool Azure name is `${NAME_PREFIX}-mp1`, so NAME_PREFIX must be ≤ 11 chars. This was discovered when CI generated "capz-tests-25b0" (15 chars) → "capz-tests-25b0-mp1" (19 chars), which Azure rejected after 90 minutes of provisioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for node-pool name prefix validation (valid, boundary, oversize, and invalid-pattern cases) and a new subtest that checks naming constraints during dependency validation.

* **Chores**
  * Enforced node-pool naming length and pattern constraints in validation.
  * Added support for a NAME_PREFIX environment variable in test configuration to drive naming checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->