### PR TITLE
update: OpenShift defaults to 4.20, add OCP_VERSION_MP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,7 +370,7 @@ export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests` for ARO, `capa-tests` for ROSA). Keep short as cloud providers may have length limits (e.g., Azure node pools max 15 chars including suffixes)
 - `CS_CLUSTER_NAME` - **C**luster **S**ervice cluster name prefix used for YAML generation and Azure resource naming. If not set, auto-generates a unique value: `${CAPI_USER}-${random5hex}` (e.g., `cate-a1b2c`). This enables parallel test runs against the same Azure subscription without resource name collisions. The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`. This prefix is also used for the ExternalAuth resource ID (max 15 chars including `-ea` suffix, so CS_CLUSTER_NAME max 12 chars). When resuming a multi-phase test run, the prefix is automatically loaded from the deployment state file.
 - `OCP_VERSION` - OpenShift version (default: `4.20`)
-- `OCP_VERSION_MP` - Full OpenShift version for MachinePool workers (default: `4.20.17`)
+- `OCP_VERSION_MP` - Full `x.y.z` OpenShift version for MachinePool workers (default: `4.20.17`)
 - `REGION` - Azure region (default: `uksouth`)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`). Used in Azure resource tags and domain prefix validation, but not included in the auto-generated `CS_CLUSTER_NAME`.
 - `CAPI_USER` - User identifier for domain prefix (default: `cate`). Used as the base for auto-generated `CS_CLUSTER_NAME` (e.g., `cate-a1b2c`). Must be short enough that `${CAPI_USER}-${DEPLOYMENT_ENV}` does not exceed 15 characters.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,7 +369,8 @@ export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests` for ARO, `capa-tests` for ROSA). Keep short as cloud providers may have length limits (e.g., Azure node pools max 15 chars including suffixes)
 - `CS_CLUSTER_NAME` - **C**luster **S**ervice cluster name prefix used for YAML generation and Azure resource naming. If not set, auto-generates a unique value: `${CAPI_USER}-${random5hex}` (e.g., `cate-a1b2c`). This enables parallel test runs against the same Azure subscription without resource name collisions. The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`. This prefix is also used for the ExternalAuth resource ID (max 15 chars including `-ea` suffix, so CS_CLUSTER_NAME max 12 chars). When resuming a multi-phase test run, the prefix is automatically loaded from the deployment state file.
-- `OCP_VERSION` - OpenShift version (default: `4.19`)
+- `OCP_VERSION` - OpenShift version (default: `4.20`)
+- `OCP_VERSION_MP` - Full OpenShift version for MachinePool workers (default: `4.20.17`)
 - `REGION` - Azure region (default: `uksouth`)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`). Used in Azure resource tags and domain prefix validation, but not included in the auto-generated `CS_CLUSTER_NAME`.
 - `CAPI_USER` - User identifier for domain prefix (default: `cate`). Used as the base for auto-generated `CS_CLUSTER_NAME` (e.g., `cate-a1b2c`). Must be short enough that `${CAPI_USER}-${DEPLOYMENT_ENV}` does not exceed 15 characters.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -174,7 +174,8 @@ See `docs/INTEGRATION.md` for detailed integration patterns.
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests-cluster` for ARO, `capa-tests-cluster` for ROSA)
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPI_USER}-${DEPLOYMENT_ENV}`). The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`.
-- `OCP_VERSION` - OpenShift version (default: `4.19`)
+- `OCP_VERSION` - OpenShift version (default: `4.20`)
+- `OCP_VERSION_MP` - Full OpenShift version for MachinePool workers (default: `4.20.17`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID (required for deployment)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -175,7 +175,7 @@ See `docs/INTEGRATION.md` for detailed integration patterns.
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests-cluster` for ARO, `capa-tests-cluster` for ROSA)
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPI_USER}-${DEPLOYMENT_ENV}`). The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`.
 - `OCP_VERSION` - OpenShift version (default: `4.20`)
