### PR TITLE
docs: update test/README.md for provider-agnostic changes (fixes #582)

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -11,8 +11,8 @@ This test suite validates each step of the deployment process using the [cluster
 ### Test Files
 
 1. **`01_check_dependencies_test.go`** - Verifies required tools and authentication
-   - Checks for required CLI tools (docker/podman, kind, az, oc, helm, git)
-   - Validates Azure CLI login status
+   - Checks for required CLI tools (docker/podman, kind, az/aws, oc, helm, git)
+   - Validates cloud provider authentication
    - Verifies tool versions
 
 2. **`02_setup_test.go`** - Repository setup and preparation
@@ -21,17 +21,17 @@ This test suite validates each step of the deployment process using the [cluster
    - Sets script permissions
 
 3. **`03_cluster_test.go`** - Kind cluster deployment
-   - Deploys Kind cluster with CAPZ components
+   - Deploys Kind cluster with CAPI and infrastructure provider components
    - Verifies cluster accessibility
    - Checks CAPI components installation
 
 4. **`04_generate_yamls_test.go`** - Infrastructure resource generation
-   - Generates ARO infrastructure resources
+   - Generates provider-specific infrastructure resources (ARO/ROSA)
    - Validates generated YAML files
    - Applies resources to the management cluster
 
 5. **`05_deploy_crs_test.go`** - Cluster deployment monitoring
-   - Monitors ARO cluster deployment
+   - Monitors workload cluster deployment via JSON monitor
    - Waits for control plane readiness
    - Checks cluster conditions
 
@@ -44,12 +44,19 @@ This test suite validates each step of the deployment process using the [cluster
 7. **`07_deletion_test.go`** - Cluster deletion
    - Deletes workload cluster from management cluster
    - Waits for cluster deletion to complete
-   - Verifies Azure resources are cleaned up
+   - Verifies cloud resources are cleaned up
+
+8. **`08_cleanup_test.go`** - Cleanup validation
+   - Validates local resource cleanup (Kind cluster, kubeconfig, repositories)
+   - Validates cloud resource cleanup (resource groups, orphaned resources)
+   - Tests cleanup modes (interactive, force, dry-run)
 
 ### Helper Files
 
 - **`config.go`** - Test configuration management
 - **`helpers.go`** - Shared utility functions
+- **`cluster_monitor.go`** - Cluster monitoring via JSON monitor script
+- **`cluster_monitor_test.go`** - Tests for cluster monitoring functions
 
 ## Prerequisites
 
@@ -57,18 +64,18 @@ This test suite validates each step of the deployment process using the [cluster
 
 - Docker or Podman
 - Kind (Kubernetes in Docker)
-- Azure CLI (`az`)
+- Azure CLI (`az`) for ARO, or AWS CLI (`aws`) for ROSA
 - OpenShift CLI (`oc`)
 - Helm
 - Git
 - kubectl
 - clusterctl (optional, can be provided by cluster-api-installer)
 
-### Azure Access
+### Cloud Access
 
-- Red Hat account with access to Azure tenant
-- Access to "ARO Hosted Control Planes" subscription
-- Authenticated via `az login`
+- For ARO: Azure account with appropriate subscription and permissions
+- For ROSA: AWS account with appropriate IAM permissions and OCM credentials
+- Authenticated via `az login` (ARO) or `aws configure` (ROSA)
 
 ## Configuration
 
@@ -76,8 +83,8 @@ Tests are configured via environment variables:
 
 ### Repository Configuration
 
-- `ARO_REPO_URL` - Repository URL (default: `https://github.com/RadekCap/cluster-api-installer.git`)
-- `ARO_REPO_BRANCH` - Branch to clone (default: `ARO-ASO`)
+- `ARO_REPO_URL` - Repository URL (default: `https://github.com/stolostron/cluster-api-installer`)
+- `ARO_REPO_BRANCH` - Branch to clone (default: `main`)
 - `ARO_REPO_DIR` - Local repository directory (default: `/tmp/cluster-api-installer-aro`)
 
 ### Infrastructure Provider
@@ -89,8 +96,8 @@ Tests are configured via environment variables:
 - `MANAGEMENT_CLUSTER_NAME` - Management cluster name (default: `capz-tests-stage` for ARO, `capa-tests-stage` for ROSA)
   - **Note**: Tests automatically translate this to `KIND_CLUSTER_NAME` for the deployment script
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
-- `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests-cluster` for ARO, `capa-tests-cluster` for ROSA)
-- `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPI_USER}-${DEPLOYMENT_ENV}`). The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`.
+- `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests` for ARO, `capa-tests` for ROSA)
+- `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPI_USER}-${random5hex}`). The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`.
 - `OCP_VERSION` - OpenShift version (default: `4.19`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
@@ -127,7 +134,7 @@ go test -v ./test -run TestVerification
 
 ```bash
 DEPLOYMENT_ENV=prod \
-WORKLOAD_CLUSTER_NAME=my-aro-cluster \
+WORKLOAD_CLUSTER_NAME=my-cluster \
 REGION=westus2 \
 AZURE_SUBSCRIPTION_NAME=your-subscription-id \
 go test -v ./test
@@ -150,8 +157,38 @@ For full deployment validation, tests should run in this order:
 5. Resource application
 6. Deployment monitoring
 7. Cluster verification
+8. Cluster deletion
+9. Cleanup validation
 
 The test suite is designed to be idempotent - you can re-run tests and they will skip steps that are already complete.
+
+## Cluster Monitoring
+
+The test suite includes a JSON-based cluster monitoring system for tracking deployment progress.
+
+### Shell Script
+
+`scripts/monitor-cluster-json.sh` produces a structured JSON snapshot of cluster state:
+
+```bash
+# Usage
+./scripts/monitor-cluster-json.sh [--context <context>] <namespace> <cluster-name>
+
+# Example
+./scripts/monitor-cluster-json.sh --context kind-capz-tests-stage capz-test-20260203 capz-tests
+```
+
+The output includes cluster phase, infrastructure readiness, control plane status, machine pool replicas, node status, and a summary with overall readiness.
+
+### Go Integration
+
+`cluster_monitor.go` provides Go functions that wrap the shell script:
+
+- **`MonitorCluster()`** - Takes a single monitoring snapshot and returns structured `ClusterMonitorData`
+- **`MonitorClusterUntilReady()`** - Polls the cluster at regular intervals until it reaches a ready state or the timeout expires
+- **`MonitorClusterUntilDeleted()`** - Polls until the cluster resources are fully deleted or the timeout expires
+
+These functions are used by Phase 05 (deployment monitoring) and Phase 07 (deletion monitoring) to track workload cluster lifecycle.
 
 ## Integration with cluster-api-installer
 
@@ -160,7 +197,7 @@ The test suite is designed to be idempotent - you can re-run tests and they will
 Add cluster-api-installer as a git submodule:
 
 ```bash
-git submodule add -b ARO-ASO https://github.com/RadekCap/cluster-api-installer.git vendor/cluster-api-installer
+git submodule add https://github.com/stolostron/cluster-api-installer.git vendor/cluster-api-installer
 git submodule update --init --recursive
 ```
 
@@ -193,8 +230,9 @@ go test -v ./test
 To clean up test resources:
 
 ```bash
-# Delete Kind cluster
-kind delete cluster --name capz-tests-stage
+# Delete Kind cluster (provider-specific names)
+kind delete cluster --name capz-tests-stage  # ARO
+kind delete cluster --name capa-tests-stage  # ROSA
 
 # Remove repository clone (if using temp directory)
 rm -rf /tmp/cluster-api-installer-aro
@@ -244,7 +282,7 @@ kubectl get pods -A --context kind-capz-tests-stage
 These tests can be integrated into GitHub Actions or other CI/CD systems. Ensure:
 
 1. Required tools are installed in the CI environment
-2. Azure credentials are configured as secrets
+2. Cloud provider credentials are configured as secrets
 3. Tests run with appropriate timeout values (deployments can take 30+ minutes)
 
 Example for GitHub Actions is provided in `.github/workflows/test.yml`.


### PR DESCRIPTION
## Description

Updates `test/README.md` to reflect the provider-agnostic changes from PR #578.

Fixes #582

## Changes Made

- Replace ARO-specific test descriptions with provider-neutral language (e.g., "Monitors ARO cluster deployment" → "Monitors workload cluster deployment via JSON monitor")
- Add phase 8 (`08_cleanup_test.go`) documentation
- Add `cluster_monitor.go` and `cluster_monitor_test.go` to helper files section
- Fix stale defaults: `ARO_REPO_URL` → `stolostron/cluster-api-installer`, `ARO_REPO_BRANCH` → `main`, `WORKLOAD_CLUSTER_NAME` → `capz-tests`/`capa-tests`, `CS_CLUSTER_NAME` → `${CAPI_USER}-${random5hex}`
- Add missing test execution steps: cluster deletion and cleanup validation
- Fix integration URLs from `RadekCap` to `stolostron`, remove stale `-b ARO-ASO` flag
- Generalize cleanup section with provider-specific Kind cluster names
- Add new "Cluster Monitoring" section documenting `monitor-cluster-json.sh` and Go integration (`MonitorCluster()`, `MonitorClusterUntilReady()`, `MonitorClusterUntilDeleted()`)

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| N/A | Documentation-only change | N/A |

## Additional Notes

All changes verified against current `config.go` defaults and actual test file contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)