### PR TITLE
fix(rosa): update OCP version and fix env var mismatch for ROSA gen.sh (ARO-25886)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,7 +369,7 @@ export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests` for ARO, `capa-tests` for ROSA). Keep short as cloud providers may have length limits (e.g., Azure node pools max 15 chars including suffixes)
 - `CS_CLUSTER_NAME` - **C**luster **S**ervice cluster name prefix used for YAML generation and Azure resource naming. If not set, auto-generates a unique value: `${CAPI_USER}-${random5hex}` (e.g., `cate-a1b2c`). This enables parallel test runs against the same Azure subscription without resource name collisions. The Azure resource group will be named `${CS_CLUSTER_NAME}-resgroup`. This prefix is also used for the ExternalAuth resource ID (max 15 chars including `-ea` suffix, so CS_CLUSTER_NAME max 12 chars). When resuming a multi-phase test run, the prefix is automatically loaded from the deployment state file.
-- `OCP_VERSION` - OpenShift version (default: `4.21`)
+- `OCP_VERSION` - OpenShift version (default: `4.18`)
 - `REGION` - Azure region (default: `uksouth`)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`). Used in Azure resource tags and domain prefix validation, but not included in the auto-generated `CS_CLUSTER_NAME`.
 - `CAPI_USER` - User identifier for domain prefix (default: `cate`). Used as the base for auto-generated `CS_CLUSTER_NAME` (e.g., `cate-a1b2c`). Must be short enough that `${CAPI_USER}-${DEPLOYMENT_ENV}` does not exceed 15 characters.
@@ -403,8 +403,8 @@ export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 This is validated during Check Dependencies (phase 1) to prevent late deployment failures.
 
 ### Test Behavior
-- `DEPLOYMENT_TIMEOUT` - Control plane deployment timeout (default: `45m`, format: Go duration like `1h`, `45m`)
-- `DEPLOYMENT_STALL_TIMEOUT` - Stall detection timeout: if no progress (control plane state, machine pool replicas, infrastructure resources) for this duration, the test fails early instead of waiting for the full deployment timeout (default: `30m`, set to `0` to disable)
+- `DEPLOYMENT_TIMEOUT` - Control plane deployment timeout (default: `60m`, format: Go duration like `1h`, `45m`)
+- `DEPLOYMENT_STALL_TIMEOUT` - Stall detection timeout: if no progress (control plane ready status, machine pool replicas, infrastructure resources) for this duration, the test fails early instead of waiting for the full deployment timeout (default: `30m`, set to `0` to disable)
 
 ### MCE Component Management
 - `MCE_AUTO_ENABLE` - Auto-enable MCE CAPI/CAPZ components if not found on external cluster (default: `true` when `USE_KUBECONFIG` is set)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -174,7 +174,7 @@ See `docs/INTEGRATION.md` for detailed integration patterns.
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests-cluster` for ARO, `capa-tests-cluster` for ROSA)
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPI_USER}-${DEPLOYMENT_ENV}`). The Azure resource group will be named `${CS_CLUSTER_NAME}-resgroup`.
-- `OCP_VERSION` - OpenShift version (default: `4.21`)
+- `OCP_VERSION` - OpenShift version (default: `4.18`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID (required for deployment)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ When using `INFRA_PROVIDER=rosa`, the following credentials are required:
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests` for ARO, `capa-tests` for ROSA). Keep short due to cloud provider length limits
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation and Azure resource naming. If not set, auto-generates a unique value: `${CAPI_USER}-${random5hex}` (e.g., `cate-a1b2c`) to enable parallel test runs. The Azure resource group will be named `${CS_CLUSTER_NAME}-resgroup`. Max 12 characters (ExternalAuth ID constraint).
-- `OCP_VERSION` - OpenShift version (default: `4.20`)
+- `OCP_VERSION` - OpenShift version (default: `4.18`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`). Used in Azure resource tags and domain prefix validation.

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -217,7 +217,7 @@ MANAGEMENT_CLUSTER_NAME=capz-tests-stage  # For running tests (default for ARO; 
 KIND_CLUSTER_NAME=capz-tests-stage        # For direct script usage (advanced)
 CLUSTER_NAME=capz-tests-cluster           # Default for ARO; capa-tests-cluster for ROSA
 CS_CLUSTER_NAME=cate-stage  # Resource group will be ${CS_CLUSTER_NAME}-resgroup
