### PR TITLE
security: pin CI tool versions to prevent supply chain attacks

### DIFF
--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -65,8 +65,12 @@ jobs:
           echo "## ❌ Analysis failed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "CodeQL analysis encountered errors. Check the workflow logs for details." >> $GITHUB_STEP_SUMMARY
-        else
+        elif [ "${{ steps.analyze.outcome }}" = "success" ]; then
           echo "CodeQL semantic code analysis completed for **Go**." >> $GITHUB_STEP_SUMMARY
+        else
+          echo "## ❌ Workflow failed before analysis could run" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "A prerequisite step failed. Check the workflow logs for details." >> $GITHUB_STEP_SUMMARY
         fi
 
         echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -52,20 +52,23 @@ jobs:
 
     - name: Generate summary
       if: always()
+      env:
+        BUILD_OUTCOME: ${{ steps.build.outcome }}
+        ANALYZE_OUTCOME: ${{ steps.analyze.outcome }}
       run: |
         echo "# CodeQL Analysis Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
-        if [ "${{ steps.build.outcome }}" = "failure" ]; then
+        if [ "$BUILD_OUTCOME" = "failure" ]; then
           echo "## ⚠️ Build failed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "The Go build step failed. CodeQL analysis could not complete." >> $GITHUB_STEP_SUMMARY
           echo "Check the workflow logs for build errors." >> $GITHUB_STEP_SUMMARY
-        elif [ "${{ steps.analyze.outcome }}" = "failure" ]; then
+        elif [ "$ANALYZE_OUTCOME" = "failure" ]; then
           echo "## ❌ Analysis failed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "CodeQL analysis encountered errors. Check the workflow logs for details." >> $GITHUB_STEP_SUMMARY
-        elif [ "${{ steps.analyze.outcome }}" = "success" ]; then
+        elif [ "$ANALYZE_OUTCOME" = "success" ]; then
           echo "CodeQL semantic code analysis completed for **Go**." >> $GITHUB_STEP_SUMMARY
         else
           echo "## ❌ Workflow failed before analysis could run" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -1,0 +1,62 @@
+name: Security CodeQL
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    # Run weekly on Monday at 4 AM UTC
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  issues: write
+
+jobs:
+  codeql:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      with:
+        languages: go
+        queries: security-and-quality
+
+    - name: Build
+      run: go build ./...
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      with:
+        category: '/language:go'
+
+    - name: Generate summary
+      if: always()
+      run: |
+        echo "# CodeQL Analysis Results" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "CodeQL semantic code analysis completed for **Go**." >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Results are available in the [Security tab](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/security/code-scanning)." >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### What CodeQL checks" >> $GITHUB_STEP_SUMMARY
+        echo "- SQL injection, XSS, and other injection flaws" >> $GITHUB_STEP_SUMMARY
+        echo "- Path traversal and unsafe file operations" >> $GITHUB_STEP_SUMMARY
+        echo "- Incorrect error handling" >> $GITHUB_STEP_SUMMARY
+        echo "- Resource leaks and race conditions" >> $GITHUB_STEP_SUMMARY
+        echo "- Cryptographic misuse" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -10,10 +10,13 @@ on:
     - cron: '0 4 * * 1'
   workflow_dispatch:
 
+# Note: CodeQL advanced setup requires disabling the "Default setup" in
+# Settings > Code security > Code scanning. Otherwise SARIF uploads will fail with:
+# "CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled"
+
 permissions:
   contents: read
   security-events: write
-  issues: write
 
 jobs:
   codeql:
@@ -39,18 +42,33 @@ jobs:
 
     - name: Build
       run: go build ./...
+      id: build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
       with:
         category: '/language:go'
+      id: analyze
 
     - name: Generate summary
       if: always()
       run: |
         echo "# CodeQL Analysis Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "CodeQL semantic code analysis completed for **Go**." >> $GITHUB_STEP_SUMMARY
