### PR TITLE
fix: two-phase stall detection to avoid false positives during HCP provisioning

### DIFF
--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -476,11 +476,15 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 	lastProgressTime := startTime
 	lastProgress := stallProgressState{}
 	if stallEnabled {
+		postInfraTimeout := stallTimeout * 2
 		if stallTimeout >= timeout {
 			PrintToTTY("Stall detection: enabled (infra: %v, post-infra: %v) — WARNING: stall timeout >= deployment timeout (%v), stall detection will never trigger\n\n",
-				stallTimeout, stallTimeout*2, timeout)
+				stallTimeout, postInfraTimeout, timeout)
+		} else if postInfraTimeout >= timeout {
+			PrintToTTY("Stall detection: enabled (infra: %v, post-infra: %v) — WARNING: post-infra stall timeout >= deployment timeout (%v), stall detection will not trigger during post-infrastructure phase\n\n",
+				stallTimeout, postInfraTimeout, timeout)
 		} else {
-			PrintToTTY("Stall detection: enabled (infra: %v, post-infra: %v)\n\n", stallTimeout, stallTimeout*2)
+			PrintToTTY("Stall detection: enabled (infra: %v, post-infra: %v)\n\n", stallTimeout, postInfraTimeout)
 		}
 	}
 
@@ -521,6 +525,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 		data, err := MonitorCluster(t, context, config.WorkloadClusterNamespace, provisionedClusterName)
 		if err != nil {
 			PrintToTTY("[%d] ⚠️  monitor-cluster-json.sh failed: %v\n", iteration, err)
+			// lastProgress used as currentProgress: no fresh data, so preserve the phase from the last successful check.
 			checkStallTimeout(t, stallEnabled, stallTimeout, lastProgressTime, lastProgress, lastProgress, context, config.WorkloadClusterNamespace, provisionedClusterName)
 			time.Sleep(pollInterval)
 			continue

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -477,10 +477,10 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 	lastProgress := stallProgressState{}
 	if stallEnabled {
 		if stallTimeout >= timeout {
-			PrintToTTY("Stall detection: enabled (timeout: %v) — WARNING: stall timeout >= deployment timeout (%v), stall detection will never trigger\n\n",
-				stallTimeout, timeout)
+			PrintToTTY("Stall detection: enabled (infra: %v, post-infra: %v) — WARNING: stall timeout >= deployment timeout (%v), stall detection will never trigger\n\n",
+				stallTimeout, stallTimeout*2, timeout)
 		} else {
-			PrintToTTY("Stall detection: enabled (timeout: %v)\n\n", stallTimeout)
+			PrintToTTY("Stall detection: enabled (infra: %v, post-infra: %v)\n\n", stallTimeout, stallTimeout*2)
 		}
 	}
 
@@ -521,7 +521,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 		data, err := MonitorCluster(t, context, config.WorkloadClusterNamespace, provisionedClusterName)
 		if err != nil {
 			PrintToTTY("[%d] ⚠️  monitor-cluster-json.sh failed: %v\n", iteration, err)
-			checkStallTimeout(t, stallEnabled, stallTimeout, lastProgressTime, lastProgress, context, config.WorkloadClusterNamespace, provisionedClusterName)
+			checkStallTimeout(t, stallEnabled, stallTimeout, lastProgressTime, lastProgress, lastProgress, context, config.WorkloadClusterNamespace, provisionedClusterName)
 			time.Sleep(pollInterval)
 			continue
 		}
@@ -696,6 +696,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 				mpProvisioningState: currentMPState,
 				infraTotalResources: infraTotal,
 				infraResourceReady:  infraReady,
+				infraComplete:       infraTotal > 0 && infraReady == infraTotal,
 			}
 
 			if current != lastProgress {
@@ -703,7 +704,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 				lastProgress = current
 			}
 
-			checkStallTimeout(t, stallEnabled, stallTimeout, lastProgressTime, lastProgress, context, config.WorkloadClusterNamespace, provisionedClusterName)
+			checkStallTimeout(t, stallEnabled, stallTimeout, lastProgressTime, lastProgress, current, context, config.WorkloadClusterNamespace, provisionedClusterName)
 		}
 
 		// Both ready — done
@@ -1372,39 +1373,56 @@ type stallProgressState struct {
 	mpProvisioningState string
 	infraTotalResources int
 	infraResourceReady  int
+	infraComplete       bool
 }
 
 // checkStallTimeout fails the test if no deployment progress has been made within the stall timeout.
+// Uses two-phase detection: the configured timeout during infrastructure provisioning, and 2x the
+// configured timeout after infrastructure completes (when waiting for the hosted control plane,
+// which is an opaque Azure-side operation that can take 30-45+ minutes).
 // Safe to call from error-recovery paths (e.g., monitor script failure) where status data is unavailable.
