### PR TITLE
fix: support Azure CLI auth in Phase 04 credential validation

### DIFF
--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -40,6 +40,22 @@ func TestInfrastructure_01_ValidateCredentials(t *testing.T) {
 		t.Skip("No provider credential environment variables to validate")
 	}
 
+	// For Azure providers, auto-extract credentials from CLI before validation.
+	// This mirrors Phase 01's auth-mode awareness: when az login is active,
+	// subscription/tenant IDs are auto-extracted and SP credentials are not required.
+	spOnlyVars := map[string]bool{}
+	if config.HasProvider("aro") {
+		if err := EnsureAzureCredentialsSet(t); err != nil {
+			t.Logf("Azure CLI credential extraction failed: %v", err)
+		}
+		authMode := DetectAzureAuthMode(t)
+		t.Logf("Azure auth mode: %s", GetAzureAuthDescription(authMode))
+		if authMode == AzureAuthModeCLI {
+			spOnlyVars["AZURE_CLIENT_ID"] = true
+			spOnlyVars["AZURE_CLIENT_SECRET"] = true
+		}
+	}
+
 	var allMissing []EnvVarRequirement
 	for _, provider := range config.InfraProviders {
 		if len(provider.YAMLGenCredentials) == 0 {
@@ -51,6 +67,10 @@ func TestInfrastructure_01_ValidateCredentials(t *testing.T) {
 
 		var missing []EnvVarRequirement
 		for _, envReq := range provider.YAMLGenCredentials {
+			if spOnlyVars[envReq.Name] {
+				PrintToTTY("  ⏭️  %s: skipped (not required for Azure CLI auth)\n", envReq.Name)
+				continue
+			}
 			value := os.Getenv(envReq.Name)
 			if value == "" {
 				missing = append(missing, envReq)


### PR DESCRIPTION
## Description

`TestInfrastructure_01_ValidateCredentials` unconditionally required all four Azure env vars (`AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`), failing when using `az login` instead of service principal credentials. This was a regression from ad3ba1a which moved credential checks from Phase 01 to Phase 04 but lost the auth-mode awareness.

## Changes Made

- Detect Azure auth mode before credential validation in Phase 04
- When Azure CLI auth is active, call `EnsureAzureCredentialsSet` to auto-extract subscription/tenant IDs from `az account show`
- Skip `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` checks when using CLI auth (only needed for service principal auth)

## Configuration Changes

No new environment variables. Existing behavior preserved for service principal auth.

## Additional Notes

Phase 01 (`TestCheckDependencies_AzureAuthentication`) already handles both auth modes correctly. This fix brings Phase 04 in line with the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)