### PR TITLE
test: add unit tests for two-phase stall detection

### DIFF
--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1381,15 +1381,20 @@ type stallProgressState struct {
 	infraComplete       bool
 }
 
-// checkStallTimeout fails the test if no deployment progress has been made within the stall timeout.
-// Uses two-phase detection: the configured timeout during infrastructure provisioning, and 2x the
-// configured timeout after infrastructure completes (when waiting for the hosted control plane,
-// which is an opaque Azure-side operation that can take 30-45+ minutes).
-// Safe to call from error-recovery paths (e.g., monitor script failure) where status data is unavailable.
-func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Duration, lastProgressTime time.Time, lastProgress, currentProgress stallProgressState, context, namespace, clusterName string) {
-	t.Helper()
+// stallResult holds the outcome of stall phase detection.
+type stallResult struct {
+	stalled          bool
+	effectiveTimeout time.Duration
+	phase            string
+	stallDuration    time.Duration
+}
+
+// detectStallPhase determines whether the deployment has stalled and which phase it is in.
+// Infrastructure phase uses the configured timeout; post-infrastructure phase (infra done,
+// waiting for HCP) uses 2x the configured timeout since HCP provisioning is opaque.
+func detectStallPhase(stallEnabled bool, stallTimeout time.Duration, stallDuration time.Duration, currentProgress stallProgressState) stallResult {
 	if !stallEnabled {
-		return
+		return stallResult{}
 	}
 
 	effectiveTimeout := stallTimeout
@@ -1399,8 +1404,22 @@ func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Durati
 		phase = "post-infrastructure"
 	}
 
-	stallDuration := time.Since(lastProgressTime)
-	if stallDuration <= effectiveTimeout {
+	return stallResult{
+		stalled:          stallDuration > effectiveTimeout,
+		effectiveTimeout: effectiveTimeout,
+		phase:            phase,
+		stallDuration:    stallDuration,
+	}
+}
+
+// checkStallTimeout fails the test if no deployment progress has been made within the stall timeout.
+// Uses two-phase detection via detectStallPhase.
+// Safe to call from error-recovery paths (e.g., monitor script failure) where status data is unavailable.
+func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Duration, lastProgressTime time.Time, lastProgress, currentProgress stallProgressState, context, namespace, clusterName string) {
+	t.Helper()
+
+	result := detectStallPhase(stallEnabled, stallTimeout, time.Since(lastProgressTime), currentProgress)
+	if !result.stalled {
 		return
 	}
 
@@ -1409,7 +1428,7 @@ func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Durati
 		infraStatus += " (done)"
 	}
 
-	PrintToTTY("\n❌ Deployment stalled: no progress for %v (%s phase, timeout: %v)\n", stallDuration.Round(time.Second), phase, effectiveTimeout)
+	PrintToTTY("\n❌ Deployment stalled: no progress for %v (%s phase, timeout: %v)\n", result.stallDuration.Round(time.Second), result.phase, result.effectiveTimeout)
 	PrintToTTY("   Infrastructure: %s\n", infraStatus)
 	PrintToTTY("   Blocked on: ControlPlane.Ready=%v, MachinePool replicas=%d, ProvisioningState=%q\n\n",
 		lastProgress.cpReady, lastProgress.mpReadyReplicas, lastProgress.mpProvisioningState)
@@ -1426,7 +1445,7 @@ func checkStallTimeout(t *testing.T, stallEnabled bool, stallTimeout time.Durati
 		"Check the cloud provider's service health dashboard.\n\n"+
 		"To increase stall timeout: export DEPLOYMENT_STALL_TIMEOUT=45m\n"+
 		"To disable stall detection: export DEPLOYMENT_STALL_TIMEOUT=0",
-		stallDuration.Round(time.Second), phase, effectiveTimeout,
+		result.stallDuration.Round(time.Second), result.phase, result.effectiveTimeout,
 		infraStatus,
 		lastProgress.cpReady, lastProgress.cpState,
 		lastProgress.mpReadyReplicas, lastProgress.mpProvisioningState)

--- a/test/stall_detection_test.go
+++ b/test/stall_detection_test.go
@@ -171,6 +171,12 @@ func TestDetectStallPhase(t *testing.T) {
 			}
 
 			if !tt.enabled {
+				if result.phase != "" {
+					t.Errorf("phase = %q, want empty when disabled", result.phase)
+				}
+				if result.effectiveTimeout != 0 {
+					t.Errorf("effectiveTimeout = %v, want 0 when disabled", result.effectiveTimeout)
+				}
 				return
 			}
 

