### PR TITLE
fix: guard nil mp.Infrastructure before accessing Kind (fixes #585)

### DIFF
--- a/test/cluster_monitor_test.go
+++ b/test/cluster_monitor_test.go
@@ -54,11 +54,15 @@ func TestMonitorCluster(t *testing.T) {
 		if len(data.MachinePools) > 0 {
 			t.Logf("Machine pools: %d", len(data.MachinePools))
 			for _, mp := range data.MachinePools {
+				infraKind := "unknown"
+				if mp.Infrastructure != nil {
+					infraKind = mp.Infrastructure.Kind
+				}
 				t.Logf("  - %s: %d/%d replicas ready (kind: %s)",
 					mp.Name,
 					mp.ReadyReplicas,
 					mp.Replicas,
-					mp.Infrastructure.Kind)
+					infraKind)
 			}
 		}
 


### PR DESCRIPTION
## Description

Fix nil pointer dereference when accessing `mp.Infrastructure.Kind` in `TestMonitorCluster`. `MachinePoolStatus.Infrastructure` is a pointer that can be nil when infrastructure data hasn't been populated yet.

Fixes #585

## Changes Made

- Add nil guard for `mp.Infrastructure` before accessing `.Kind` in the machine pool logging loop
- Default to `"unknown"` when infrastructure data is unavailable, matching the pattern used in `05_deploy_crs_test.go`

## Configuration Changes

No configuration changes.

## Additional Notes

Found during self-review of PR #578 (ARO-24261 - unify capi tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in cluster monitoring to safely handle cases where infrastructure details may be unavailable, preventing potential crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->