-OCP_VERSION=4.21
+OCP_VERSION=4.18
 REGION=uksouth
 DEPLOYMENT_ENV=stage
 

--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -202,6 +202,9 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 	SetEnvVar(t, config.RegionEnvVar, config.Region) // Provider-specific: REGION for ARO, AWS_REGION for ROSA
 	SetEnvVar(t, "CS_CLUSTER_NAME", config.ClusterNamePrefix)
 	SetEnvVar(t, "OCP_VERSION", config.OCPVersion)
+	// ROSA gen.sh reads OPENSHIFT_VERSION (not OCP_VERSION) for the cluster version.
+	// Set both so the test's configured version reaches the generation script.
+	SetEnvVar(t, "OPENSHIFT_VERSION", config.OCPVersion)
 	// Pass namespace as NAMESPACE env var for YAML generation script
 	// This namespace will be embedded in generated YAMLs for Azure resources
 	SetEnvVar(t, "NAMESPACE", config.WorkloadClusterNamespace)

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -747,6 +747,10 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 		}
 
 		if stallEnabled {
+			currentCPState := ""
+			if status.ControlPlane.State != nil {
+				currentCPState = *status.ControlPlane.State
+			}
 			currentMPReplicas := 0
 			if len(status.MachinePools) > 0 {
 				// Only the first MachinePool is tracked — ARO/ROSA use a single pool
@@ -760,6 +764,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 
 			current := stallProgressState{
 				cpReady:            controlPlaneReady,
+				cpState:            currentCPState,
 				mpReadyReplicas:    currentMPReplicas,
 				infraResourceReady: infraReady,
 			}
@@ -1432,6 +1437,7 @@ func toJSONArray(items []string) (string, error) {
 // Uses only comparable types so Go's == operator works for change detection.
 type stallProgressState struct {
 	cpReady            bool
+	cpState            string
 	mpReadyReplicas    int
 	infraResourceReady int
 }
@@ -1449,13 +1455,14 @@ func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Durati
 	}
 
 	PrintToTTY("\n❌ Deployment stalled: no progress for %v\n", stallDuration.Round(time.Second))
-	PrintToTTY("   Last state: ControlPlane.Ready=%v, MachinePool.ReadyReplicas=%d, InfraResources=%d\n\n",
-		lastProgress.cpReady, lastProgress.mpReadyReplicas, lastProgress.infraResourceReady)
+	PrintToTTY("   Last state: ControlPlane.Ready=%v, State=%q, MachinePool.ReadyReplicas=%d, InfraResources=%d\n\n",
+		lastProgress.cpReady, lastProgress.cpState, lastProgress.mpReadyReplicas, lastProgress.infraResourceReady)
 
 	CollectAndDumpInfraDiagnostics(t, context, namespace, clusterName)
 
 	t.Fatalf("Deployment stalled: no progress for %v (stall timeout: %v).\n"+
 		"  ControlPlane ready: %v\n"+
+		"  ControlPlane state: %s\n"+
 		"  MachinePool ready replicas: %d\n"+
 		"  Infrastructure resources ready: %d\n\n"+
 		"This usually indicates an infrastructure-side issue (e.g., ARO HCP stuck in Reconciling).\n"+
@@ -1463,6 +1470,6 @@ func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Durati
 		"To increase stall timeout: export DEPLOYMENT_STALL_TIMEOUT=45m\n"+
 		"To disable stall detection: export DEPLOYMENT_STALL_TIMEOUT=0",
 		stallDuration.Round(time.Second), stallTimeout,
-		lastProgress.cpReady, lastProgress.mpReadyReplicas,
+		lastProgress.cpReady, lastProgress.cpState, lastProgress.mpReadyReplicas,
 		lastProgress.infraResourceReady)
 }

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -752,9 +752,12 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 				currentCPState = *status.ControlPlane.State
 			}
 			currentMPReplicas := 0
