### PR TITLE
feat: implement train testing teardown — revert MCE components after test run (ARO-26036)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test _check-dep _setup _management_cluster _generate-yamls _deploy-crs _verify-workload-cluster _delete-workload-cluster _validate-cleanup test-all _test-all-impl clean clean-all clean-azure clean-my-resources check-stale help summary scheduled-review
+.PHONY: test _check-dep _setup _management_cluster _generate-yamls _deploy-crs _verify-workload-cluster _delete-workload-cluster _mce-teardown _validate-cleanup test-all _test-all-impl clean clean-all clean-azure clean-my-resources check-stale help summary scheduled-review
 
 # Use bash for shell commands (required for PIPESTATUS in test-all target)
 SHELL := /bin/bash
@@ -103,7 +103,8 @@ help: ## Display this help message
 	@echo "  5. make _deploy-crs      # Deploy CRs and verify deployment"
 	@echo "  6. make _verify-workload-cluster  # Verify deployed workload cluster"
 	@echo "  7. make _delete-workload-cluster  # Delete workload cluster and verify deletion"
-	@echo "  8. make _validate-cleanup         # Validate cleanup operations (optional, standalone)"
+	@echo "  8. make _mce-teardown             # Revert MCE components to original state (MCE clusters only)"
+	@echo "  9. make _validate-cleanup         # Validate cleanup operations (optional, standalone)"
 	@echo ""
 	@echo "Quick start:"
 	@echo ""
@@ -272,6 +273,27 @@ _delete-workload-cluster: check-gotestsum
 	echo ""; \
 	exit $$EXIT_CODE
 
