### PR TITLE
feat: add fail-fast for permanent deployment failures

### DIFF
--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -589,6 +589,44 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 			continue
 		}
 
+		// Fail-fast: check Cluster.Phase for terminal failure
+		if status.Cluster.Phase == ClusterPhaseFailed {
+			PrintToTTY("\n❌ Cluster phase is Failed — aborting early\n\n")
+			t.Fatalf("Cluster phase is 'Failed' — deployment cannot recover.\n\n"+
+				"Check cluster status:\n"+
+				"  kubectl --context %s -n %s get cluster %s -o yaml",
+				context, config.WorkloadClusterNamespace, provisionedClusterName)
+			return
+		}
+
+		// Fail-fast: check ControlPlane conditions for permanent failures
+		if err := CheckConditionsForPermanentFailure(status.ControlPlane.Conditions); err != nil {
+			PrintToTTY("\n❌ Permanent failure detected in %s conditions — aborting early\n", status.ControlPlane.Kind)
+			PrintToTTY("   %v\n\n", err)
+			t.Fatalf("Permanent failure in %s conditions — deployment cannot recover.\n%v\n\n"+
+				"Check control plane status:\n"+
+				"  kubectl --context %s -n %s get %s %s -o yaml",
+				status.ControlPlane.Kind, err,
+				context, config.WorkloadClusterNamespace, strings.ToLower(status.ControlPlane.Kind), controlPlaneName)
+			return
+		}
+
+		// Fail-fast: check MachinePool infrastructure conditions for permanent failures
+		for _, mp := range status.MachinePools {
+			if mp.Infrastructure != nil {
+				if err := CheckConditionsForPermanentFailure(mp.Infrastructure.Conditions); err != nil {
+					PrintToTTY("\n❌ Permanent failure detected in %s conditions — aborting early\n", mp.Infrastructure.Kind)
+					PrintToTTY("   %v\n\n", err)
+					t.Fatalf("Permanent failure in %s conditions — deployment cannot recover.\n%v\n\n"+
+						"Check machine pool status:\n"+
+						"  kubectl --context %s -n %s get %s %s -o yaml",
+						mp.Infrastructure.Kind, err,
+						context, config.WorkloadClusterNamespace, strings.ToLower(mp.Infrastructure.Kind), mp.Name)
+					return
+				}
+			}
+		}
+
 		// Check ControlPlane ready status (works for ARO/ROSA dynamically)
 		if !controlPlaneReady {
 			cpKind := status.ControlPlane.Kind
@@ -800,6 +838,18 @@ func TestDeployment_WaitForExternalAuthReady(t *testing.T) {
 			continue
 		}
 
+		// Fail-fast: check all control plane conditions for permanent failures
+		if err := CheckK8sConditionsForPermanentFailure(data.ControlPlane.Conditions); err != nil {
+			PrintToTTY("\n❌ Permanent failure detected in %s conditions — aborting early\n", data.ControlPlane.Kind)
+			PrintToTTY("   %v\n\n", err)
+			t.Fatalf("Permanent failure in %s conditions — deployment cannot recover.\n%v\n\n"+
+				"Check control plane status:\n"+
+				"  kubectl --context %s -n %s get %s -o yaml",
+				data.ControlPlane.Kind, err,
+				context, config.WorkloadClusterNamespace, strings.ToLower(data.ControlPlane.Kind))
+			return
+		}
+
 		// Search for ExternalAuthReady in control plane conditions
 		found := false
 		for _, cond := range data.ControlPlane.Conditions {
@@ -898,6 +948,18 @@ func TestDeployment_VerifyInfrastructureResources(t *testing.T) {
 			PrintToTTY("[%d] ⚠️  Failed to parse monitor output: %v\n", iteration, err)
 			time.Sleep(pollInterval)
 			continue
+		}
+
+		// Fail-fast: check infrastructure conditions for permanent failures
+		if err := CheckConditionsForPermanentFailure(status.Infrastructure.Conditions); err != nil {
+			PrintToTTY("\n❌ Permanent failure detected in %s conditions — aborting early\n", status.Infrastructure.Kind)
+			PrintToTTY("   %v\n\n", err)
+			t.Fatalf("Permanent failure in %s conditions — deployment cannot recover.\n%v\n\n"+
+				"Check infrastructure status:\n"+
+				"  kubectl --context %s -n %s get %s %s -o yaml",
+				status.Infrastructure.Kind, err,
+				context, config.WorkloadClusterNamespace, strings.ToLower(status.Infrastructure.Kind), provisionedClusterName)
+			return
 		}
 
 		// Get infrastructure status from already-parsed data
@@ -1002,6 +1064,20 @@ func TestDeployment_VerifyAROClusterReady(t *testing.T) {
 			return
 		}
 
+		// Fail-fast: check infrastructure conditions for permanent failures
+		if err == nil {
+			if failErr := CheckK8sConditionsForPermanentFailure(data.Infrastructure.Conditions); failErr != nil {
+				PrintToTTY("\n❌ Permanent failure detected in %s conditions — aborting early\n", data.Infrastructure.Kind)
+				PrintToTTY("   %v\n\n", failErr)
+				t.Fatalf("Permanent failure in %s conditions — deployment cannot recover.\n%v\n\n"+
+					"Check infrastructure status:\n"+
+					"  kubectl --context %s -n %s get %s %s -o yaml",
+					data.Infrastructure.Kind, failErr,
+					context, config.WorkloadClusterNamespace, infraResourceType, provisionedClusterName)
+				return
+			}
+		}
+
 		PrintToTTY("⏳ %s.Ready: %s (elapsed %v)\n", data.Infrastructure.Kind, status, elapsed.Round(time.Second))
 		time.Sleep(pollInterval)
 	}
@@ -1059,6 +1135,27 @@ func TestDeployment_VerifyClusterProvisioned(t *testing.T) {
 			return
 		}
 
+		// Fail-fast: check cluster phase and conditions for permanent failures
+		if err == nil {
+			if data.Cluster.Phase == ClusterPhaseFailed {
+				PrintToTTY("\n❌ Cluster phase is Failed — aborting early\n\n")
+				t.Fatalf("Cluster phase is 'Failed' — deployment cannot recover.\n\n"+
+					"Check cluster status:\n"+
+					"  kubectl --context %s -n %s get cluster %s -o yaml",
+					context, config.WorkloadClusterNamespace, provisionedClusterName)
+				return
+			}
+			if failErr := CheckK8sConditionsForPermanentFailure(data.Cluster.Conditions); failErr != nil {
+				PrintToTTY("\n❌ Permanent failure detected in Cluster conditions — aborting early\n")
+				PrintToTTY("   %v\n\n", failErr)
+				t.Fatalf("Permanent failure in Cluster conditions — deployment cannot recover.\n%v\n\n"+
+					"Check cluster status:\n"+
+					"  kubectl --context %s -n %s get cluster %s -o yaml",
+					failErr, context, config.WorkloadClusterNamespace, provisionedClusterName)
+				return
+			}
+		}
+
 		PrintToTTY("⏳ Cluster.Initialization.InfrastructureProvisioned: %s (elapsed %v)\n", status, elapsed.Round(time.Second))
 		time.Sleep(pollInterval)
 	}
