### PR TITLE
fix: remove non-credential env vars from YAMLGenCredentials validation

### DIFF
--- a/test/config.go
+++ b/test/config.go
@@ -183,8 +183,6 @@ func NewAzureProvider(namespace string) InfraProvider {
 		RequiredTools:    []string{"az"},
 		RequiredScripts:  []string{"scripts/deploy-charts.sh", "scripts/aro-hcp/gen.sh"},
 		YAMLGenCredentials: []EnvVarRequirement{
-			{Name: "REGION", Desc: "Azure region for deployment", Sensitive: false},
-			{Name: "DEPLOYMENT_ENV", Desc: "Deployment environment identifier", Sensitive: false},
 			{Name: "AZURE_SUBSCRIPTION_ID", Desc: "Azure subscription ID", Sensitive: false},
 			{Name: "AZURE_TENANT_ID", Desc: "Azure tenant ID", Sensitive: false},
 			{Name: "AZURE_CLIENT_ID", Desc: "Azure service principal client ID", Sensitive: false},


### PR DESCRIPTION
## Description

`TestInfrastructure_ValidateCredentials` fails when `DEPLOYMENT_ENV` (and `REGION`) are not
explicitly exported, even though both have defaults in `NewTestConfig()` and are set via
`SetEnvVar` before gen.sh runs.

## Changes Made

- Remove `REGION` and `DEPLOYMENT_ENV` from `YAMLGenCredentials` in `NewAzureProvider()` — they
  are config values with defaults, not credentials that the user must provide

## Configuration Changes

No new variables. No behavior change — `REGION` and `DEPLOYMENT_ENV` remain optional with
defaults `uksouth` and `stage`.

## Additional Notes

Introduced by `ad3ba1a` (refactor: move credential checks to just-in-time validation) which
moved env var checks into the `YAMLGenCredentials` list. The two config entries were included
alongside actual credentials, but unlike `AZURE_CLIENT_ID` etc., they have built-in defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Azure provider no longer requires REGION and DEPLOYMENT_ENV environment variables for credential generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->