+			currentMPState := ""
 			if len(status.MachinePools) > 0 {
-				// Only the first MachinePool is tracked — ARO/ROSA use a single pool
 				currentMPReplicas = status.MachinePools[0].ReadyReplicas
+				if status.MachinePools[0].Infrastructure != nil {
+					currentMPState = status.MachinePools[0].Infrastructure.ProvisioningState
+				}
 			}
 			infraReady := 0
 			infraTotal := 0
@@ -768,6 +771,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 				cpReady:             controlPlaneReady,
 				cpState:             currentCPState,
 				mpReadyReplicas:     currentMPReplicas,
+				mpProvisioningState: currentMPState,
 				infraTotalResources: infraTotal,
 				infraResourceReady:  infraReady,
 			}
@@ -1442,6 +1446,7 @@ type stallProgressState struct {
 	cpReady             bool
 	cpState             string
 	mpReadyReplicas     int
+	mpProvisioningState string
 	infraTotalResources int
 	infraResourceReady  int
 }
@@ -1459,8 +1464,9 @@ func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Durati
 	}
 
 	PrintToTTY("\n❌ Deployment stalled: no progress for %v\n", stallDuration.Round(time.Second))
-	PrintToTTY("   Last state: ControlPlane.Ready=%v, State=%q, MachinePool.ReadyReplicas=%d, InfraResources=%d/%d\n\n",
-		lastProgress.cpReady, lastProgress.cpState, lastProgress.mpReadyReplicas, lastProgress.infraResourceReady, lastProgress.infraTotalResources)
+	PrintToTTY("   Last state: ControlPlane.Ready=%v, State=%q, MachinePool.ReadyReplicas=%d, ProvisioningState=%q, InfraResources=%d/%d\n\n",
+		lastProgress.cpReady, lastProgress.cpState, lastProgress.mpReadyReplicas, lastProgress.mpProvisioningState,
+		lastProgress.infraResourceReady, lastProgress.infraTotalResources)
 
 	CollectAndDumpInfraDiagnostics(t, context, namespace, clusterName)
 
@@ -1468,12 +1474,14 @@ func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Durati
 		"  ControlPlane ready: %v\n"+
 		"  ControlPlane state: %s\n"+
 		"  MachinePool ready replicas: %d\n"+
+		"  MachinePool provisioning state: %s\n"+
 		"  Infrastructure resources: %d/%d\n\n"+
 		"This usually indicates an infrastructure-side issue (e.g., ARO HCP stuck in Reconciling).\n"+
 		"Check the cloud provider's service health dashboard.\n\n"+
 		"To increase stall timeout: export DEPLOYMENT_STALL_TIMEOUT=45m\n"+
 		"To disable stall detection: export DEPLOYMENT_STALL_TIMEOUT=0",
 		stallDuration.Round(time.Second), stallTimeout,
-		lastProgress.cpReady, lastProgress.cpState, lastProgress.mpReadyReplicas,
+		lastProgress.cpReady, lastProgress.cpState,
+		lastProgress.mpReadyReplicas, lastProgress.mpProvisioningState,
 		lastProgress.infraResourceReady, lastProgress.infraTotalResources)
 }

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -757,16 +757,19 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 				currentMPReplicas = status.MachinePools[0].ReadyReplicas
 			}
 			infraReady := 0
