### PR TITLE
fix: nil pointer dereference in TestDeployment_VerifyAROClusterReady (fixes #583)

### DIFF
--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1135,7 +1135,11 @@ func TestDeployment_VerifyAROClusterReady(t *testing.T) {
 			}
 		}
 
-		PrintToTTY("⏳ %s.Ready: %s (elapsed %v)\n", data.Infrastructure.Kind, status, elapsed.Round(time.Second))
+		displayKind := infraKind
+		if data != nil && data.Infrastructure.Kind != "" {
+			displayKind = data.Infrastructure.Kind
+		}
+		PrintToTTY("⏳ %s.Ready: %s (elapsed %v)\n", displayKind, status, elapsed.Round(time.Second))
 		time.Sleep(pollInterval)
 	}
 }


### PR DESCRIPTION
## Description

Fix nil pointer dereference in `TestDeployment_VerifyAROClusterReady` when `MonitorCluster()` returns an error.

When `MonitorCluster()` fails, `data` is nil but `data.Infrastructure.Kind` was accessed unconditionally on the progress status line. The fix uses the pre-computed `infraKind` variable (set before the polling loop) as a fallback, overriding only when `data` is non-nil and has a Kind value.

Fixes #583

## Changes Made

- Use `infraKind` fallback variable instead of unconditional `data.Infrastructure.Kind` access in the progress message at `test/05_deploy_crs_test.go:1138`

## Configuration Changes

No configuration changes.

## Additional Notes

Found during self-review of PR #578 (ARO-24261 - unify capi tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved deployment progress logging to prevent blank infrastructure kind values from appearing when monitoring data is unavailable, ensuring clearer messages during cluster deployment verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->