### PR TITLE
feat: add deployment stall detection (ARO-25887)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,7 @@ This is validated during Check Dependencies (phase 1) to prevent late deployment
 
 ### Test Behavior
 - `DEPLOYMENT_TIMEOUT` - Control plane deployment timeout (default: `45m`, format: Go duration like `1h`, `45m`)
+- `DEPLOYMENT_STALL_TIMEOUT` - Stall detection timeout: if no progress (control plane state, machine pool replicas, infrastructure resources) for this duration, the test fails early instead of waiting for the full deployment timeout (default: `30m`, set to `0` to disable)
 
 ### MCE Component Management
 - `MCE_AUTO_ENABLE` - Auto-enable MCE CAPI/CAPZ components if not found on external cluster (default: `true` when `USE_KUBECONFIG` is set)

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The test suite validates naming compliance during the Check Dependencies phase (
 ### Test Behavior
 
 - `DEPLOYMENT_TIMEOUT` - Control plane deployment timeout (default: `60m`). Use Go duration format: `1h`, `45m`, `90m`, etc.
+- `DEPLOYMENT_STALL_TIMEOUT` - Stall detection timeout (default: `30m`). If the deployment makes no progress for this duration, the test fails early instead of waiting for the full timeout. Set to `0` to disable.
 - `TEST_VERBOSITY` - Test output verbosity (default: `-v` for verbose). Set to empty string for quiet output: `TEST_VERBOSITY= make test`
 
 #### Makefile Timeout Variables

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -538,6 +538,21 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 	controlPlaneReady := false
 	machinePoolReady := false
 
+	// Stall detection: fail fast when deployment makes no progress
+	stallTimeout := config.DeploymentStallTimeout
+	stallEnabled := stallTimeout > 0
+	lastProgressTime := startTime
+	// Track state for stall detection (detect when nothing changes)
+	type progressState struct {
+		cpReady            bool
+		mpReadyReplicas    int
+		infraResourceReady int
+	}
+	lastProgress := progressState{}
+	if stallEnabled {
+		PrintToTTY("Stall detection: enabled (timeout: %v)\n\n", stallTimeout)
+	}
+
 	iteration := 0
 	for {
 		elapsed := time.Since(startTime)
@@ -686,6 +701,52 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 		} else {
 			if len(status.MachinePools) > 0 {
 				PrintToTTY("[%d] ✅ MachinePool: ready\n", iteration)
+			}
+		}
+
+		// Stall detection: check if meaningful progress was made since last iteration
+		if stallEnabled {
+			// Build current state snapshot
+			currentMPReplicas := 0
+			if len(status.MachinePools) > 0 {
+				currentMPReplicas = status.MachinePools[0].ReadyReplicas
+			}
+			infraReady := 0
+			infraStatus := GetInfrastructureResourceStatusFromParsed(status.Infrastructure.Resources, status.Infrastructure.Conditions)
+			infraReady = infraStatus.ReadyResources
+
+			current := progressState{
+				cpReady:            controlPlaneReady,
+				mpReadyReplicas:    currentMPReplicas,
+				infraResourceReady: infraReady,
+			}
+
+			if current != lastProgress {
+				lastProgressTime = time.Now()
+				lastProgress = current
+			}
+
+			stallDuration := time.Since(lastProgressTime)
+			if stallDuration > stallTimeout {
+				PrintToTTY("\n❌ Deployment stalled: no progress for %v\n", stallDuration.Round(time.Second))
+				PrintToTTY("   Last state: ControlPlane.Ready=%v, MachinePool.ReadyReplicas=%d, InfraResources=%d/%d\n\n",
+					current.cpReady, current.mpReadyReplicas, infraReady, infraStatus.TotalResources)
+
+				// Dump diagnostics for not-ready infrastructure resources
+				CollectAndDumpInfraDiagnostics(t, context, config.WorkloadClusterNamespace, provisionedClusterName)
+
+				t.Fatalf("Deployment stalled: no progress for %v (stall timeout: %v).\n"+
+					"  ControlPlane ready: %v\n"+
+					"  MachinePool ready replicas: %d\n"+
+					"  Infrastructure resources: %d/%d\n\n"+
+					"This usually indicates an infrastructure-side issue (e.g., ARO HCP stuck in Reconciling).\n"+
+					"Check the cloud provider's service health dashboard.\n\n"+
+					"To increase stall timeout: export DEPLOYMENT_STALL_TIMEOUT=45m\n"+
+					"To disable stall detection: export DEPLOYMENT_STALL_TIMEOUT=0",
+					stallDuration.Round(time.Second), stallTimeout,
+					current.cpReady, current.mpReadyReplicas,
+					infraReady, infraStatus.TotalResources)
+				return
 			}
 		}
 

--- a/test/config.go
+++ b/test/config.go
@@ -29,6 +29,13 @@ const (
 	// MCE components need time to deploy controllers, pull images, and initialize.
 	DefaultMCEEnablementTimeout = 15 * time.Minute
 
+	// DefaultDeploymentStallTimeout is the default stall detection timeout.
+	// If the deployment makes no progress (control plane state, machine pool replicas,
+	// or infrastructure resource count unchanged) for this duration, the test fails early
+	// instead of waiting for the full DeploymentTimeout.
+	// Set to 0 to disable stall detection.
+	DefaultDeploymentStallTimeout = 30 * time.Minute
+
 	// DefaultNodeReadyTimeout is the default timeout for waiting for worker nodes to become available.
 	// In ARO HCP, the control plane becomes ready before worker nodes are provisioned.
 	// The AROMachinePool creates nodes after the HcpOpenShiftCluster is up.
@@ -358,9 +365,10 @@ type TestConfig struct {
 	GenScriptPath     string
 
 	// Timeouts
-	DeploymentTimeout    time.Duration
-	ASOControllerTimeout time.Duration
-	HelmInstallTimeout   time.Duration
+	DeploymentTimeout      time.Duration
+	DeploymentStallTimeout time.Duration // 0 disables stall detection
+	ASOControllerTimeout   time.Duration
+	HelmInstallTimeout     time.Duration
 
 	// Infrastructure providers
 	// InfraProviderName is the selected infrastructure provider ("aro" or "rosa").
@@ -565,9 +573,10 @@ func NewTestConfig() *TestConfig {
 		GenScriptPath:     GetEnvOrDefault("GEN_SCRIPT_PATH", defaultGenScriptPath),
 
 		// Timeouts
-		DeploymentTimeout:    parseDeploymentTimeout(),
-		ASOControllerTimeout: asoTimeout,
-		HelmInstallTimeout:   parseHelmInstallTimeout(),
+		DeploymentTimeout:      parseDeploymentTimeout(),
+		DeploymentStallTimeout: parseDeploymentStallTimeout(),
+		ASOControllerTimeout:   asoTimeout,
+		HelmInstallTimeout:     parseHelmInstallTimeout(),
 
 		// Infrastructure providers
 		InfraProviderName: infraProviderName,
@@ -614,6 +623,23 @@ func parseDeploymentTimeout() time.Duration {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: invalid DEPLOYMENT_TIMEOUT '%s', using default %v\n", timeoutStr, DefaultDeploymentTimeout)
 		return DefaultDeploymentTimeout
+	}
+	return timeout
+}
+
+// parseDeploymentStallTimeout parses the DEPLOYMENT_STALL_TIMEOUT environment variable.
+// Returns the parsed duration or defaults to DefaultDeploymentStallTimeout.
+// Set to "0" to disable stall detection entirely.
+func parseDeploymentStallTimeout() time.Duration {
+	timeoutStr := os.Getenv("DEPLOYMENT_STALL_TIMEOUT")
+	if timeoutStr == "" {
+		return DefaultDeploymentStallTimeout
+	}
+
+	timeout, err := time.ParseDuration(timeoutStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: invalid DEPLOYMENT_STALL_TIMEOUT '%s', using default %v\n", timeoutStr, DefaultDeploymentStallTimeout)
+		return DefaultDeploymentStallTimeout
 	}
 	return timeout
 }

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -150,6 +150,77 @@ func TestParseDeploymentTimeout_InvalidDuration(t *testing.T) {
 	}
 }
 
+func TestParseDeploymentStallTimeout_Default(t *testing.T) {
+	originalValue := os.Getenv("DEPLOYMENT_STALL_TIMEOUT")
+	_ = os.Unsetenv("DEPLOYMENT_STALL_TIMEOUT")
+	defer func() {
+		if originalValue != "" {
+			_ = os.Setenv("DEPLOYMENT_STALL_TIMEOUT", originalValue)
+		}
+	}()
+
+	timeout := parseDeploymentStallTimeout()
+	if timeout != DefaultDeploymentStallTimeout {
+		t.Errorf("Expected default stall timeout %v, got %v", DefaultDeploymentStallTimeout, timeout)
+	}
+	t.Logf("Default stall timeout: %v", timeout)
+}
+
+func TestParseDeploymentStallTimeout_ValidDuration(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected time.Duration
+	}{
+		{"15m", 15 * time.Minute},
+		{"30m", 30 * time.Minute},
+		{"1h", 1 * time.Hour},
+		{"0", 0},  // disables stall detection
+		{"0s", 0}, // disables stall detection
+		{"0m", 0}, // disables stall detection
+	}
+
+	originalValue := os.Getenv("DEPLOYMENT_STALL_TIMEOUT")
+	defer func() {
+		if originalValue != "" {
+			_ = os.Setenv("DEPLOYMENT_STALL_TIMEOUT", originalValue)
+		} else {
+			_ = os.Unsetenv("DEPLOYMENT_STALL_TIMEOUT")
+		}
+	}()
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			_ = os.Setenv("DEPLOYMENT_STALL_TIMEOUT", tc.input)
+			timeout := parseDeploymentStallTimeout()
+			if timeout != tc.expected {
+				t.Errorf("For input '%s', expected %v, got %v", tc.input, tc.expected, timeout)
+			}
+		})
+	}
+}
+
+func TestParseDeploymentStallTimeout_InvalidDuration(t *testing.T) {
+	originalValue := os.Getenv("DEPLOYMENT_STALL_TIMEOUT")
+	defer func() {
+		if originalValue != "" {
+			_ = os.Setenv("DEPLOYMENT_STALL_TIMEOUT", originalValue)
+		} else {
+			_ = os.Unsetenv("DEPLOYMENT_STALL_TIMEOUT")
+		}
+	}()
+
+	invalidValues := []string{"invalid", "abc", "45", "1x"}
+	for _, val := range invalidValues {
+		t.Run(val, func(t *testing.T) {
+			_ = os.Setenv("DEPLOYMENT_STALL_TIMEOUT", val)
+			timeout := parseDeploymentStallTimeout()
+			if timeout != DefaultDeploymentStallTimeout {
+				t.Errorf("For invalid input '%s', expected default %v, got %v", val, DefaultDeploymentStallTimeout, timeout)
+			}
+		})
+	}
+}
+
 func TestIsKindMode(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
## Description

Add deployment stall detection to `TestDeployment_WaitForControlPlane` that fails fast when the deployment makes no progress, instead of waiting for the full timeout.

**Root cause of the aro-int failure (Apr 9):** The ARO HCP cluster was stuck in "Reconciling" state for the entire 2-hour timeout. All 46/46 infrastructure resources reconciled successfully, but `HcpClusterReady` never became true. No code changes between the last success (Apr 2) and this failure — this was a transient infrastructure-side issue. With stall detection, the test would have failed at ~30 minutes instead of 120 minutes.

JIRA: https://redhat.atlassian.net/browse/ARO-25887

## Changes Made

- Add `DEPLOYMENT_STALL_TIMEOUT` config option (default: 30m, set to 0 to disable)
- Track deployment progress state (control plane ready, machine pool replicas, infrastructure resources)
- Fail early with descriptive error when no progress is made for the stall timeout period
- Add config parser tests for the new timeout
- Update CLAUDE.md and README.md documentation

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `DEPLOYMENT_STALL_TIMEOUT` | Fail early if deployment makes no progress for this duration | `30m` |

## Additional Notes

- Set `DEPLOYMENT_STALL_TIMEOUT=0` to disable stall detection entirely
- Progress is defined as any change in: control plane ready state, machine pool ready replicas, or infrastructure resources reconciled count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stall detection to deployment testing with configurable timeout via environment variable
  * Automatic diagnostics collection triggered when deployment progress halts

* **Tests**
  * Added configuration tests for deployment stall timeout parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->