### PR TITLE
fix: make resource group tagging non-fatal to match documented intent

### DIFF
--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1322,7 +1322,7 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 
 	PrintToTTY("Tagging resource group %s-resgroup...\n", config.ClusterNamePrefix)
 	if err := TagAzureResourceGroup(t, config); err != nil {
-		t.Errorf("Failed to tag resource group post-deployment (RG should exist): %v", err)
+		t.Logf("Warning: failed to tag resource group: %v", err)
 	}
 	tagAzureADApplications(t, config)
 	tagAzureServicePrincipals(t, config)


### PR DESCRIPTION
## Description

Resource group tagging failure in `TestDeployment_TagAzureResources` incorrectly uses `t.Errorf` (fails the test), while the function comment says "Non-fatal: failures are logged as warnings since tagging is for cleanup convenience only." This caused a fully successful MCE→ARO deployment ([run #24678962784](https://github.com/stolostron/capi-tests/actions/runs/24678962784/job/72170723536)) to be marked as failed.

## Changes Made

- Change `t.Errorf` to `t.Logf` in `TagAzureResourceGroup` error handling, matching the documented intent and the behavior already used by `tagAzureADApplications` and `tagAzureServicePrincipals`

## Configuration Changes

No configuration changes.

## Additional Notes

The deployment itself passed perfectly — control plane ready in ~11min, machine pool 2/2 in ~24min, all 46/46 infrastructure resources reconciled, ExternalAuth ready. Only the post-deployment tagging failed because the MCE CI runner's Azure CLI lacked permissions to call `az group update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modified deployment validation test to log Azure resource tagging issues as warnings instead of test failures, allowing test execution to continue without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->