-- `OCP_VERSION_MP` - Full OpenShift version for MachinePool workers (default: `4.20.17`)
+- `OCP_VERSION_MP` - Full `x.y.z` OpenShift version for MachinePool workers (default: `4.20.17`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID (required for deployment)
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ When using `INFRA_PROVIDER=rosa`, the following credentials are required:
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests` for ARO, `capa-tests` for ROSA). Keep short due to cloud provider length limits
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation and Azure resource naming. If not set, auto-generates a unique value: `${CAPI_USER}-${random5hex}` (e.g., `cate-a1b2c`) to enable parallel test runs. The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`. Max 12 characters (ExternalAuth ID constraint).
-- `OCP_VERSION` - OpenShift version (default: `4.19`)
+- `OCP_VERSION` - OpenShift version (default: `4.20`)
+- `OCP_VERSION_MP` - Full OpenShift version for MachinePool workers (default: `4.20.17`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`). Used in Azure resource tags and domain prefix validation.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ When using `INFRA_PROVIDER=rosa`, the following credentials are required:
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests` for ARO, `capa-tests` for ROSA). Keep short due to cloud provider length limits
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation and Azure resource naming. If not set, auto-generates a unique value: `${CAPI_USER}-${random5hex}` (e.g., `cate-a1b2c`) to enable parallel test runs. The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`. Max 12 characters (ExternalAuth ID constraint).
 - `OCP_VERSION` - OpenShift version (default: `4.20`)
-- `OCP_VERSION_MP` - Full OpenShift version for MachinePool workers (default: `4.20.17`)
+- `OCP_VERSION_MP` - Full `x.y.z` OpenShift version for MachinePool workers (default: `4.20.17`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `DEPLOYMENT_ENV` - Deployment environment identifier (default: `stage`). Used in Azure resource tags and domain prefix validation.

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -217,7 +217,8 @@ MANAGEMENT_CLUSTER_NAME=capz-tests-stage  # For running tests (default for ARO; 
 KIND_CLUSTER_NAME=capz-tests-stage        # For direct script usage (advanced)
 CLUSTER_NAME=capz-tests-cluster           # Default for ARO; capa-tests-cluster for ROSA
 CS_CLUSTER_NAME=cate-stage  # Used for YAML generation and ExternalAuth
-OCP_VERSION=4.19
+OCP_VERSION=4.20
+OCP_VERSION_MP=4.20.17
 REGION=uksouth
 DEPLOYMENT_ENV=stage
 

--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -202,6 +202,7 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 	SetEnvVar(t, config.RegionEnvVar, config.Region) // Provider-specific: REGION for ARO, AWS_REGION for ROSA
 	SetEnvVar(t, "CS_CLUSTER_NAME", config.ClusterNamePrefix)
 	SetEnvVar(t, "OCP_VERSION", config.OCPVersion)
+	SetEnvVar(t, "OCP_VERSION_MP", config.OCPVersionMP)
 	// ROSA gen.sh reads OPENSHIFT_VERSION (not OCP_VERSION) for the cluster version.
 	// Set both so the test's configured version reaches the generation script.
 	SetEnvVar(t, "OPENSHIFT_VERSION", config.OCPVersion)

--- a/test/README.md
+++ b/test/README.md
@@ -99,7 +99,7 @@ Tests are configured via environment variables:
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests` for ARO, `capa-tests` for ROSA)
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPI_USER}-${random5hex}`). The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`.
 - `OCP_VERSION` - OpenShift version (default: `4.20`)