+			infraTotal := 0
 			infraStatus := GetInfrastructureResourceStatusFromParsed(status.Infrastructure.Resources, status.Infrastructure.Conditions)
 			if infraStatus.TotalResources > 0 {
+				infraTotal = infraStatus.TotalResources
 				infraReady = infraStatus.ReadyResources
 			}
 
 			current := stallProgressState{
-				cpReady:            controlPlaneReady,
-				cpState:            currentCPState,
-				mpReadyReplicas:    currentMPReplicas,
-				infraResourceReady: infraReady,
+				cpReady:             controlPlaneReady,
+				cpState:             currentCPState,
+				mpReadyReplicas:     currentMPReplicas,
+				infraTotalResources: infraTotal,
+				infraResourceReady:  infraReady,
 			}
 
 			if current != lastProgress {
@@ -1436,10 +1439,11 @@ func toJSONArray(items []string) (string, error) {
 // stallProgressState tracks deployment progress for stall detection.
 // Uses only comparable types so Go's == operator works for change detection.
 type stallProgressState struct {
-	cpReady            bool
-	cpState            string
-	mpReadyReplicas    int
-	infraResourceReady int
+	cpReady             bool
+	cpState             string
+	mpReadyReplicas     int
+	infraTotalResources int
+	infraResourceReady  int
 }
 
 // checkStallTimeout fails the test if no deployment progress has been made within the stall timeout.
@@ -1455,8 +1459,8 @@ func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Durati
 	}
 
 	PrintToTTY("\n❌ Deployment stalled: no progress for %v\n", stallDuration.Round(time.Second))
-	PrintToTTY("   Last state: ControlPlane.Ready=%v, State=%q, MachinePool.ReadyReplicas=%d, InfraResources=%d\n\n",
-		lastProgress.cpReady, lastProgress.cpState, lastProgress.mpReadyReplicas, lastProgress.infraResourceReady)
+	PrintToTTY("   Last state: ControlPlane.Ready=%v, State=%q, MachinePool.ReadyReplicas=%d, InfraResources=%d/%d\n\n",
+		lastProgress.cpReady, lastProgress.cpState, lastProgress.mpReadyReplicas, lastProgress.infraResourceReady, lastProgress.infraTotalResources)
 
 	CollectAndDumpInfraDiagnostics(t, context, namespace, clusterName)
 
@@ -1464,12 +1468,12 @@ func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Durati
 		"  ControlPlane ready: %v\n"+
 		"  ControlPlane state: %s\n"+
 		"  MachinePool ready replicas: %d\n"+
-		"  Infrastructure resources ready: %d\n\n"+
+		"  Infrastructure resources: %d/%d\n\n"+
 		"This usually indicates an infrastructure-side issue (e.g., ARO HCP stuck in Reconciling).\n"+
 		"Check the cloud provider's service health dashboard.\n\n"+
 		"To increase stall timeout: export DEPLOYMENT_STALL_TIMEOUT=45m\n"+
 		"To disable stall detection: export DEPLOYMENT_STALL_TIMEOUT=0",
 		stallDuration.Round(time.Second), stallTimeout,
 		lastProgress.cpReady, lastProgress.cpState, lastProgress.mpReadyReplicas,
-		lastProgress.infraResourceReady)
+		lastProgress.infraResourceReady, lastProgress.infraTotalResources)
 }

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -538,19 +538,17 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 	controlPlaneReady := false
 	machinePoolReady := false
 
-	// Stall detection: fail fast when deployment makes no progress
 	stallTimeout := config.DeploymentStallTimeout
 	stallEnabled := stallTimeout > 0
 	lastProgressTime := startTime
-	// Track state for stall detection (detect when nothing changes)
-	type progressState struct {
-		cpReady            bool
-		mpReadyReplicas    int
-		infraResourceReady int
-	}
-	lastProgress := progressState{}
+	lastProgress := stallProgressState{}
 	if stallEnabled {
-		PrintToTTY("Stall detection: enabled (timeout: %v)\n\n", stallTimeout)
+		if stallTimeout >= timeout {
+			PrintToTTY("Stall detection: enabled (timeout: %v) — WARNING: stall timeout >= deployment timeout (%v), stall detection will never trigger\n\n",
+				stallTimeout, timeout)
+		} else {
+			PrintToTTY("Stall detection: enabled (timeout: %v)\n\n", stallTimeout)
+		}
 	}
 
 	iteration := 0