+
+        if [ "${{ steps.build.outcome }}" = "failure" ]; then
+          echo "## ⚠️ Build failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The Go build step failed. CodeQL analysis could not complete." >> $GITHUB_STEP_SUMMARY
+          echo "Check the workflow logs for build errors." >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ steps.analyze.outcome }}" = "failure" ]; then
+          echo "## ❌ Analysis failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "CodeQL analysis encountered errors. Check the workflow logs for details." >> $GITHUB_STEP_SUMMARY
+        else
+          echo "CodeQL semantic code analysis completed for **Go**." >> $GITHUB_STEP_SUMMARY
+        fi
+
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Results are available in the [Security tab](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/security/code-scanning)." >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -58,5 +76,5 @@ jobs:
         echo "- SQL injection, XSS, and other injection flaws" >> $GITHUB_STEP_SUMMARY
         echo "- Path traversal and unsafe file operations" >> $GITHUB_STEP_SUMMARY
         echo "- Incorrect error handling" >> $GITHUB_STEP_SUMMARY
-        echo "- Resource leaks and race conditions" >> $GITHUB_STEP_SUMMARY
+        echo "- Resource leaks" >> $GITHUB_STEP_SUMMARY
         echo "- Cryptographic misuse" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/security-gosec.yml
+++ b/.github/workflows/security-gosec.yml
@@ -198,7 +198,7 @@ jobs:
             echo "go test ./..."
             echo ""
             echo "# Run gosec locally"
-            echo "go install github.com/securego/gosec/v2/cmd/gosec@latest"
+            echo "go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0"
             echo "gosec ./..."
             echo "\`\`\`"
             echo ""

--- a/.github/workflows/security-govulncheck.yml
+++ b/.github/workflows/security-govulncheck.yml
@@ -32,7 +32,8 @@ jobs:
         cache: true
 
     - name: Install govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      # Pin to specific version to prevent supply chain attacks (update manually or via Renovate)
+      run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
     - name: Run govulncheck
       run: |

--- a/.github/workflows/security-nancy.yml
+++ b/.github/workflows/security-nancy.yml
@@ -40,8 +40,8 @@ jobs:
     - name: Run nancy dependency scanner
       id: nancy-scan
       run: |
-        # Install nancy
-        go install github.com/sonatype-nexus-community/nancy@latest
+        # Install nancy — pin to specific version to prevent supply chain attacks
+        go install github.com/sonatype-nexus-community/nancy@v1.2.0
 
         # Run nancy and capture output
         set +e
@@ -236,7 +236,7 @@ jobs:
             echo ""
             echo "\`\`\`bash"
             echo "# Install nancy"
-            echo "go install github.com/sonatype-nexus-community/nancy@latest"
+            echo "go install github.com/sonatype-nexus-community/nancy@v1.2.0"
             echo ""
             echo "# Generate dependency list"
             echo "go list -json -deps ./... > go.list"

--- a/.github/workflows/security-scorecard.yml
+++ b/.github/workflows/security-scorecard.yml
@@ -8,7 +8,8 @@ on:
     - cron: '30 4 * * 1'
   workflow_dispatch:
 
-# Scorecard needs read access to repo contents and write access to publish results
+# Scorecard requires read-all at workflow level per upstream recommendation:
+# https://github.com/ossf/scorecard-action#workflow-restrictions
 permissions: read-all
 
 jobs:
@@ -30,6 +31,7 @@ jobs:
 
     - name: Run OpenSSF Scorecard
       uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+      id: scorecard
       with:
         results_file: scorecard-results.sarif
         results_format: sarif
@@ -40,6 +42,7 @@ jobs:
       uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
       with:
         sarif_file: scorecard-results.sarif
+      continue-on-error: true
 
     - name: Upload Scorecard results (artifact)
       if: always()
@@ -48,13 +51,22 @@ jobs:
         name: scorecard-results
         path: scorecard-results.sarif
         retention-days: 30