@@ -1114,6 +1211,27 @@ func TestDeployment_VerifyClusterInfrastructureReady(t *testing.T) {
 			PrintToTTY("✅ Cluster.InfrastructureReady is True (took %v)\n\n", elapsed.Round(time.Second))
 			t.Logf("Cluster InfrastructureReady=True (took %v)", elapsed.Round(time.Second))
 			return
+		}
+
+		// Fail-fast: check cluster phase and conditions for permanent failures
+		if err == nil {
+			if data.Cluster.Phase == ClusterPhaseFailed {
+				PrintToTTY("\n❌ Cluster phase is Failed — aborting early\n\n")
+				t.Fatalf("Cluster phase is 'Failed' — deployment cannot recover.\n\n"+
+					"Check cluster status:\n"+
+					"  kubectl --context %s -n %s get cluster %s -o yaml",
+					context, config.WorkloadClusterNamespace, provisionedClusterName)
+				return
+			}
+			if failErr := CheckK8sConditionsForPermanentFailure(data.Cluster.Conditions); failErr != nil {
+				PrintToTTY("\n❌ Permanent failure detected in Cluster conditions — aborting early\n")
+				PrintToTTY("   %v\n\n", failErr)
+				t.Fatalf("Permanent failure in Cluster conditions — deployment cannot recover.\n%v\n\n"+
+					"Check cluster status:\n"+
+					"  kubectl --context %s -n %s get cluster %s -o yaml",
+					failErr, context, config.WorkloadClusterNamespace, provisionedClusterName)
+				return
+			}
 		}
 
 		PrintToTTY("⏳ Cluster.InfrastructureReady: %s (elapsed %v)\n", status, elapsed.Round(time.Second))

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -617,11 +617,15 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 				if err := CheckConditionsForPermanentFailure(mp.Infrastructure.Conditions); err != nil {
 					PrintToTTY("\n❌ Permanent failure detected in %s conditions — aborting early\n", mp.Infrastructure.Kind)
 					PrintToTTY("   %v\n\n", err)
+					infraName := mp.Infrastructure.Name
+					if infraName == "" {
+						infraName = mp.Name
+					}
 					t.Fatalf("Permanent failure in %s conditions — deployment cannot recover.\n%v\n\n"+
 						"Check machine pool status:\n"+
 						"  kubectl --context %s -n %s get %s %s -o yaml",
 						mp.Infrastructure.Kind, err,
-						context, config.WorkloadClusterNamespace, strings.ToLower(mp.Infrastructure.Kind), mp.Name)
+						context, config.WorkloadClusterNamespace, strings.ToLower(mp.Infrastructure.Kind), infraName)
 					return
 				}
 			}