+_mce-teardown: check-gotestsum
+	@mkdir -p $(RESULTS_DIR)
+	@echo "=== Running MCE Teardown Tests ==="
+	@echo "Results will be saved to: $(RESULTS_DIR)"
+	@echo ""
+	@EXIT_CODE=0; \
+	TEST_RESULTS_DIR=$(CURDIR)/$(RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-mce-teardown.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestTeardown -timeout 30m || EXIT_CODE=$$?; \
+	mkdir -p $(LATEST_RESULTS_DIR); \
+	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
+	cp -f $(RESULTS_DIR)/*.log $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
+	echo ""; \
+	echo "Test results saved to: $(RESULTS_DIR)/junit-mce-teardown.xml"; \
+	echo "Latest results copied to: $(LATEST_RESULTS_DIR)/"; \
+	if [ $$EXIT_CODE -eq 0 ]; then \
+		echo "✅ MCE Teardown Tests completed"; \
+	else \
+		echo "❌ MCE Teardown Tests failed"; \
+	fi; \
+	echo ""; \
+	exit $$EXIT_CODE
+
 _validate-cleanup: check-gotestsum
 	@mkdir -p $(RESULTS_DIR)
 	@echo "=== Running Cleanup Validation Tests ==="
@@ -373,6 +395,9 @@ _test-all-impl:
 		echo ""; \
 		exit 1 \
 	)
+	@# MCE teardown: revert MCE components to original state (best-effort, non-blocking)
+	@# This is a safety net for local runs; Prow CI runs this via the post step.
+	@$(MAKE) --no-print-directory _mce-teardown RESULTS_DIR=$(RESULTS_DIR) || true
 	@echo ""
 	@echo "======================================="
 	@echo "=== All Test Phases Completed Successfully ==="

--- a/openshift-ci/step-registry/capz-test-teardown-commands.sh
+++ b/openshift-ci/step-registry/capz-test-teardown-commands.sh
@@ -4,7 +4,10 @@ set -o pipefail
 set -o xtrace
 
 # Teardown: Safety net cleanup (post step - always runs)
-# Deletes Kind cluster, cloned repository, kubeconfig files, and Azure resources.
+# 1. Revert MCE components to original state (skips if not an MCE cluster)
+# 2. Delete Kind cluster, cloned repository, kubeconfig files, and Azure resources
 # Uses best_effort so cleanup failures do not mask test failures.
 # Does NOT delete ${ARTIFACT_DIR} - only the local results/ directory.
+export TEST_RESULTS_DIR="${ARTIFACT_DIR}"
+make _mce-teardown RESULTS_DIR="${ARTIFACT_DIR}" || true
 FORCE=1 make clean-all || true

--- a/openshift-ci/step-registry/capz-test-teardown-commands.sh
+++ b/openshift-ci/step-registry/capz-test-teardown-commands.sh
@@ -4,10 +4,7 @@ set -o pipefail
 set -o xtrace
 
 # Teardown: Safety net cleanup (post step - always runs)
-# 1. Revert MCE components to original state (skips if not an MCE cluster)
-# 2. Delete Kind cluster, cloned repository, kubeconfig files, and Azure resources
+# Deletes Kind cluster, cloned repository, kubeconfig files, and Azure resources.
 # Uses best_effort so cleanup failures do not mask test failures.
 # Does NOT delete ${ARTIFACT_DIR} - only the local results/ directory.
-export TEST_RESULTS_DIR="${ARTIFACT_DIR}"
-make _mce-teardown RESULTS_DIR="${ARTIFACT_DIR}" || true
 FORCE=1 make clean-all || true

--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -91,6 +91,21 @@ func TestExternalCluster_01b_MCEBaselineStatus(t *testing.T) {
 		"Validate and configure MCE components baseline (HyperShift disabled, core components enabled)")
 
 	PrintToTTY("\n=== Checking MCE component baseline status ===\n")
+
+	// Capture original states before any modifications for teardown
+	baselineComponentNames := make([]string, len(ExpectedMCEComponents))
+	for i, c := range ExpectedMCEComponents {
+		baselineComponentNames[i] = c.Name
+	}
+	originalStates, err := CaptureMCEComponentStates(t, context, baselineComponentNames)
+	if err != nil {
+		t.Logf("Warning: failed to capture MCE original states: %v", err)
+	} else if err := SaveMCEOriginalStates(originalStates); err != nil {
+		t.Logf("Warning: failed to save MCE original states: %v", err)
+	} else {
+		PrintToTTY("📝 Saved original MCE component states for teardown\n")
+	}
+
 	PrintToTTY("%-35s %s\n", "COMPONENT", "STATUS")
 	PrintToTTY("%s\n", strings.Repeat("-", 50))
 
@@ -221,6 +236,17 @@ func TestExternalCluster_02_EnsureMCEComponents(t *testing.T) {
 			components = append(components, p.MCEComponentName)
 		}
 	}
+
+	// Capture original states before any modifications for teardown
+	originalStates, captureErr := CaptureMCEComponentStates(t, context, components)
+	if captureErr != nil {
+		t.Logf("Warning: failed to capture MCE original states: %v", captureErr)
+	} else if err := SaveMCEOriginalStates(originalStates); err != nil {
+		t.Logf("Warning: failed to save MCE original states: %v", err)
+	} else {
+		PrintToTTY("📝 Saved original MCE component states for teardown\n")
+	}
+
 	enabledCount := 0
 	needsEnablement := false
 

--- a/test/09_teardown_test.go
+++ b/test/09_teardown_test.go
@@ -1,0 +1,139 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestTeardown_RevertMCEComponents reverts MCE components to their original states.
+// This undoes changes made by TestExternalCluster_01b_MCEBaselineStatus and
+// TestExternalCluster_02_EnsureMCEComponents, restoring the cluster to its pre-test state.
+//
+// Runs only when USE_KUBECONFIG is set and MCE is installed.
+// Reads saved original states from the deployment state file.
+func TestTeardown_RevertMCEComponents(t *testing.T) {
+	if configError != nil {
+		t.Fatalf("Configuration initialization failed: %s", *configError)
+	}
+
+	config := NewTestConfig()
+
+	if !config.IsExternalCluster() {
+		t.Skip("Not using external cluster (USE_KUBECONFIG not set)")
+	}
+
+	SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
+	context := config.GetKubeContext()
+
+	if !IsMCECluster(t, context) {
+		t.Skip("Not an MCE cluster, no MCE teardown needed")
+	}
+
+	PrintTestHeader(t, "TestTeardown_RevertMCEComponents",
+		"Revert MCE components to their original pre-test states")
+
+	state, err := ReadDeploymentState()
+	if err != nil {
+		t.Fatalf("Failed to read deployment state: %v", err)
+	}
+
+	if state == nil || len(state.MCEOriginalStates) == 0 {
+		PrintToTTY("No MCE original states saved — nothing to revert\n\n")
+		t.Skip("No MCE original states found in deployment state file")
+	}
+
+	// Show what will be reverted
+	PrintToTTY("\n=== MCE component teardown plan ===\n")
+	PrintToTTY("%-40s %-12s %s\n", "COMPONENT", "ORIGINAL", "CURRENT")
+	PrintToTTY("%s\n", strings.Repeat("-", 65))
+
+	type revertAction struct {
+		name            string
+		originalEnabled bool
+	}
+	var actions []revertAction
+	var queryErrors []string
+
+	for component, originalEnabled := range state.MCEOriginalStates {
+		current, err := GetMCEComponentStatus(t, context, component)
+		if err != nil {
+			queryErrors = append(queryErrors, fmt.Sprintf("%s: %v", component, err))
+			PrintToTTY("%-40s %-12s ⚠️  error: %v\n", component, fmtEnabled(originalEnabled), err)
+			continue
+		}
+
+		currentStr := fmtEnabled(current.Enabled)
+		originalStr := fmtEnabled(originalEnabled)
+
+		if current.Enabled == originalEnabled {
+			PrintToTTY("%-40s %-12s %-12s (no change needed)\n", component, originalStr, currentStr)
+		} else {
+			PrintToTTY("%-40s %-12s %-12s ← will revert\n", component, originalStr, currentStr)
+			actions = append(actions, revertAction{name: component, originalEnabled: originalEnabled})
+		}
+	}
+
+	PrintToTTY("%s\n", strings.Repeat("-", 65))
+
+	if len(queryErrors) > 0 {
+		PrintToTTY("\n⚠️  Failed to query %d component(s):\n", len(queryErrors))
+		for _, e := range queryErrors {
+			PrintToTTY("   - %s\n", e)
+		}
+	}
+
+	if len(actions) == 0 {
+		PrintToTTY("\n✅ All MCE components are already in their original state — no revert needed\n\n")
+		t.Log("All MCE components already in original state")
+		return
+	}
+
+	// Revert components
+	PrintToTTY("\n=== Reverting %d MCE component(s) ===\n\n", len(actions))
+
+	var revertErrors []string
+	var reverted []string
+
+	for _, action := range actions {
+		if err := SetMCEComponentState(t, context, action.name, action.originalEnabled); err != nil {
+			revertErrors = append(revertErrors, fmt.Sprintf("%s: %v", action.name, err))
+			PrintToTTY("❌ Failed to revert %s: %v\n", action.name, err)
+		} else {
+			reverted = append(reverted, fmt.Sprintf("%s → %s", action.name, fmtEnabled(action.originalEnabled)))
+		}
+	}
+
+	if len(revertErrors) > 0 {
+		PrintToTTY("\n❌ Failed to revert %d component(s):\n", len(revertErrors))
+		for _, e := range revertErrors {
+			PrintToTTY("   - %s\n", e)
+		}
+		t.Errorf("Failed to revert MCE components: %v", revertErrors)
+	}
+
+	if len(reverted) > 0 {
+		PrintToTTY("\n✅ Successfully reverted %d component(s):\n", len(reverted))
+		for _, r := range reverted {
+			PrintToTTY("   - %s\n", r)
+		}
+		t.Logf("Reverted MCE components: %v", reverted)
+
+		// Wait for MCE to reconcile
+		PrintToTTY("\n=== Waiting for MCE to reconcile ===\n")
+		PrintToTTY("Waiting 30 seconds for MCE to start reconciling...\n")
+		time.Sleep(30 * time.Second)
+		PrintToTTY("✅ MCE reconciliation wait complete\n\n")
+	}
+
+	PrintToTTY("✅ MCE teardown complete\n\n")
+	t.Log("MCE component teardown completed")
+}
+
+func fmtEnabled(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2616,6 +2616,9 @@ const DeploymentStateFile = ".deployment-state.json"
 // This allows cleanup commands to know which Azure resources were actually created,
 // regardless of current environment variables or config defaults.
 func WriteDeploymentState(config *TestConfig) error {
+	// Preserve data saved by other phases (e.g., MCE original states from phase 03)
+	existing, _ := ReadDeploymentState()
+
 	state := DeploymentState{
 		ResourceGroup:            fmt.Sprintf("%s-resgroup", config.WorkloadClusterName),
 		ManagementClusterName:    config.ManagementClusterName,
@@ -2627,6 +2630,10 @@ func WriteDeploymentState(config *TestConfig) error {
 		Environment:              config.Environment,
 		TestRunID:                config.TestRunID,
 		AzureResourceTags:        config.AzureResourceTags,
+	}
+
+	if existing != nil && len(existing.MCEOriginalStates) > 0 {
+		state.MCEOriginalStates = existing.MCEOriginalStates
 	}
 
 	data, err := json.MarshalIndent(state, "", "  ")
@@ -2756,56 +2763,6 @@ func SaveMCEOriginalStates(states map[string]bool) error {
 	return nil
 }
 
-// RestoreMCEOriginalStates reads the saved MCE original states from the deployment state file
-// and reverts each component to its pre-test state.
-func RestoreMCEOriginalStates(t *testing.T, kubeContext string) error {
-	t.Helper()
-
-	state, err := ReadDeploymentState()
-	if err != nil {
-		return fmt.Errorf("failed to read deployment state: %w", err)
-	}
-
-	if state == nil || len(state.MCEOriginalStates) == 0 {
-		return fmt.Errorf("no MCE original states found in deployment state file")
-	}
-
-	var revertErrors []string
-	var revertedComponents []string
-
-	for component, originalEnabled := range state.MCEOriginalStates {
-		current, err := GetMCEComponentStatus(t, kubeContext, component)
-		if err != nil {
-			revertErrors = append(revertErrors, fmt.Sprintf("%s: failed to get current status: %v", component, err))
-			continue
-		}
-
-		if current.Enabled == originalEnabled {
-			continue
-		}
-
-		if err := SetMCEComponentState(t, kubeContext, component, originalEnabled); err != nil {
-			revertErrors = append(revertErrors, fmt.Sprintf("%s: failed to revert: %v", component, err))
-			continue
-		}
-
-		action := "disabled"
-		if originalEnabled {
-			action = "enabled"
-		}
-		revertedComponents = append(revertedComponents, fmt.Sprintf("%s → %s", component, action))
-	}
-
-	if len(revertedComponents) > 0 {
-		t.Logf("Reverted MCE components: %v", revertedComponents)
-	}
-
-	if len(revertErrors) > 0 {
-		return fmt.Errorf("failed to revert %d MCE component(s): %v", len(revertErrors), revertErrors)
-	}
-
-	return nil
-}
 
 // ControllerLogSummary holds summarized log information for a controller.
 type ControllerLogSummary struct {

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2605,6 +2605,7 @@ type DeploymentState struct {
 	Environment              string            `json:"environment"`
 	TestRunID                string            `json:"test_run_id,omitempty"`
 	AzureResourceTags        map[string]string `json:"azure_resource_tags,omitempty"`
+	MCEOriginalStates        map[string]bool   `json:"mce_original_states,omitempty"`
 }
 
 // DeploymentStateFile is the path to the deployment state file.
@@ -2701,6 +2702,108 @@ func DeleteDeploymentState() error {
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to delete deployment state file: %w", err)
 	}
+	return nil
+}
+
+// CaptureMCEComponentStates queries the current enabled/disabled state of the given MCE components.
+// Returns a map of component name to enabled state (true = enabled, false = disabled).
+func CaptureMCEComponentStates(t *testing.T, kubeContext string, componentNames []string) (map[string]bool, error) {
+	t.Helper()
+
+	states := make(map[string]bool, len(componentNames))
+	for _, name := range componentNames {
+		status, err := GetMCEComponentStatus(t, kubeContext, name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get status for %s: %w", name, err)
+		}
+		states[name] = status.Enabled
+	}
+	return states, nil
+}
+
+// SaveMCEOriginalStates persists the original MCE component states to the deployment state file.
+// If the file already exists, it merges MCE states (existing component entries are not overwritten).
+// If the file does not exist, it creates a minimal state file with only MCE data.
+func SaveMCEOriginalStates(states map[string]bool) error {
+	existing, err := ReadDeploymentState()
+	if err != nil {
+		return fmt.Errorf("failed to read existing deployment state: %w", err)
+	}
+
+	if existing == nil {
+		existing = &DeploymentState{}
+	}
+
+	if existing.MCEOriginalStates == nil {
+		existing.MCEOriginalStates = make(map[string]bool)
+	}
+
+	for name, enabled := range states {
+		if _, alreadySaved := existing.MCEOriginalStates[name]; !alreadySaved {
+			existing.MCEOriginalStates[name] = enabled
+		}
+	}
+
+	data, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal deployment state: %w", err)
+	}
+
+	if err := os.WriteFile(DeploymentStateFile, data, 0600); err != nil {
+		return fmt.Errorf("failed to write deployment state file: %w", err)
+	}
+
+	return nil
+}
+
+// RestoreMCEOriginalStates reads the saved MCE original states from the deployment state file
+// and reverts each component to its pre-test state.
+func RestoreMCEOriginalStates(t *testing.T, kubeContext string) error {
+	t.Helper()
+
+	state, err := ReadDeploymentState()
+	if err != nil {
+		return fmt.Errorf("failed to read deployment state: %w", err)
+	}
+
+	if state == nil || len(state.MCEOriginalStates) == 0 {
+		return fmt.Errorf("no MCE original states found in deployment state file")
+	}
+
+	var revertErrors []string
+	var revertedComponents []string
+
+	for component, originalEnabled := range state.MCEOriginalStates {
+		current, err := GetMCEComponentStatus(t, kubeContext, component)
+		if err != nil {
+			revertErrors = append(revertErrors, fmt.Sprintf("%s: failed to get current status: %v", component, err))
+			continue
+		}
+
+		if current.Enabled == originalEnabled {
+			continue
+		}
+
+		if err := SetMCEComponentState(t, kubeContext, component, originalEnabled); err != nil {
+			revertErrors = append(revertErrors, fmt.Sprintf("%s: failed to revert: %v", component, err))
+			continue
+		}
+
+		action := "disabled"
+		if originalEnabled {
+			action = "enabled"
+		}
+		revertedComponents = append(revertedComponents, fmt.Sprintf("%s → %s", component, action))
+	}
+
+	if len(revertedComponents) > 0 {
+		t.Logf("Reverted MCE components: %v", revertedComponents)
+	}
+
+	if len(revertErrors) > 0 {
+		return fmt.Errorf("failed to revert %d MCE component(s): %v", len(revertErrors), revertErrors)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description

Implements train testing teardown for MCE clusters — after a test run, MCE components
are reverted to their original pre-test state, preventing shared clusters from being
left in a modified state.

JIRA: https://redhat.atlassian.net/browse/ARO-26036

## Changes Made

- Add `MCEOriginalStates` field to `DeploymentState` struct to track pre-test component states
- Add `CaptureMCEComponentStates` and `SaveMCEOriginalStates` helper functions in `helpers.go`
- Fix `WriteDeploymentState` to preserve MCE original states when overwriting the deployment state file (without this, phases 03/04 would destroy saved MCE states)
- Save original MCE states before modifications in `TestExternalCluster_01b_MCEBaselineStatus` and `TestExternalCluster_02_EnsureMCEComponents`
- Create `test/09_teardown_test.go` with `TestTeardown_RevertMCEComponents` phase
- Add `_mce-teardown` Makefile target, wired into `test-all` as best-effort post-deletion step

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------| 
| N/A      | No new env vars — teardown uses existing `USE_KUBECONFIG` and deployment state file | |

## Additional Notes

- Prow CI teardown step update tracked separately in [ARO-26307](https://redhat.atlassian.net/browse/ARO-26307)
- Teardown gracefully skips when not on an MCE cluster or when no original states were saved
- `SaveMCEOriginalStates` uses merge semantics — only the first capture is preserved per component

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-26307]: https://redhat.atlassian.net/browse/ARO-26307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