### PR TITLE
test: fail fast on ErrImagePull during Kind cluster deployment (fixes #518)

### DIFF
--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -728,7 +728,6 @@ func TestKindCluster_CAPIControllerReady(t *testing.T) {
 			PrintToTTY("\n❌ Image pull errors detected — failing fast\n")
 			t.Fatalf("Controller pods have image pull errors in %s namespace.\n%v",
 				config.CAPINamespace, imgErr)
-			return
 		}
 
 		time.Sleep(pollInterval)
@@ -820,7 +819,6 @@ func TestKindCluster_InfraControllersReady(t *testing.T) {
 						PrintToTTY("\n❌ Image pull errors detected — failing fast\n")
 						t.Fatalf("%s controller pods have image pull errors.\n%v",
 							ctrl.DisplayName, imgErr)
-						return
 					}
 
 					time.Sleep(pollInterval)

--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -724,6 +724,13 @@ func TestKindCluster_CAPIControllerReady(t *testing.T) {
 
 		ReportProgress(t, iteration, elapsed, remaining, timeout)
 
+		if imgErr := CheckPodsForImagePullErrors(t, context, config.CAPINamespace); imgErr != nil {
+			PrintToTTY("\n❌ Image pull errors detected — failing fast\n")
+			t.Fatalf("Controller pods have image pull errors in %s namespace.\n%v",
+				config.CAPINamespace, imgErr)
+			return
+		}
+
 		time.Sleep(pollInterval)
 	}
 }
@@ -808,6 +815,13 @@ func TestKindCluster_InfraControllersReady(t *testing.T) {
 					}
 
 					ReportProgress(t, iteration, elapsed, remaining, timeout)
+
+					if imgErr := CheckPodsForImagePullErrors(t, context, ctrl.Namespace); imgErr != nil {
+						PrintToTTY("\n❌ Image pull errors detected — failing fast\n")
+						t.Fatalf("%s controller pods have image pull errors.\n%v",
+							ctrl.DisplayName, imgErr)
+						return
+					}
 
 					time.Sleep(pollInterval)
 				}

--- a/test/config.go
+++ b/test/config.go
@@ -417,13 +417,13 @@ type TestConfig struct {
 	Region                   string
 	AzureSubscriptionName    string // Azure subscription name (from AZURE_SUBSCRIPTION_NAME env var)
 	Environment              string
-	CAPIUser                 string // User identifier for CAPI resources (from CAPI_USER env var)
+	CAPIUser                 string            // User identifier for CAPI resources (from CAPI_USER env var)
 	WorkloadClusterNamespace string            // Namespace for workload cluster resources on management cluster (unique per test run)
 	TestLabelPrefix          string            // Provider-specific label prefix for test namespaces (e.g., "capz-test" for ARO, "capa-test" for ROSA)
 	TestRunID                string            // Unique run identifier extracted from ClusterNamePrefix (the part after CAPI_USER-). Empty when prefix does not start with CAPI_USER-.
 	AzureResourceTags        map[string]string // Azure tags applied to all created resources for cleanup queries
-	CAPINamespace            string // Namespace for CAPI controller (default: "capi-system", or "multicluster-engine" when USE_K8S=true)
-	CAPZNamespace            string // Namespace for CAPZ/ASO controllers (default: "capz-system", or "multicluster-engine" when USE_K8S=true)
+	CAPINamespace            string            // Namespace for CAPI controller (default: "capi-system", or "multicluster-engine" when USE_K8S=true)
+	CAPZNamespace            string            // Namespace for CAPZ/ASO controllers (default: "capz-system", or "multicluster-engine" when USE_K8S=true)
 
 	// Management cluster mode
 	// ClusterMode specifies the management cluster deployment mode ("kind" or "mce").

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2729,6 +2729,8 @@ func CheckPodsForImagePullErrors(t *testing.T, kubeContext, namespace string) er
 		"get", "pods",
 		"-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\t\"}{range .status.containerStatuses[*]}{.state.waiting.reason}{\" \"}{end}{range .status.initContainerStatuses[*]}{.state.waiting.reason}{\" \"}{end}{\"\\n\"}{end}")
 	if err != nil {
+		//nolint:nilerr // Best-effort check: don't fail readiness loops on transient kubectl errors.
+		t.Logf("Warning: skipping image pull error check in namespace %s: %v", namespace, err)
 		return nil
 	}
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2719,6 +2719,42 @@ type ControllerLogSummary struct {
 // MaxSampleMessages is the maximum number of error/warning messages to keep in summary.
 const MaxSampleMessages = 10
 
+// CheckPodsForImagePullErrors checks if any pods in the given namespace have ErrImagePull or
+// ImagePullBackOff status. Returns an error describing the affected pods if found, nil otherwise.
+func CheckPodsForImagePullErrors(t *testing.T, kubeContext, namespace string) error {
+	t.Helper()
+
+	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
+		"-n", namespace, "--request-timeout=10s",
+		"get", "pods",
+		"-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\t\"}{range .status.containerStatuses[*]}{.state.waiting.reason}{\" \"}{end}{\"\\n\"}{end}")
+	if err != nil {
+		return nil
+	}
+
+	var affectedPods []string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.Contains(line, "ErrImagePull") || strings.Contains(line, "ImagePullBackOff") {
+			parts := strings.SplitN(line, "\t", 2)
+			if len(parts) > 0 {
+				affectedPods = append(affectedPods, parts[0])
+			}
+		}
+	}
+
+	if len(affectedPods) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("pods with image pull errors in namespace %s: %s\n"+
+		"Ensure registry credentials are configured (e.g., Docker config for registry.redhat.io)",
+		namespace, strings.Join(affectedPods, ", "))
+}
+
 // GetControllerLogs retrieves logs from a controller deployment.
 // Returns the log output or an error if the logs cannot be retrieved.
 func GetControllerLogs(t *testing.T, kubeContext, namespace, deploymentName string, tailLines int) (string, error) {

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2727,7 +2727,7 @@ func CheckPodsForImagePullErrors(t *testing.T, kubeContext, namespace string) er
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
 		"-n", namespace, "--request-timeout=10s",
 		"get", "pods",
-		"-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\t\"}{range .status.containerStatuses[*]}{.state.waiting.reason}{\" \"}{end}{\"\\n\"}{end}")
+		"-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\t\"}{range .status.containerStatuses[*]}{.state.waiting.reason}{\" \"}{end}{range .status.initContainerStatuses[*]}{.state.waiting.reason}{\" \"}{end}{\"\\n\"}{end}")
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
## Description

Detect ErrImagePull/ImagePullBackOff pod statuses during controller readiness
polling and fail immediately with a clear error message, instead of waiting for
the full timeout.

Fixes #518

## Changes Made

- Add `CheckPodsForImagePullErrors` helper function in `test/helpers.go` that inspects pod container statuses in a namespace for image pull errors
- Call the helper in `TestKindCluster_CAPIControllerReady` polling loop
- Call the helper in `TestKindCluster_InfraControllersReady` polling loop
- Both locations fail fast with a message indicating registry credentials may be missing

## Configuration Changes

No new environment variables.

## Additional Notes

Saves several minutes of CI time when registry.redhat.io credentials are not configured. The check runs on every poll iteration after the deployment is not yet ready, so it detects the error within one poll interval (~10s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added proactive image-pull error detection to cluster readiness tests so image fetch failures are detected and reported immediately with diagnostic details instead of waiting for deployment timeouts.
  * Added a test helper that scans pod statuses and surfaces image pull failures, including guidance for registry/credential issues.
* **Style**
  * Minor formatting adjustments in test configuration declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->