@@ -592,6 +590,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 		jsonOutput, err := RunCommandQuiet(t, monitorScript, "--context", context, config.WorkloadClusterNamespace, provisionedClusterName)
 		if err != nil {
 			PrintToTTY("[%d] ⚠️  monitor-cluster-json.sh failed: %v\n", iteration, err)
+			checkStallTimeout(t, stallEnabled, stallTimeout, lastProgressTime, lastProgress, context, config.WorkloadClusterNamespace, provisionedClusterName)
 			time.Sleep(pollInterval)
 			continue
 		}
@@ -600,6 +599,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 		var status ClusterMonitorStatus
 		if err := json.Unmarshal([]byte(jsonOutput), &status); err != nil {
 			PrintToTTY("[%d] ⚠️  Failed to parse monitor output: %v\n", iteration, err)
+			checkStallTimeout(t, stallEnabled, stallTimeout, lastProgressTime, lastProgress, context, config.WorkloadClusterNamespace, provisionedClusterName)
 			time.Sleep(pollInterval)
 			continue
 		}
@@ -746,18 +746,19 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 			}
 		}
 
-		// Stall detection: check if meaningful progress was made since last iteration
 		if stallEnabled {
-			// Build current state snapshot
 			currentMPReplicas := 0
 			if len(status.MachinePools) > 0 {
+				// Only the first MachinePool is tracked — ARO/ROSA use a single pool
 				currentMPReplicas = status.MachinePools[0].ReadyReplicas
 			}
 			infraReady := 0
 			infraStatus := GetInfrastructureResourceStatusFromParsed(status.Infrastructure.Resources, status.Infrastructure.Conditions)
-			infraReady = infraStatus.ReadyResources
+			if infraStatus.TotalResources > 0 {
+				infraReady = infraStatus.ReadyResources
+			}
 
-			current := progressState{
+			current := stallProgressState{
 				cpReady:            controlPlaneReady,
 				mpReadyReplicas:    currentMPReplicas,
 				infraResourceReady: infraReady,
@@ -768,28 +769,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 				lastProgress = current
 			}
 
-			stallDuration := time.Since(lastProgressTime)
-			if stallDuration > stallTimeout {
-				PrintToTTY("\n❌ Deployment stalled: no progress for %v\n", stallDuration.Round(time.Second))
-				PrintToTTY("   Last state: ControlPlane.Ready=%v, MachinePool.ReadyReplicas=%d, InfraResources=%d/%d\n\n",
-					current.cpReady, current.mpReadyReplicas, infraReady, infraStatus.TotalResources)
-
-				// Dump diagnostics for not-ready infrastructure resources
-				CollectAndDumpInfraDiagnostics(t, context, config.WorkloadClusterNamespace, provisionedClusterName)
-
-				t.Fatalf("Deployment stalled: no progress for %v (stall timeout: %v).\n"+
-					"  ControlPlane ready: %v\n"+
-					"  MachinePool ready replicas: %d\n"+
-					"  Infrastructure resources: %d/%d\n\n"+
-					"This usually indicates an infrastructure-side issue (e.g., ARO HCP stuck in Reconciling).\n"+
-					"Check the cloud provider's service health dashboard.\n\n"+
-					"To increase stall timeout: export DEPLOYMENT_STALL_TIMEOUT=45m\n"+
-					"To disable stall detection: export DEPLOYMENT_STALL_TIMEOUT=0",
-					stallDuration.Round(time.Second), stallTimeout,
-					current.cpReady, current.mpReadyReplicas,
-					infraReady, infraStatus.TotalResources)
-				return
-			}
+			checkStallTimeout(t, stallEnabled, stallTimeout, lastProgressTime, lastProgress, context, config.WorkloadClusterNamespace, provisionedClusterName)
 		}
 
 		// Both ready — done
@@ -1446,4 +1426,43 @@ func toJSONArray(items []string) (string, error) {
 		return "", fmt.Errorf("failed to marshal tag array: %w", err)
 	}
 	return string(data), nil
+}
+
+// stallProgressState tracks deployment progress for stall detection.
+// Uses only comparable types so Go's == operator works for change detection.
+type stallProgressState struct {
+	cpReady            bool
+	mpReadyReplicas    int
+	infraResourceReady int
+}
+
+// checkStallTimeout fails the test if no deployment progress has been made within the stall timeout.
+// Safe to call from error-recovery paths (e.g., monitor script failure) where status data is unavailable.
+func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Duration, lastProgressTime time.Time, lastProgress stallProgressState, context, namespace, clusterName string) {
+	t.Helper()
+	if !stallEnabled {
+		return
+	}
+	stallDuration := time.Since(lastProgressTime)
+	if stallDuration <= stallTimeout {
+		return
+	}
+
+	PrintToTTY("\n❌ Deployment stalled: no progress for %v\n", stallDuration.Round(time.Second))
+	PrintToTTY("   Last state: ControlPlane.Ready=%v, MachinePool.ReadyReplicas=%d, InfraResources=%d\n\n",
+		lastProgress.cpReady, lastProgress.mpReadyReplicas, lastProgress.infraResourceReady)
+
+	CollectAndDumpInfraDiagnostics(t, context, namespace, clusterName)
+
+	t.Fatalf("Deployment stalled: no progress for %v (stall timeout: %v).\n"+
+		"  ControlPlane ready: %v\n"+
+		"  MachinePool ready replicas: %d\n"+
+		"  Infrastructure resources ready: %d\n\n"+
+		"This usually indicates an infrastructure-side issue (e.g., ARO HCP stuck in Reconciling).\n"+
+		"Check the cloud provider's service health dashboard.\n\n"+
+		"To increase stall timeout: export DEPLOYMENT_STALL_TIMEOUT=45m\n"+
+		"To disable stall detection: export DEPLOYMENT_STALL_TIMEOUT=0",
+		stallDuration.Round(time.Second), stallTimeout,
+		lastProgress.cpReady, lastProgress.mpReadyReplicas,
+		lastProgress.infraResourceReady)
 }

