### PR TITLE
refactor: convert invalid Example functions to doc comments (fixes #586)

### DIFF
--- a/test/cluster_monitor.go
+++ b/test/cluster_monitor.go
@@ -233,6 +233,20 @@ func (d *ClusterMonitorData) FormatSummary() string {
 // MonitorClusterUntilReady polls the cluster status until it's ready or timeout is reached.
 // This is a generic monitoring function that works for any CAPI cluster.
 // Returns the final cluster data when ready.
+//
+// Usage:
+//
+//	data, err := MonitorClusterUntilReady(
+//		t,
+//		config.GetKubeContext(),
+//		config.WorkloadClusterNamespace,
+//		config.GetProvisionedClusterName(),
+//		config.DeploymentTimeout,
+//	)
+//	if err != nil {
+//		t.Fatalf("Cluster failed to become ready: %v", err)
+//	}
+//	t.Logf("Provider: %s, Nodes: %d ready", data.GetProviderType(), data.GetReadyNodeCount())
 func MonitorClusterUntilReady(t *testing.T, kubeContext, namespace, clusterName string, timeout time.Duration) (*ClusterMonitorData, error) {
 	t.Helper()
 
@@ -283,6 +297,20 @@ func MonitorClusterUntilReady(t *testing.T, kubeContext, namespace, clusterName 
 // MonitorControlPlaneUntilReady waits for the control plane to become ready.
 // This is useful when you want to proceed before worker nodes are available.
 // Returns the cluster data when control plane is ready.
+//
+// Usage:
+//
+//	data, err := MonitorControlPlaneUntilReady(
+//		t,
+//		config.GetKubeContext(),
+//		config.WorkloadClusterNamespace,
+//		config.GetProvisionedClusterName(),
+//		config.DeploymentTimeout,
+//	)
+//	if err != nil {
+//		t.Fatalf("Control plane failed to become ready: %v", err)
+//	}
+//	t.Logf("Control plane ready! Provider: %s", data.GetProviderType())
 func MonitorControlPlaneUntilReady(t *testing.T, kubeContext, namespace, clusterName string, timeout time.Duration) (*ClusterMonitorData, error) {
 	t.Helper()
 

--- a/test/cluster_monitor_test.go
+++ b/test/cluster_monitor_test.go
@@ -77,52 +77,32 @@ func TestMonitorCluster(t *testing.T) {
 	})
 }
 
-// Example of how to use the monitoring in deployment tests
-func ExampleMonitorControlPlaneUntilReady() {
-	// This example shows how to wait for control plane to be ready
-	// (This is just documentation - it won't run as a real test)
+// Usage: MonitorControlPlaneUntilReady waits for the control plane to become ready
+// without waiting for worker nodes. Typical usage in a deployment test:
+//
+//	data, err := MonitorControlPlaneUntilReady(
+//		t,
+//		config.GetKubeContext(),
+//		config.WorkloadClusterNamespace,
+//		config.GetProvisionedClusterName(),
+//		config.DeploymentTimeout,
+//	)
+//	if err != nil {
+//		t.Fatalf("Control plane failed to become ready: %v", err)
+//	}
+//	t.Logf("Control plane ready! Provider: %s", data.GetProviderType())
 
-	t := &testing.T{} // placeholder
-	config := NewTestConfig()
-
-	// Wait for control plane (doesn't wait for worker nodes)
-	data, err := MonitorControlPlaneUntilReady(
-		t,
-		config.GetKubeContext(),
-		config.WorkloadClusterNamespace,
-		config.GetProvisionedClusterName(),
-		config.DeploymentTimeout,
-	)
-
-	if err != nil {
-		t.Fatalf("Control plane failed to become ready: %v", err)
-	}
-
-	t.Logf("Control plane ready! Provider: %s", data.GetProviderType())
-}
-
-// Example of how to wait for full cluster readiness
-func ExampleMonitorClusterUntilReady() {
-	// This example shows how to wait for complete cluster readiness
-	// (This is just documentation - it won't run as a real test)
-
-	t := &testing.T{} // placeholder
-	config := NewTestConfig()
-
-	// Wait for full cluster (infrastructure + control plane + nodes)
-	data, err := MonitorClusterUntilReady(
-		t,
-		config.GetKubeContext(),
-		config.WorkloadClusterNamespace,
-		config.GetProvisionedClusterName(),
-		config.DeploymentTimeout,
-	)
-
-	if err != nil {
-		t.Fatalf("Cluster failed to become ready: %v", err)
-	}
-
-	t.Logf("Cluster fully ready!")
-	t.Logf("Provider: %s", data.GetProviderType())
-	t.Logf("Nodes: %d ready", data.GetReadyNodeCount())
-}
+// Usage: MonitorClusterUntilReady waits for full cluster readiness including
+// infrastructure, control plane, and worker nodes. Typical usage:
+//
+//	data, err := MonitorClusterUntilReady(
+//		t,
+//		config.GetKubeContext(),
+//		config.WorkloadClusterNamespace,
+//		config.GetProvisionedClusterName(),
+//		config.DeploymentTimeout,
+//	)
+//	if err != nil {
+//		t.Fatalf("Cluster failed to become ready: %v", err)
+//	}
+//	t.Logf("Provider: %s, Nodes: %d ready", data.GetProviderType(), data.GetReadyNodeCount())

--- a/test/cluster_monitor_test.go
+++ b/test/cluster_monitor_test.go
@@ -76,33 +76,3 @@ func TestMonitorCluster(t *testing.T) {
 		}
 	})
 }