-func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Duration, lastProgressTime time.Time, lastProgress stallProgressState, context, namespace, clusterName string) {
+func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Duration, lastProgressTime time.Time, lastProgress, currentProgress stallProgressState, context, namespace, clusterName string) {
 	t.Helper()
 	if !stallEnabled {
 		return
 	}
+
+	effectiveTimeout := stallTimeout
+	phase := "infrastructure"
+	if currentProgress.infraComplete && !currentProgress.cpReady {
+		effectiveTimeout = stallTimeout * 2
+		phase = "post-infrastructure"
+	}
+
 	stallDuration := time.Since(lastProgressTime)
-	if stallDuration <= stallTimeout {
+	if stallDuration <= effectiveTimeout {
 		return
 	}
 
-	PrintToTTY("\n❌ Deployment stalled: no progress for %v\n", stallDuration.Round(time.Second))
-	PrintToTTY("   Last state: ControlPlane.Ready=%v, State=%q, MachinePool.ReadyReplicas=%d, ProvisioningState=%q, InfraResources=%d/%d\n\n",
-		lastProgress.cpReady, lastProgress.cpState, lastProgress.mpReadyReplicas, lastProgress.mpProvisioningState,
-		lastProgress.infraResourceReady, lastProgress.infraTotalResources)
+	infraStatus := fmt.Sprintf("%d/%d", lastProgress.infraResourceReady, lastProgress.infraTotalResources)
+	if lastProgress.infraComplete {
+		infraStatus += " (done)"
+	}
+
+	PrintToTTY("\n❌ Deployment stalled: no progress for %v (%s phase, timeout: %v)\n", stallDuration.Round(time.Second), phase, effectiveTimeout)
+	PrintToTTY("   Infrastructure: %s\n", infraStatus)
+	PrintToTTY("   Blocked on: ControlPlane.Ready=%v, MachinePool replicas=%d, ProvisioningState=%q\n\n",
+		lastProgress.cpReady, lastProgress.mpReadyReplicas, lastProgress.mpProvisioningState)
 
 	CollectAndDumpInfraDiagnostics(t, context, namespace, clusterName)
 
-	t.Fatalf("Deployment stalled: no progress for %v (stall timeout: %v).\n"+
+	t.Fatalf("Deployment stalled: no progress for %v (%s phase, stall timeout: %v).\n"+
+		"  Infrastructure: %s\n"+
 		"  ControlPlane ready: %v\n"+
 		"  ControlPlane state: %s\n"+
 		"  MachinePool ready replicas: %d\n"+
-		"  MachinePool provisioning state: %s\n"+
-		"  Infrastructure resources: %d/%d\n\n"+
+		"  MachinePool provisioning state: %s\n\n"+
 		"This usually indicates an infrastructure-side issue (e.g., ARO HCP stuck in Reconciling).\n"+
 		"Check the cloud provider's service health dashboard.\n\n"+
 		"To increase stall timeout: export DEPLOYMENT_STALL_TIMEOUT=45m\n"+
 		"To disable stall detection: export DEPLOYMENT_STALL_TIMEOUT=0",
-		stallDuration.Round(time.Second), stallTimeout,
+		stallDuration.Round(time.Second), phase, effectiveTimeout,
+		infraStatus,
 		lastProgress.cpReady, lastProgress.cpState,
-		lastProgress.mpReadyReplicas, lastProgress.mpProvisioningState,
-		lastProgress.infraResourceReady, lastProgress.infraTotalResources)
+		lastProgress.mpReadyReplicas, lastProgress.mpProvisioningState)
 }

--- a/test/config.go
+++ b/test/config.go
@@ -31,10 +31,9 @@ const (
 	// MCE components need time to deploy controllers, pull images, and initialize.
 	DefaultMCEEnablementTimeout = 15 * time.Minute
 
-	// DefaultDeploymentStallTimeout is the default stall detection timeout.
-	// If the deployment makes no progress (control plane ready status, machine pool replicas,
-	// or infrastructure resource count unchanged) for this duration, the test fails early
-	// instead of waiting for the full DeploymentTimeout.
+	// DefaultDeploymentStallTimeout is the default stall detection timeout for the infrastructure phase.
+	// After infrastructure resources are fully reconciled, the timeout doubles (2x) for the
+	// post-infrastructure phase where the hosted control plane provisioning is opaque.
 	// Set to 0 to disable stall detection.
 	DefaultDeploymentStallTimeout = 30 * time.Minute
 


### PR DESCRIPTION
## Description

The stall detection (30m default) triggers false positives when the ARO HCP control plane takes longer than 30 minutes to provision after infrastructure resources complete. In successful runs, this post-infrastructure quiet period is ~15 minutes, but it can legitimately take 30-45+ minutes — during which `HcpClusterReady: False (Reconciling)` stays identical with no sub-progress signal from Azure.

## Changes Made

- Split stall detection into two phases:
  - **Infrastructure phase** (resources still provisioning): uses configured timeout (default 30m)
  - **Post-infrastructure phase** (infra done, waiting for HCP): uses 2x timeout (default 60m)
- Improve stall error messages to show which phase triggered and infrastructure completion status
- Update startup banner to display both phase timeouts

## Configuration Changes

No new environment variables. `DEPLOYMENT_STALL_TIMEOUT` continues to work as before — the post-infrastructure timeout is automatically derived as 2x the configured value.

## Additional Notes

- A stuck infrastructure provisioning still fails at ~30m (unchanged)
- A stuck HCP provisioning now fails at ~60m instead of 30m (was causing false positives)
- Normal deployments (15-30m HCP provisioning) are no longer affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stall detection during deployment with two-phase timeout monitoring: infrastructure phase uses the standard timeout, while post-infrastructure phase uses an extended timeout
  * Updated diagnostic messages to show the detected phase, effective timeout value, and whether infrastructure is complete for clearer troubleshooting

* **Documentation**
  * Clarified timeout behavior description for deployment stall detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->