--- a/test/README.md
+++ b/test/README.md
@@ -91,7 +91,7 @@ Tests are configured via environment variables:
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests-cluster` for ARO, `capa-tests-cluster` for ROSA)
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPI_USER}-${DEPLOYMENT_ENV}`). The Azure resource group will be named `${CS_CLUSTER_NAME}-resgroup`.
-- `OCP_VERSION` - OpenShift version (default: `4.21`)
+- `OCP_VERSION` - OpenShift version (default: `4.18`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `DEPLOYMENT_ENV` - Deployment environment (stage/prod) (default: `stage`)

--- a/test/config.go
+++ b/test/config.go
@@ -658,7 +658,7 @@ func NewTestConfig() *TestConfig {
 		WorkloadClusterName:      GetEnvOrDefault("WORKLOAD_CLUSTER_NAME", defaultWorkloadCluster),
 		ClusterNamePrefix:        prefix,
 		NamePrefix:               GetEnvOrDefault("NAME_PREFIX", ""),
-		OCPVersion:               GetEnvOrDefault("OCP_VERSION", "4.20"),
+		OCPVersion:               GetEnvOrDefault("OCP_VERSION", "4.18"),
 		Region:                   GetEnvOrDefault(regionEnvVar, defaultRegion),
 		AzureSubscriptionName:    os.Getenv("AZURE_SUBSCRIPTION_NAME"),
 		Environment:              environment,

--- a/test/config.go
+++ b/test/config.go
@@ -32,7 +32,7 @@ const (
 	DefaultMCEEnablementTimeout = 15 * time.Minute
 
 	// DefaultDeploymentStallTimeout is the default stall detection timeout.
-	// If the deployment makes no progress (control plane state, machine pool replicas,
+	// If the deployment makes no progress (control plane ready status, machine pool replicas,
 	// or infrastructure resource count unchanged) for this duration, the test fails early
 	// instead of waiting for the full DeploymentTimeout.
 	// Set to 0 to disable stall detection.
@@ -752,6 +752,10 @@ func parseDeploymentStallTimeout() time.Duration {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: invalid DEPLOYMENT_STALL_TIMEOUT '%s', using default %v\n", timeoutStr, DefaultDeploymentStallTimeout)
 		return DefaultDeploymentStallTimeout
+	}
+	if timeout < 0 {
+		fmt.Fprintf(os.Stderr, "Warning: negative DEPLOYMENT_STALL_TIMEOUT '%s' treated as disabled (0)\n", timeoutStr)
+		return 0
 	}
 	return timeout
 }

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -221,6 +221,23 @@ func TestParseDeploymentStallTimeout_InvalidDuration(t *testing.T) {
 	}
 }
 
+func TestParseDeploymentStallTimeout_NegativeDuration(t *testing.T) {
+	originalValue := os.Getenv("DEPLOYMENT_STALL_TIMEOUT")
+	defer func() {
+		if originalValue != "" {
+			_ = os.Setenv("DEPLOYMENT_STALL_TIMEOUT", originalValue)
+		} else {
+			_ = os.Unsetenv("DEPLOYMENT_STALL_TIMEOUT")
+		}
+	}()
+
+	_ = os.Setenv("DEPLOYMENT_STALL_TIMEOUT", "-30m")
+	timeout := parseDeploymentStallTimeout()
+	if timeout != 0 {
+		t.Errorf("For negative input '-30m', expected 0 (disabled), got %v", timeout)
+	}
+}
+
 func TestIsKindMode(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -3338,6 +3338,11 @@ func TestTimeoutConstants(t *testing.T) {
 	if MaxDeploymentTimeout > 6*time.Hour {
 		t.Errorf("MaxDeploymentTimeout (%v) seems too long", MaxDeploymentTimeout)
 	}
+
+	if DefaultDeploymentStallTimeout >= DefaultDeploymentTimeout {
+		t.Errorf("DefaultDeploymentStallTimeout (%v) should be less than DefaultDeploymentTimeout (%v)",
+			DefaultDeploymentStallTimeout, DefaultDeploymentTimeout)
+	}
 }
 
 // TestConfigValidationResult tests the ConfigValidationResult struct.


### PR DESCRIPTION
## Description

Fix the ROSA full-cluster deployment that has been failing nightly since April 1, 2026.

Closes #602

JIRA: https://redhat.atlassian.net/browse/ARO-25886

## Changes Made

- Set `OPENSHIFT_VERSION` alongside `OCP_VERSION` in YAML generation phase — the ROSA gen.sh reads `OPENSHIFT_VERSION` (not `OCP_VERSION`), so the test's configured version was never reaching the script
- Update default OCP version from `4.20` to `4.18` (stable, widely available on OCM)
- Add deployment stall detection (30min default) to fail fast when deployment makes no progress instead of waiting the full 2h timeout
- Document `DEPLOYMENT_STALL_TIMEOUT` in CLAUDE.md

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `DEPLOYMENT_STALL_TIMEOUT` | Fail early if no deployment progress (CP state, MP replicas, infra resources unchanged) | `30m` (set `0` to disable) |

## Additional Notes

Root cause: ROSAControlPlane stays at `state: waiting` and never transitions to `installing`. This indicates OCP 4.20.0 is no longer available on the OCM stage environment. The env var mismatch (`OCP_VERSION` vs `OPENSHIFT_VERSION`) prevented the test suite from controlling the version passed to the generation script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added optional stall detection for deployment tests (configurable, default 30m) that fails early, captures diagnostics, and warns if misconfigured.
  * Added tests for stall-time parsing and for timeout-constant relationships.
  * Test runs now provide the cluster version via OPENSHIFT_VERSION and the default cluster version was changed to 4.18.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->