--- a/test/stall_detection_test.go
+++ b/test/stall_detection_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestDetectStallPhase(t *testing.T) {
-	const baseTimeout = 30 * time.Minute
+	const baseTimeout = DefaultDeploymentStallTimeout
 
 	tests := []struct {
 		name             string

--- a/test/stall_detection_test.go
+++ b/test/stall_detection_test.go
@@ -1,0 +1,188 @@
+package test
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDetectStallPhase(t *testing.T) {
+	const baseTimeout = 30 * time.Minute
+
+	tests := []struct {
+		name             string
+		enabled          bool
+		stallTimeout     time.Duration
+		stallDuration    time.Duration
+		progress         stallProgressState
+		wantStalled      bool
+		wantPhase        string
+		wantEffective    time.Duration
+	}{
+		{
+			name:    "disabled returns not stalled",
+			enabled: false,
+			progress: stallProgressState{
+				infraComplete: true,
+			},
+			wantStalled: false,
+		},
+		{
+			name:          "infra phase within timeout",
+			enabled:       true,
+			stallTimeout:  baseTimeout,
+			stallDuration: 20 * time.Minute,
+			progress: stallProgressState{
+				infraComplete: false,
+				cpReady:       false,
+			},
+			wantStalled:   false,
+			wantPhase:     "infrastructure",
+			wantEffective: baseTimeout,
+		},
+		{
+			name:          "infra phase exceeded timeout",
+			enabled:       true,
+			stallTimeout:  baseTimeout,
+			stallDuration: 35 * time.Minute,
+			progress: stallProgressState{
+				infraComplete: false,
+				cpReady:       false,
+			},
+			wantStalled:   true,
+			wantPhase:     "infrastructure",
+			wantEffective: baseTimeout,
+		},
+		{
+			name:          "post-infra phase within 2x timeout",
+			enabled:       true,
+			stallTimeout:  baseTimeout,
+			stallDuration: 45 * time.Minute,
+			progress: stallProgressState{
+				infraComplete:       true,
+				cpReady:             false,
+				infraTotalResources: 46,
+				infraResourceReady:  46,
+			},
+			wantStalled:   false,
+			wantPhase:     "post-infrastructure",
+			wantEffective: 2 * baseTimeout,
+		},
+		{
+			name:          "post-infra phase exceeded 2x timeout",
+			enabled:       true,
+			stallTimeout:  baseTimeout,
+			stallDuration: 65 * time.Minute,
+			progress: stallProgressState{
+				infraComplete:       true,
+				cpReady:             false,
+				infraTotalResources: 46,
+				infraResourceReady:  46,
+			},
+			wantStalled:   true,
+			wantPhase:     "post-infrastructure",
+			wantEffective: 2 * baseTimeout,
+		},
+		{
+			name:          "both infra and cp ready uses base timeout",
+			enabled:       true,
+			stallTimeout:  baseTimeout,
+			stallDuration: 35 * time.Minute,
+			progress: stallProgressState{
+				infraComplete: true,
+				cpReady:       true,
+			},
+			wantStalled:   true,
+			wantPhase:     "infrastructure",
+			wantEffective: baseTimeout,
+		},
+		{
+			name:          "zero stall duration never triggers",
+			enabled:       true,
+			stallTimeout:  baseTimeout,
+			stallDuration: 0,
+			progress: stallProgressState{
+				infraComplete: false,
+				cpReady:       false,
+			},
+			wantStalled:   false,
+			wantPhase:     "infrastructure",
+			wantEffective: baseTimeout,
+		},
+		{
+			name:          "exactly at infra timeout does not trigger",
+			enabled:       true,
+			stallTimeout:  baseTimeout,
+			stallDuration: baseTimeout,
+			progress: stallProgressState{
+				infraComplete: false,
+				cpReady:       false,
+			},
+			wantStalled:   false,
+			wantPhase:     "infrastructure",
+			wantEffective: baseTimeout,
+		},
+		{
+			name:          "exactly at post-infra timeout does not trigger",
+			enabled:       true,
+			stallTimeout:  baseTimeout,
+			stallDuration: 2 * baseTimeout,
+			progress: stallProgressState{
+				infraComplete: true,
+				cpReady:       false,
+			},
+			wantStalled:   false,
+			wantPhase:     "post-infrastructure",
+			wantEffective: 2 * baseTimeout,
+		},
+		{
+			name:          "one nanosecond past infra timeout triggers",
+			enabled:       true,
+			stallTimeout:  baseTimeout,
+			stallDuration: baseTimeout + 1,
+			progress: stallProgressState{
+				infraComplete: false,
+				cpReady:       false,
+			},
+			wantStalled:   true,
+			wantPhase:     "infrastructure",
+			wantEffective: baseTimeout,
+		},
+		{
+			name:          "one nanosecond past post-infra timeout triggers",
+			enabled:       true,
+			stallTimeout:  baseTimeout,
+			stallDuration: 2*baseTimeout + 1,
+			progress: stallProgressState{
+				infraComplete: true,
+				cpReady:       false,
+			},
+			wantStalled:   true,
+			wantPhase:     "post-infrastructure",
+			wantEffective: 2 * baseTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detectStallPhase(tt.enabled, tt.stallTimeout, tt.stallDuration, tt.progress)
+
+			if result.stalled != tt.wantStalled {
+				t.Errorf("stalled = %v, want %v", result.stalled, tt.wantStalled)
+			}
+
+			if !tt.enabled {
+				return
+			}
+
+			if result.phase != tt.wantPhase {
+				t.Errorf("phase = %q, want %q", result.phase, tt.wantPhase)
+			}
+			if result.effectiveTimeout != tt.wantEffective {
+				t.Errorf("effectiveTimeout = %v, want %v", result.effectiveTimeout, tt.wantEffective)
+			}
+			if result.stallDuration != tt.stallDuration {
+				t.Errorf("stallDuration = %v, want %v", result.stallDuration, tt.stallDuration)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add unit tests for the two-phase stall detection logic (ARO-26542).

Depends on #684 (two-phase stall detection).

## Changes Made

- Extract `detectStallPhase` pure function from `checkStallTimeout` for testability
- Add `stallResult` struct to hold phase detection outcome
- Refactor `checkStallTimeout` to delegate to `detectStallPhase`
- Add `test/stall_detection_test.go` with 11 table-driven test cases covering:
  - Disabled stall detection
  - Infrastructure phase: within timeout, exceeded, boundary
  - Post-infrastructure phase: within 2x timeout, exceeded, boundary
  - Both phases complete (cpReady=true falls back to base timeout)
  - Edge cases: zero duration, nanosecond past boundary

## Configuration Changes

No configuration changes.

## Additional Notes

The `detectStallPhase` function takes `stallDuration` as a parameter (instead of computing via `time.Since`),
making it a pure function that's deterministic and fast to test without real cluster connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced stall detection test coverage with comprehensive unit tests and improved deployment reliability validation during infrastructure provisioning phases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->