+      continue-on-error: true
 
     - name: Generate summary
       if: always()
       run: |
         echo "# OpenSSF Scorecard Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "Supply chain security assessment completed." >> $GITHUB_STEP_SUMMARY
+
+        if [ "${{ steps.scorecard.outcome }}" = "failure" ]; then
+          echo "## ❌ Scorecard assessment failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The OpenSSF Scorecard action encountered errors. Check the workflow logs for details." >> $GITHUB_STEP_SUMMARY
+        else
+          echo "Supply chain security assessment completed." >> $GITHUB_STEP_SUMMARY
+        fi
+
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Results are available in the [Security tab](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/security/code-scanning)." >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/security-scorecard.yml
+++ b/.github/workflows/security-scorecard.yml
@@ -64,8 +64,12 @@ jobs:
           echo "## ❌ Scorecard assessment failed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "The OpenSSF Scorecard action encountered errors. Check the workflow logs for details." >> $GITHUB_STEP_SUMMARY
-        else
+        elif [ "${{ steps.scorecard.outcome }}" = "success" ]; then
           echo "Supply chain security assessment completed." >> $GITHUB_STEP_SUMMARY
+        else
+          echo "## ❌ Scorecard assessment was skipped" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "A prerequisite step failed. Scorecard did not run." >> $GITHUB_STEP_SUMMARY
         fi
 
         echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/security-scorecard.yml
+++ b/.github/workflows/security-scorecard.yml
@@ -1,0 +1,69 @@
+name: Security Scorecard
+
+on:
+  push:
+    branches: [ "main" ]
+  schedule:
+    # Run weekly on Monday at 4:30 AM UTC
+    - cron: '30 4 * * 1'
+  workflow_dispatch:
+
+# Scorecard needs read access to repo contents and write access to publish results
+permissions: read-all
+
+jobs:
+  scorecard:
+    name: OpenSSF Scorecard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+
+    - name: Run OpenSSF Scorecard
+      uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+      with:
+        results_file: scorecard-results.sarif
+        results_format: sarif
+        publish_results: true
+
+    - name: Upload Scorecard results (SARIF)
+      if: always()
+      uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      with:
+        sarif_file: scorecard-results.sarif
+
+    - name: Upload Scorecard results (artifact)
+      if: always()
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: scorecard-results
+        path: scorecard-results.sarif
+        retention-days: 30
+
+    - name: Generate summary
+      if: always()
+      run: |
+        echo "# OpenSSF Scorecard Results" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Supply chain security assessment completed." >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Results are available in the [Security tab](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/security/code-scanning)." >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### What Scorecard checks" >> $GITHUB_STEP_SUMMARY
+        echo "- Pinned dependencies and GitHub Actions" >> $GITHUB_STEP_SUMMARY
+        echo "- Branch protection rules" >> $GITHUB_STEP_SUMMARY
+        echo "- SAST tool integration" >> $GITHUB_STEP_SUMMARY
+        echo "- Code review practices" >> $GITHUB_STEP_SUMMARY
+        echo "- Vulnerability disclosure policy" >> $GITHUB_STEP_SUMMARY
+        echo "- License and contributor requirements" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "View the badge and detailed results at [OpenSSF Scorecard Viewer](https://scorecard.dev/viewer/?uri=github.com/${GITHUB_REPOSITORY})." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/security-scorecard.yml
+++ b/.github/workflows/security-scorecard.yml
@@ -8,8 +8,9 @@ on:
     - cron: '30 4 * * 1'
   workflow_dispatch:
 
-# Scorecard requires read-all at workflow level per upstream recommendation:
+# Scorecard requires no workflow-level write permissions per upstream docs:
 # https://github.com/ossf/scorecard-action#workflow-restrictions
+# Using read-all satisfies this constraint while granting read access for all scopes.
 permissions: read-all
 
 jobs:

--- a/.github/workflows/security-scorecard.yml
+++ b/.github/workflows/security-scorecard.yml
@@ -56,15 +56,17 @@ jobs:
 
     - name: Generate summary
       if: always()
