### PR TITLE
fix: strip YAML frontmatter from command file in scheduled-review.sh

### DIFF
--- a/scripts/scheduled-review.sh
+++ b/scripts/scheduled-review.sh
@@ -106,7 +106,7 @@ if [[ ! -f "$COMMAND_FILE" ]]; then
     exit 1
 fi
 
-PROMPT=$(cat "$COMMAND_FILE")
+PROMPT=$(sed '1{/^---$/d}' "$COMMAND_FILE" | sed '1,/^---$/d')
 
 # Adjust time window if not default
 if [[ "$HOURS" != "24" ]]; then


### PR DESCRIPTION
## Description

The `make scheduled-review` target fails because `scheduled-review.sh` passes
the raw command file (including YAML frontmatter) as a prompt to `claude -p`.
The leading `---` is interpreted as an unknown CLI option.

## Changes Made

- Strip YAML frontmatter from the command file before passing it to `claude -p`

## Additional Notes

The command file `.claude/commands/scheduled-review.md` starts with a `---`
delimited frontmatter block (used by Claude Code for skill metadata). The `sed`
pipeline removes the opening `---`, then everything up to and including the
closing `---`, leaving only the prompt content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the scheduled review process to correctly handle files containing YAML headers, ensuring they are properly processed without including metadata markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->