### PR TITLE
fix(ci): use default stolostron repo instead of personal fork

### DIFF
--- a/.github/workflows/management-cluster-aro.yml
+++ b/.github/workflows/management-cluster-aro.yml
@@ -40,8 +40,6 @@ permissions:
 
 env:
   INFRA_PROVIDER: aro
-  ARO_REPO_URL: https://github.com/marek-veber/cluster-api-installer.git
-  ARO_REPO_BRANCH: capi-tests
   ARO_REPO_DIR: /tmp/cluster-api-installer-aro
   USE_KIND: "true"
   QUAY_AUTH: ${{ secrets.QUAY_AUTH }}

--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -44,13 +44,10 @@ permissions:
 
 env:
   INFRA_PROVIDER: aro
-  ARO_REPO_URL: https://github.com/marek-veber/cluster-api-installer.git
-  ARO_REPO_BRANCH: capi-tests
   ARO_REPO_DIR: /tmp/cluster-api-installer-aro
   TEST_TIMEOUT_MINUTES: 120
   # Global variables (not environment-specific)
   QUAY_AUTH: ${{ secrets.QUAY_AUTH }}
-  CAPI_USER: mv2
 
 jobs:
   check-changes:


### PR DESCRIPTION
## Description

Both GHA workflows (`management-cluster-aro.yml` and `workload-cluster-aro.yml`) were hardcoded to clone `marek-veber/cluster-api-installer` on the `capi-tests` branch with `CAPI_USER=mv2`. This pointed all CI runs at a personal fork instead of the stolostron organization repo.

## Changes Made

- Removed `ARO_REPO_URL` and `ARO_REPO_BRANCH` overrides from both workflow files
- Removed `CAPI_USER: mv2` override from `workload-cluster-aro.yml`
- Workflows now use the defaults from `config.go`: `stolostron/cluster-api-installer` on `main` with `CAPI_USER=cate`

## Configuration Changes

No new variables. Existing overrides removed to use defaults.

## Additional Notes

The defaults in `test/config.go` are:
- `ARO_REPO_URL` → `https://github.com/stolostron/cluster-api-installer`
- `ARO_REPO_BRANCH` → `main`
- `CAPI_USER` → `cate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed environment variable definitions (`ARO_REPO_URL`, `ARO_REPO_BRANCH`, and `CAPI_USER`) from Azure Red Hat OpenShift workflow configurations to streamline pipeline settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->