### PR TITLE
fix: bump default OCP_VERSION from 4.18 to 4.19

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,7 +369,7 @@ export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests` for ARO, `capa-tests` for ROSA). Keep short as cloud providers may have length limits (e.g., Azure node pools max 15 chars including suffixes)
 - `CS_CLUSTER_NAME` - **C**luster **S**ervice cluster name prefix used for YAML generation and Azure resource naming. If not set, auto-generates a unique value: `${CAPI_USER}-${random5hex}` (e.g., `cate-a1b2c`). This enables parallel test runs against the same Azure subscription without resource name collisions. The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`. This prefix is also used for the ExternalAuth resource ID (max 15 chars including `-ea` suffix, so CS_CLUSTER_NAME max 12 chars). When resuming a multi-phase test run, the prefix is automatically loaded from the deployment state file.
-- `OCP_VERSION` - OpenShift version (default: `4.18`)
+- `OCP_VERSION` - OpenShift version (default: `4.19`)
 - `REGION` - Azure region (default: `uksouth`)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`). Used in Azure resource tags and domain prefix validation, but not included in the auto-generated `CS_CLUSTER_NAME`.
 - `CAPI_USER` - User identifier for domain prefix (default: `cate`). Used as the base for auto-generated `CS_CLUSTER_NAME` (e.g., `cate-a1b2c`). Must be short enough that `${CAPI_USER}-${DEPLOYMENT_ENV}` does not exceed 15 characters.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -174,7 +174,7 @@ See `docs/INTEGRATION.md` for detailed integration patterns.
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests-cluster` for ARO, `capa-tests-cluster` for ROSA)
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPI_USER}-${DEPLOYMENT_ENV}`). The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`.
-- `OCP_VERSION` - OpenShift version (default: `4.18`)
+- `OCP_VERSION` - OpenShift version (default: `4.19`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID (required for deployment)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ When using `INFRA_PROVIDER=rosa`, the following credentials are required:
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests` for ARO, `capa-tests` for ROSA). Keep short due to cloud provider length limits
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation and Azure resource naming. If not set, auto-generates a unique value: `${CAPI_USER}-${random5hex}` (e.g., `cate-a1b2c`) to enable parallel test runs. The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`. Max 12 characters (ExternalAuth ID constraint).
-- `OCP_VERSION` - OpenShift version (default: `4.18`)
+- `OCP_VERSION` - OpenShift version (default: `4.19`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`). Used in Azure resource tags and domain prefix validation.

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -217,7 +217,7 @@ MANAGEMENT_CLUSTER_NAME=capz-tests-stage  # For running tests (default for ARO; 
 KIND_CLUSTER_NAME=capz-tests-stage        # For direct script usage (advanced)
 CLUSTER_NAME=capz-tests-cluster           # Default for ARO; capa-tests-cluster for ROSA
 CS_CLUSTER_NAME=cate-stage  # Used for YAML generation and ExternalAuth
-OCP_VERSION=4.18
+OCP_VERSION=4.19
 REGION=uksouth
 DEPLOYMENT_ENV=stage
 

--- a/test/README.md
+++ b/test/README.md
@@ -91,7 +91,7 @@ Tests are configured via environment variables:
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests-cluster` for ARO, `capa-tests-cluster` for ROSA)
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPI_USER}-${DEPLOYMENT_ENV}`). The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`.
-- `OCP_VERSION` - OpenShift version (default: `4.18`)
+- `OCP_VERSION` - OpenShift version (default: `4.19`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `DEPLOYMENT_ENV` - Deployment environment (stage/prod) (default: `stage`)

--- a/test/config.go
+++ b/test/config.go
@@ -656,7 +656,7 @@ func NewTestConfig() *TestConfig {
 		WorkloadClusterName:      GetEnvOrDefault("WORKLOAD_CLUSTER_NAME", defaultWorkloadCluster),
 		ClusterNamePrefix:        prefix,
 		NamePrefix:               GetEnvOrDefault("NAME_PREFIX", ""),
-		OCPVersion:               GetEnvOrDefault("OCP_VERSION", "4.18"),
+		OCPVersion:               GetEnvOrDefault("OCP_VERSION", "4.19"),
 		Region:                   GetEnvOrDefault(regionEnvVar, defaultRegion),
 		AzureSubscriptionName:    os.Getenv("AZURE_SUBSCRIPTION_NAME"),
 		Environment:              environment,


### PR DESCRIPTION
## Description

Azure now rejects OCP 4.18 for HCP cluster creation with `InvalidRequestContent: must be at least 4.19`. 
This bumps the default `OCP_VERSION` from `4.18` to `4.19`.

## Changes Made

- Update default `OCP_VERSION` from `4.18` to `4.19` in `test/config.go`
- Update all documentation references (README.md, CLAUDE.md, GEMINI.md, test/README.md, docs/INTEGRATION.md)

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `OCP_VERSION` | OpenShift version for cluster deployment | `4.19` (was `4.18`) |

## Additional Notes

Discovered via stuck CI run where ARO control plane was failing with:
`HcpClusterReady: False (InvalidRequestContent) - Invalid value: "4.18": must be at least 4.19`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration default OCP version to 4.19.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->