### PR TITLE
fix: use unique cluster prefix for orphaned resource cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -539,17 +539,17 @@ clean: ## Clean up test resources (interactive, use FORCE=1 to skip prompts)
 		fi; \
 		echo ""; \
 		echo "--- Orphaned Azure Resources ---"; \
-		echo "These are resources with prefix '$(CLEANUP_WORKLOAD_CLUSTER)' that may exist outside the resource group."; \
+		echo "These are resources with prefix '$(CLEANUP_CLUSTER_PREFIX)' that may exist outside the resource group."; \
 		echo ""; \
 		if ! command -v az >/dev/null 2>&1; then \
 			echo "⚠️  Azure CLI (az) not available - skipping orphaned resources cleanup"; \
 		elif ! az account show >/dev/null 2>&1; then \
 			echo "⚠️  Not logged in to Azure - skipping orphaned resources cleanup"; \
 		else \
-			read -p "Search for and delete orphaned Azure resources with prefix '$(CLEANUP_WORKLOAD_CLUSTER)'? [y/N] " -n 1 -r; \
+			read -p "Search for and delete orphaned Azure resources with prefix '$(CLEANUP_CLUSTER_PREFIX)'? [y/N] " -n 1 -r; \
 			echo ""; \
 			if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
-				./scripts/cleanup-azure-resources.sh --prefix "$(CLEANUP_WORKLOAD_CLUSTER)" --match-mode contains || echo "Orphaned resources cleanup encountered an error"; \
+				./scripts/cleanup-azure-resources.sh --prefix "$(CLEANUP_CLUSTER_PREFIX)" --match-mode contains || echo "Orphaned resources cleanup encountered an error"; \
 			else \
 				echo "Skipped orphaned resources cleanup."; \
 				echo "Tip: Run 'make clean-azure' to clean all Azure resources (including orphaned)."; \
@@ -641,15 +641,15 @@ clean-azure: ## Delete all Azure resources (resource group, orphaned resources, 
 		echo ""; \
 	fi
 	@if [ "$(FORCE)" = "1" ]; then \
-		./scripts/cleanup-azure-resources.sh --resource-group "$(CLEANUP_RESOURCE_GROUP)" --prefix "$(CLEANUP_WORKLOAD_CLUSTER)" --match-mode contains --force; \
+		./scripts/cleanup-azure-resources.sh --resource-group "$(CLEANUP_RESOURCE_GROUP)" --prefix "$(CLEANUP_CLUSTER_PREFIX)" --match-mode contains --force; \
 	else \
-		./scripts/cleanup-azure-resources.sh --resource-group "$(CLEANUP_RESOURCE_GROUP)" --prefix "$(CLEANUP_WORKLOAD_CLUSTER)" --match-mode contains; \
+		./scripts/cleanup-azure-resources.sh --resource-group "$(CLEANUP_RESOURCE_GROUP)" --prefix "$(CLEANUP_CLUSTER_PREFIX)" --match-mode contains; \
 	fi
 
 # Internal target: force delete all Azure resources without prompting
 .PHONY: _clean-azure-force
 _clean-azure-force:
-	@./scripts/cleanup-azure-resources.sh --resource-group "$(CLEANUP_RESOURCE_GROUP)" --prefix "$(CLEANUP_WORKLOAD_CLUSTER)" --match-mode contains --force 2>/dev/null || true
+	@./scripts/cleanup-azure-resources.sh --resource-group "$(CLEANUP_RESOURCE_GROUP)" --prefix "$(CLEANUP_CLUSTER_PREFIX)" --match-mode contains --force 2>/dev/null || true
 
 # Internal target: conditionally clean Azure resources (only for ARO)
 .PHONY: _clean-azure-conditional

--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,11 @@ DEPLOYMENT_STATE_FILE := .deployment-state.json
 STATE_RESOURCE_GROUP := $(shell if [ -f $(DEPLOYMENT_STATE_FILE) ]; then cat $(DEPLOYMENT_STATE_FILE) | grep '"resource_group"' | sed 's/.*: *"\([^"]*\)".*/\1/'; fi)
 STATE_MANAGEMENT_CLUSTER := $(shell if [ -f $(DEPLOYMENT_STATE_FILE) ]; then cat $(DEPLOYMENT_STATE_FILE) | grep '"management_cluster_name"' | sed 's/.*: *"\([^"]*\)".*/\1/'; fi)
 STATE_CLUSTER_PREFIX := $(shell if [ -f $(DEPLOYMENT_STATE_FILE) ]; then cat $(DEPLOYMENT_STATE_FILE) | grep '"cluster_name_prefix"' | sed 's/.*: *"\([^"]*\)".*/\1/'; fi)
-STATE_WORKLOAD_CLUSTER := $(shell if [ -f $(DEPLOYMENT_STATE_FILE) ]; then cat $(DEPLOYMENT_STATE_FILE) | grep '"workload_cluster_name"' | sed 's/.*: *"\([^"]*\)".*/\1/'; fi)
 
 # Use state file values if available, otherwise use defaults
 CLEANUP_RESOURCE_GROUP := $(if $(STATE_RESOURCE_GROUP),$(STATE_RESOURCE_GROUP),$(AZURE_RESOURCE_GROUP))
 CLEANUP_MANAGEMENT_CLUSTER := $(if $(STATE_MANAGEMENT_CLUSTER),$(STATE_MANAGEMENT_CLUSTER),$(MANAGEMENT_CLUSTER_NAME))
 CLEANUP_CLUSTER_PREFIX := $(if $(STATE_CLUSTER_PREFIX),$(STATE_CLUSTER_PREFIX),$(CS_CLUSTER_NAME))
-CLEANUP_WORKLOAD_CLUSTER := $(if $(STATE_WORKLOAD_CLUSTER),$(STATE_WORKLOAD_CLUSTER),$(WORKLOAD_CLUSTER_NAME))
 
 # Test configuration
 GOTESTSUM_FORMAT ?= testname


### PR DESCRIPTION
## Description

Cleanup targets used the static workload cluster name (`capz-tests`) as the `--prefix` for orphaned Azure resource discovery instead of the unique per-run cluster name prefix (e.g., `cate-a1b2c`). This could cause cleanup to match resources from other parallel test runs.

## Changes Made

- Changed `--prefix` parameter in `clean`, `clean-azure`, and `_clean-azure-force` Makefile targets from `CLEANUP_WORKLOAD_CLUSTER` to `CLEANUP_CLUSTER_PREFIX`
- Updated interactive prompt text to show the correct prefix

## Configuration Changes

No new variables. `CLEANUP_CLUSTER_PREFIX` was already defined (line 45) but unused.

## Additional Notes

Observed in CI run: https://github.com/stolostron/capi-tests/actions/runs/25046619700/job/73363282941
- Cleanup showed: `[INFO] Resource prefix: capz-tests`
- Test run used: `RESOURCEGROUPNAME: capz-tests-14f73-resgroup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Azure resource cleanup to use a consistent cluster prefix for identifying orphaned resources.
  * Aligned forced and non-forced cleanup flows to behave consistently.

* **Bug Fixes**
  * Improved interactive messaging and prompts related to orphaned Azure resources for clearer user guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->