-- `OCP_VERSION_MP` - Full OpenShift version for MachinePool workers (default: `4.20.17`)
+- `OCP_VERSION_MP` - Full `x.y.z` OpenShift version for MachinePool workers (default: `4.20.17`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `DEPLOYMENT_ENV` - Deployment environment (stage/prod) (default: `stage`)

--- a/test/README.md
+++ b/test/README.md
@@ -98,7 +98,8 @@ Tests are configured via environment variables:
   - Use this variable for configuring tests; `KIND_CLUSTER_NAME` is set internally
 - `WORKLOAD_CLUSTER_NAME` - Workload cluster name (default: `capz-tests` for ARO, `capa-tests` for ROSA)
 - `CS_CLUSTER_NAME` - Cluster name prefix used for YAML generation (default: `${CAPI_USER}-${random5hex}`). The Azure resource group is named `${WORKLOAD_CLUSTER_NAME}-resgroup`.
-- `OCP_VERSION` - OpenShift version (default: `4.19`)
+- `OCP_VERSION` - OpenShift version (default: `4.20`)
+- `OCP_VERSION_MP` - Full OpenShift version for MachinePool workers (default: `4.20.17`)
 - `REGION` - Azure region (default: `uksouth`)
 - `AZURE_SUBSCRIPTION_NAME` - Azure subscription ID
 - `DEPLOYMENT_ENV` - Deployment environment (stage/prod) (default: `stage`)

--- a/test/config.go
+++ b/test/config.go
@@ -414,6 +414,7 @@ type TestConfig struct {
 	ClusterNamePrefix        string // Used as CS_CLUSTER_NAME for YAML generation
 	NamePrefix               string // NAME_PREFIX used for Azure resource naming (Key Vault, node pools); passed to YAML generation
 	OCPVersion               string
+	OCPVersionMP             string // Full x.y.z OpenShift version for MachinePool workers (from OCP_VERSION_MP env var)
 	Region                   string
 	AzureSubscriptionName    string // Azure subscription name (from AZURE_SUBSCRIPTION_NAME env var)
 	Environment              string
@@ -656,7 +657,8 @@ func NewTestConfig() *TestConfig {
 		WorkloadClusterName:      GetEnvOrDefault("WORKLOAD_CLUSTER_NAME", defaultWorkloadCluster),
 		ClusterNamePrefix:        prefix,
 		NamePrefix:               GetEnvOrDefault("NAME_PREFIX", ""),
-		OCPVersion:               GetEnvOrDefault("OCP_VERSION", "4.19"),
+		OCPVersion:               GetEnvOrDefault("OCP_VERSION", "4.20"),
+		OCPVersionMP:             GetEnvOrDefault("OCP_VERSION_MP", "4.20.17"),
 		Region:                   GetEnvOrDefault(regionEnvVar, defaultRegion),
 		AzureSubscriptionName:    os.Getenv("AZURE_SUBSCRIPTION_NAME"),
 		Environment:              environment,

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2547,6 +2547,7 @@ func FormatComponentVersions(versions []ComponentVersion, config *TestConfig) st
 		}
 		fmt.Fprintf(&result, "  Resource Group:     %s-resgroup\n", config.WorkloadClusterName)
 		fmt.Fprintf(&result, "  OpenShift Version:  %s\n", config.OCPVersion)
+		fmt.Fprintf(&result, "  MachinePool Version: %s\n", config.OCPVersionMP)
 	}
 
 	// Used repositories

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2547,7 +2547,7 @@ func FormatComponentVersions(versions []ComponentVersion, config *TestConfig) st
 		}
 		fmt.Fprintf(&result, "  Resource Group:     %s-resgroup\n", config.WorkloadClusterName)
 		fmt.Fprintf(&result, "  OpenShift Version:  %s\n", config.OCPVersion)
-		fmt.Fprintf(&result, "  MachinePool Version: %s\n", config.OCPVersionMP)
+		fmt.Fprintf(&result, "  MP OCP Version:     %s\n", config.OCPVersionMP)
 	}
 
 	// Used repositories
@@ -2803,7 +2803,6 @@ func SaveMCEOriginalStates(states map[string]bool) error {
 
 	return nil
 }
-
 
 // ControllerLogSummary holds summarized log information for a controller.
 type ControllerLogSummary struct {


### PR DESCRIPTION
## Description

Update default OpenShift versions to 4.20 and add OCP_VERSION_MP for MachinePool worker version.

## Changes Made

- Update `OCP_VERSION` default from `4.19` to `4.20`
- Add `OCP_VERSION_MP` config field for full `x.y.z` MachinePool worker version (default: `4.20.17`)
- Pass `OCP_VERSION_MP` to the YAML generation script
- Display MachinePool version in component version output (aligned column formatting)

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `OCP_VERSION` | OpenShift version (updated) | `4.20` |
| `OCP_VERSION_MP` | Full `x.y.z` OpenShift version for MachinePool workers (new) | `4.20.17` |

## Additional Notes

Documentation updated across README.md, test/README.md, CLAUDE.md, GEMINI.md, and docs/INTEGRATION.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)