-
-// Usage: MonitorControlPlaneUntilReady waits for the control plane to become ready
-// without waiting for worker nodes. Typical usage in a deployment test:
-//
-//	data, err := MonitorControlPlaneUntilReady(
-//		t,
-//		config.GetKubeContext(),
-//		config.WorkloadClusterNamespace,
-//		config.GetProvisionedClusterName(),
-//		config.DeploymentTimeout,
-//	)
-//	if err != nil {
-//		t.Fatalf("Control plane failed to become ready: %v", err)
-//	}
-//	t.Logf("Control plane ready! Provider: %s", data.GetProviderType())
-
-// Usage: MonitorClusterUntilReady waits for full cluster readiness including
-// infrastructure, control plane, and worker nodes. Typical usage:
-//
-//	data, err := MonitorClusterUntilReady(
-//		t,
-//		config.GetKubeContext(),
-//		config.WorkloadClusterNamespace,
-//		config.GetProvisionedClusterName(),
-//		config.DeploymentTimeout,
-//	)
-//	if err != nil {
-//		t.Fatalf("Cluster failed to become ready: %v", err)
-//	}
-//	t.Logf("Provider: %s, Nodes: %d ready", data.GetProviderType(), data.GetReadyNodeCount())


### PR DESCRIPTION
## Description

Remove invalid `Example` functions from `cluster_monitor_test.go` and convert their usage examples into doc comments on the actual function declarations in `cluster_monitor.go`.

The `ExampleMonitorControlPlaneUntilReady()` and `ExampleMonitorClusterUntilReady()` functions used `&testing.T{}` placeholders, which would panic if executed via `go test -run Example` since the testing machinery isn't properly initialized. Moving the examples to doc comments on `MonitorClusterUntilReady` and `MonitorControlPlaneUntilReady` makes them visible to `go doc` and keeps them attached to the declarations they document.

Fixes #586

## Changes Made

- Removed `ExampleMonitorControlPlaneUntilReady()` from `cluster_monitor_test.go`
- Removed `ExampleMonitorClusterUntilReady()` from `cluster_monitor_test.go`
- Added usage examples as doc comments on `MonitorClusterUntilReady` in `cluster_monitor.go`
- Added usage examples as doc comments on `MonitorControlPlaneUntilReady` in `cluster_monitor.go`

## Configuration Changes

N/A

## Additional Notes

CodeRabbit finding #5 from PR #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved usage documentation for cluster monitoring utilities with practical examples.

* **Tests**
  * Reorganized test documentation structure for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->