--- a/test/cluster_monitor.go
+++ b/test/cluster_monitor.go
@@ -258,6 +258,19 @@ func MonitorClusterUntilReady(t *testing.T, kubeContext, namespace, clusterName 
 
 		t.Logf("[%d] %s", iteration, data.FormatSummary())
 
+		// Fail-fast: check for terminal cluster phase
+		if data.Cluster.Phase == ClusterPhaseFailed {
+			return data, fmt.Errorf("cluster phase is 'Failed' — deployment cannot recover")
+		}
+
+		// Fail-fast: check conditions for permanent failures
+		if err := CheckK8sConditionsForPermanentFailure(data.ControlPlane.Conditions); err != nil {
+			return data, fmt.Errorf("permanent failure in %s: %w", data.ControlPlane.Kind, err)
+		}
+		if err := CheckK8sConditionsForPermanentFailure(data.Infrastructure.Conditions); err != nil {
+			return data, fmt.Errorf("permanent failure in %s: %w", data.Infrastructure.Kind, err)
+		}
+
 		if data.IsReady() {
 			t.Logf("Cluster is ready after %v", elapsed.Round(time.Second))
 			return data, nil
@@ -294,6 +307,16 @@ func MonitorControlPlaneUntilReady(t *testing.T, kubeContext, namespace, cluster
 		}
 
 		t.Logf("[%d] %s", iteration, data.FormatSummary())
+
+		// Fail-fast: check for terminal cluster phase
+		if data.Cluster.Phase == ClusterPhaseFailed {
+			return data, fmt.Errorf("cluster phase is 'Failed' — deployment cannot recover")
+		}
+
+		// Fail-fast: check control plane conditions for permanent failures
+		if err := CheckK8sConditionsForPermanentFailure(data.ControlPlane.Conditions); err != nil {
+			return data, fmt.Errorf("permanent failure in %s: %w", data.ControlPlane.Kind, err)
+		}
 
 		if data.IsControlPlaneReady() {
 			t.Logf("Control plane is ready after %v", elapsed.Round(time.Second))

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -889,6 +889,105 @@ func isWaitingCondition(cond ControlPlaneCondition) (bool, string) {
 	return false, ""
 }
 
+// permanentFailureReasons defines condition Reason values that indicate a permanent failure
+// (the controller has given up and will not retry). When a condition has Status=False and
+// one of these reasons WITHOUT matching any waitingPatterns, the deployment has failed
+// and waiting further is pointless.
+var permanentFailureReasons = []string{
+	"Failed",
+}
+
+// isPermanentFailure checks if a condition indicates a permanent, non-recoverable failure.
+// A condition is a permanent failure when:
+//  1. Status is "False"
+//  2. Reason matches one of the permanentFailureReasons
+//  3. The condition is NOT a transient waiting state (checked via isWaitingCondition)
+//
+// Returns true and a description string if the condition is a permanent failure.
+func isPermanentFailure(cond ControlPlaneCondition) (bool, string) {
+	if cond.Status != "False" {
+		return false, ""
+	}
+
+	// Check if the reason matches a known permanent failure
+	reasonMatches := false
+	for _, reason := range permanentFailureReasons {
+		if strings.EqualFold(cond.Reason, reason) {
+			reasonMatches = true
+			break
+		}
+	}
+
+	if !reasonMatches {
+		return false, ""
+	}
+
+	// Even with a failure reason, check if the message indicates a transient waiting state
+	if isWaiting, _ := isWaitingCondition(cond); isWaiting {
+		return false, ""
+	}
+
+	desc := fmt.Sprintf("%s: %s (%s)", cond.Type, cond.Status, cond.Reason)
+	if cond.Message != "" {
+		desc = fmt.Sprintf("%s - %s", desc, cond.Message)
+	}
+	return true, desc
+}
+
+// CheckConditionsForPermanentFailure inspects a list of conditions (as []interface{} from JSON)
+// and returns an error if any condition indicates a permanent failure.
+// This enables fail-fast behavior: instead of waiting for the full deployment timeout,
+// the test can abort immediately when a controller reports a terminal failure.
+func CheckConditionsForPermanentFailure(conditionsInterface []interface{}) error {
+	if len(conditionsInterface) == 0 {
+		return nil
+	}
+
+	// Convert []interface{} to []ControlPlaneCondition via JSON round-trip
+	conditionsJSON, err := json.Marshal(conditionsInterface)
+	if err != nil {
+		return nil // Don't fail-fast on parse errors, let the caller handle it
+	}
+
+	var conditions []ControlPlaneCondition
+	if err := json.Unmarshal(conditionsJSON, &conditions); err != nil {
+		return nil
+	}
+
+	return CheckTypedConditionsForPermanentFailure(conditions)
+}
+
+// CheckTypedConditionsForPermanentFailure inspects typed conditions for permanent failures.
+func CheckTypedConditionsForPermanentFailure(conditions []ControlPlaneCondition) error {
+	var failures []string
+	for _, cond := range conditions {
+		if failed, desc := isPermanentFailure(cond); failed {
+			failures = append(failures, desc)
+		}
+	}
+
+	if len(failures) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("permanent failure detected:\n  %s", strings.Join(failures, "\n  "))
+}
+
+// CheckK8sConditionsForPermanentFailure inspects K8sCondition (from ClusterMonitorData) for permanent failures.
+func CheckK8sConditionsForPermanentFailure(conditions []K8sCondition) error {
+	// Convert to ControlPlaneCondition format (same fields)
+	typed := make([]ControlPlaneCondition, len(conditions))
+	for i, c := range conditions {
+		typed[i] = ControlPlaneCondition{
+			Type:    c.Type,
+			Status:  c.Status,
+			Reason:  c.Reason,
+			Message: c.Message,
+		}
+	}
+	return CheckTypedConditionsForPermanentFailure(typed)
+}
+
 // FormatControlPlaneConditions formats control plane conditions for display (works for ARO, ROSA, etc.).
 // It parses the JSON output from kubectl and returns a formatted string showing
 // the status of each condition with visual indicators.

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -889,27 +889,18 @@ func isWaitingCondition(cond ControlPlaneCondition) (bool, string) {
 	return false, ""
 }
 
-// permanentFailureReasons defines condition Reason values that indicate a permanent failure
-// (the controller has given up and will not retry). When a condition has Status=False and
-// one of these reasons WITHOUT matching any waitingPatterns, the deployment has failed
-// and waiting further is pointless.
+// permanentFailureReasons lists Reason values where the controller has given up (will not retry).
 var permanentFailureReasons = []string{
 	"Failed",
 }
 
 // isPermanentFailure checks if a condition indicates a permanent, non-recoverable failure.
-// A condition is a permanent failure when:
-//  1. Status is "False"
-//  2. Reason matches one of the permanentFailureReasons
-//  3. The condition is NOT a transient waiting state (checked via isWaitingCondition)
-//
-// Returns true and a description string if the condition is a permanent failure.
+// Returns true and a description if Status=False with a terminal reason that isn't a waiting state.
 func isPermanentFailure(cond ControlPlaneCondition) (bool, string) {
 	if cond.Status != "False" {
 		return false, ""
 	}
 
-	// Check if the reason matches a known permanent failure
 	reasonMatches := false
 	for _, reason := range permanentFailureReasons {
 		if strings.EqualFold(cond.Reason, reason) {
@@ -922,7 +913,6 @@ func isPermanentFailure(cond ControlPlaneCondition) (bool, string) {
 		return false, ""
 	}
 
-	// Even with a failure reason, check if the message indicates a transient waiting state
 	if isWaiting, _ := isWaitingCondition(cond); isWaiting {
 		return false, ""
 	}
@@ -934,19 +924,16 @@ func isPermanentFailure(cond ControlPlaneCondition) (bool, string) {
 	return true, desc
 }
 
-// CheckConditionsForPermanentFailure inspects a list of conditions (as []interface{} from JSON)
-// and returns an error if any condition indicates a permanent failure.
-// This enables fail-fast behavior: instead of waiting for the full deployment timeout,
-// the test can abort immediately when a controller reports a terminal failure.
+// CheckConditionsForPermanentFailure inspects []interface{} conditions (from untyped JSON)
+// and returns an error if any indicates a permanent failure.
 func CheckConditionsForPermanentFailure(conditionsInterface []interface{}) error {
 	if len(conditionsInterface) == 0 {
 		return nil
 	}
 
-	// Convert []interface{} to []ControlPlaneCondition via JSON round-trip
 	conditionsJSON, err := json.Marshal(conditionsInterface)
 	if err != nil {
-		return nil // Don't fail-fast on parse errors, let the caller handle it
+		return nil
 	}
 
 	var conditions []ControlPlaneCondition
@@ -957,7 +944,6 @@ func CheckConditionsForPermanentFailure(conditionsInterface []interface{}) error
 	return CheckTypedConditionsForPermanentFailure(conditions)
 }
 
-// CheckTypedConditionsForPermanentFailure inspects typed conditions for permanent failures.
 func CheckTypedConditionsForPermanentFailure(conditions []ControlPlaneCondition) error {
 	var failures []string
 	for _, cond := range conditions {
@@ -973,9 +959,7 @@ func CheckTypedConditionsForPermanentFailure(conditions []ControlPlaneCondition)
 	return fmt.Errorf("permanent failure detected:\n  %s", strings.Join(failures, "\n  "))
 }
 
-// CheckK8sConditionsForPermanentFailure inspects K8sCondition (from ClusterMonitorData) for permanent failures.
 func CheckK8sConditionsForPermanentFailure(conditions []K8sCondition) error {
-	// Convert to ControlPlaneCondition format (same fields)
 	typed := make([]ControlPlaneCondition, len(conditions))
 	for i, c := range conditions {
 		typed[i] = ControlPlaneCondition{
@@ -1042,7 +1026,6 @@ func FormatControlPlaneConditionsFromParsed(conditionsInterface []interface{}) s
 		return "  (no conditions available)"
 	}
 
-	// Convert []interface{} to []ControlPlaneCondition via JSON round-trip
 	conditionsJSON, err := json.Marshal(conditionsInterface)
 	if err != nil {
 		return fmt.Sprintf("  (failed to marshal conditions: %v)", err)
@@ -1064,7 +1047,6 @@ func FormatNonTrueConditionsFromParsed(conditionsInterface []interface{}) string
 		return ""
 	}
 
-	// Convert []interface{} to []ControlPlaneCondition via JSON round-trip
 	conditionsJSON, err := json.Marshal(conditionsInterface)
 	if err != nil {
 		return ""

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -1081,6 +1081,209 @@ func TestIsWaitingCondition(t *testing.T) {
 	}
 }
 
+func TestIsPermanentFailure(t *testing.T) {
+	tests := []struct {
+		name           string
+		condition      ControlPlaneCondition
+		expectedFailed bool
+	}{
+		{
+			name: "AgentPoolsReady Failed - permanent failure",
+			condition: ControlPlaneCondition{
+				Type:   "AgentPoolsReady",
+				Status: "False",
+				Reason: "Failed",
+			},
+			expectedFailed: true,
+		},
+		{
+			name: "Failed reason with message",
+			condition: ControlPlaneCondition{
+				Type:    "NetworkInfrastructureReady",
+				Status:  "False",
+				Reason:  "Failed",
+				Message: "resource deployment failed permanently",
+			},
+			expectedFailed: true,
+		},
+		{
+			name: "Failed reason case insensitive",
+			condition: ControlPlaneCondition{
+				Type:   "SomeCondition",
+				Status: "False",
+				Reason: "failed",
+			},
+			expectedFailed: true,
+		},
+		{
+			name: "True status - never a failure",
+			condition: ControlPlaneCondition{
+				Type:   "Ready",
+				Status: "True",
+				Reason: "Failed",
+			},
+			expectedFailed: false,
+		},
+		{
+			name: "ReconciliationFailed - not a permanent failure reason",
+			condition: ControlPlaneCondition{
+				Type:    "ExternalAuthReady",
+				Status:  "False",
+				Reason:  "ReconciliationFailed",
+				Message: "something went wrong",
+			},
+			expectedFailed: false,
+		},
+		{
+			name: "Failed reason but waiting pattern in message - not permanent",
+			condition: ControlPlaneCondition{
+				Type:    "ExternalAuthReady",
+				Status:  "False",
+				Reason:  "Failed",
+				Message: "requires at least one ready machine pool",
+			},
+			expectedFailed: false,
+		},
+		{
+			name: "Failed reason but 'waiting for' in message - not permanent",
+			condition: ControlPlaneCondition{
+				Type:    "SomeCondition",
+				Status:  "False",
+				Reason:  "Failed",
+				Message: "waiting for dependency to be available",
+			},
+			expectedFailed: false,
+		},
+		{
+			name: "Empty reason - not a permanent failure",
+			condition: ControlPlaneCondition{
+				Type:   "Ready",
+				Status: "False",
+			},
+			expectedFailed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			failed, desc := isPermanentFailure(tt.condition)
+			if failed != tt.expectedFailed {
+				t.Errorf("isPermanentFailure() = %v, expected %v (desc: %q)", failed, tt.expectedFailed, desc)
+			}
+			if failed && desc == "" {
+				t.Error("isPermanentFailure() returned true but empty description")
+			}
+		})
+	}
+}
+
+func TestCheckConditionsForPermanentFailure(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []interface{}
+		expectErr  bool
+	}{
+		{
+			name:       "nil conditions",
+			conditions: nil,
+			expectErr:  false,
+		},
+		{
+			name:       "empty conditions",
+			conditions: []interface{}{},
+			expectErr:  false,
+		},
+		{
+			name: "all conditions True",
+			conditions: []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "True"},
+				map[string]interface{}{"type": "Available", "status": "True"},
+			},
+			expectErr: false,
+		},
+		{
+			name: "condition with Failed reason",
+			conditions: []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "True"},
+				map[string]interface{}{"type": "AgentPoolsReady", "status": "False", "reason": "Failed"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "ReconciliationFailed is not permanent",
+			conditions: []interface{}{
+				map[string]interface{}{
+					"type":    "ExternalAuthReady",
+					"status":  "False",
+					"reason":  "ReconciliationFailed",
+					"message": "something went wrong",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Failed reason with waiting pattern is not permanent",
+			conditions: []interface{}{
+				map[string]interface{}{
+					"type":    "SomeCondition",
+					"status":  "False",
+					"reason":  "Failed",
+					"message": "waiting for dependency",
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckConditionsForPermanentFailure(tt.conditions)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("CheckConditionsForPermanentFailure() error = %v, expectErr = %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+
+func TestCheckK8sConditionsForPermanentFailure(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []K8sCondition
+		expectErr  bool
+	}{
+		{
+			name:       "nil conditions",
+			conditions: nil,
+			expectErr:  false,
+		},
+		{
+			name: "permanent failure in K8sCondition",
+			conditions: []K8sCondition{
+				{Type: "Ready", Status: "True"},
+				{Type: "AgentPoolsReady", Status: "False", Reason: "Failed", Message: "agent pool creation failed"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "no permanent failures",
+			conditions: []K8sCondition{
+				{Type: "Ready", Status: "True"},
+				{Type: "InProgress", Status: "False", Reason: "Provisioning"},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckK8sConditionsForPermanentFailure(tt.conditions)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("CheckK8sConditionsForPermanentFailure() error = %v, expectErr = %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+
 func TestGetDomainPrefix(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Description

Implement fail-fast behavior for deployment monitoring. When a condition reports a permanent failure (e.g., `AgentPoolsReady: False (Failed)`), the test aborts immediately instead of waiting for the full deployment timeout (up to 60 minutes).

## Changes Made

- Add `isPermanentFailure()` detection in `helpers.go` — mirrors the existing `isWaitingCondition()` pattern. A condition is a permanent failure when `Status=False`, `Reason=Failed`, and the message doesn't match any transient waiting pattern
- Add `CheckConditionsForPermanentFailure()`, `CheckTypedConditionsForPermanentFailure()`, and `CheckK8sConditionsForPermanentFailure()` helpers for all condition formats used in the codebase
- Add fail-fast checks to all 6 polling loops in `05_deploy_crs_test.go`: `WaitForControlPlane`, `WaitForExternalAuthReady`, `VerifyInfrastructureResources`, `VerifyAROClusterReady`, `VerifyClusterProvisioned`, `VerifyClusterInfrastructureReady`
- Add fail-fast to 2 generic monitors in `cluster_monitor.go`: `MonitorClusterUntilReady`, `MonitorControlPlaneUntilReady`
- Add 17 unit tests covering all new functions
- Fix pre-existing `go fmt` issue in `01_check_dependencies_test.go`

## Configuration Changes

No new environment variables.

## Additional Notes

The fail-fast logic is conservative: only `Reason: "Failed"` triggers early abort, and even then, conditions with transient waiting patterns in their message (e.g., "waiting for dependency") are excluded. `ReconciliationFailed` and other reasons are not treated as permanent failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now abort earlier on permanent or terminal failures during cluster deployment and monitoring to avoid long timeout waits.
  * Added reusable permanent-failure detection and checks for control-plane and infrastructure conditions used by monitoring and polling flows.
  * Expanded unit tests to validate permanent-failure classification and improve diagnostics for provisioning and readiness failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->