+      env:
+        SCORECARD_OUTCOME: ${{ steps.scorecard.outcome }}
       run: |
         echo "# OpenSSF Scorecard Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
-        if [ "${{ steps.scorecard.outcome }}" = "failure" ]; then
+        if [ "$SCORECARD_OUTCOME" = "failure" ]; then
           echo "## ❌ Scorecard assessment failed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "The OpenSSF Scorecard action encountered errors. Check the workflow logs for details." >> $GITHUB_STEP_SUMMARY
-        elif [ "${{ steps.scorecard.outcome }}" = "success" ]; then
+        elif [ "$SCORECARD_OUTCOME" = "success" ]; then
           echo "Supply chain security assessment completed." >> $GITHUB_STEP_SUMMARY
         else
           echo "## ❌ Scorecard assessment was skipped" >> $GITHUB_STEP_SUMMARY

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -49,7 +49,7 @@ When adding new dependencies:
 go get github.com/example/package@v1.2.3
 
 # Run security checks
-go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
 
 # Commit changes
 git add go.mod go.sum
@@ -117,13 +117,13 @@ The repository includes multiple security scanning workflows:
 
 ```bash
 # Official Go vulnerability checker
-go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
 
 # Nancy (Sonatype OSS Index) - requires API token for full access
-go list -json -m all | go run github.com/sonatype-nexus-community/nancy@latest sleuth
+go list -json -m all | go run github.com/sonatype-nexus-community/nancy@v1.2.0 sleuth
 
 # gosec static analysis
-go run github.com/securego/gosec/v2/cmd/gosec@latest ./...
+go run github.com/securego/gosec/v2/cmd/gosec@v2.25.0 ./...
 ```
 
 ### Dependabot
@@ -178,7 +178,7 @@ go mod tidy
 make test
 
 # Run security scans
-go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
 
 # Commit if all passes
 git add go.mod go.sum
@@ -197,7 +197,7 @@ For critical vulnerabilities:
    ```
 3. Run security scan to verify fix:
    ```bash
-   go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+   go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
    ```
 4. Run tests:
    ```bash

--- a/docs/SECURITY_REVIEW.md
+++ b/docs/SECURITY_REVIEW.md
@@ -359,11 +359,11 @@ if err := os.WriteFile(kubeconfigPath, decoded, 0600); err != nil {
 
 ```bash
 # Run gosec locally
-go install github.com/securego/gosec/v2/cmd/gosec@latest
+go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
 gosec ./...
 
 # Run govulncheck locally
-go install golang.org/x/vuln/cmd/govulncheck@latest
+go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 govulncheck ./...
 
 # Check for secrets (requires git-secrets)


### PR DESCRIPTION
## Description

Pin CI tools (govulncheck, nancy, gosec) to specific versions instead of using @latest to prevent supply chain attacks. A compromised release would be pulled automatically with @latest.

Resolves ARO-25506

## Changes Made

- Pin govulncheck from @latest to @v1.1.4 in security-govulncheck.yml
- Pin nancy from @latest to @v1.2.0 in security-nancy.yml
- Pin gosec from @latest to @v2.25.0 in issue template echo (actual gosec run already uses SHA-pinned GitHub Action)
- Update all @latest references in docs/DEPENDENCIES.md and docs/SECURITY_REVIEW.md

## Configuration Changes

No new environment variables.

## Additional Notes

- Dependabot cannot track `go install` commands in workflow scripts, so these versions must be updated manually or via Renovate
- `kind@latest` references in user-facing installation docs were intentionally left unchanged (not a CI tool)
- The gosec GitHub Action was already SHA-pinned (`securego/gosec@48e8716...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security scanning infrastructure with automated CodeQL and Scorecard workflows for comprehensive vulnerability and code quality analysis.
  * Pinned security scanning tool versions to ensure deterministic and reproducible security assessments across CI/CD pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->