### PR TITLE
feat: add namespace cleanup to deletion and cleanup phases (ARO-26591)

### DIFF
--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -453,10 +453,15 @@ func TestDeletion_Summary(t *testing.T) {
 	}
 
 	// Check namespace status
-	_, nsErr := RunCommandQuiet(t, "kubectl", "--context", context,
+	nsOutput, nsErr := RunCommandQuiet(t, "kubectl", "--context", context,
 		"get", "namespace", config.WorkloadClusterNamespace)
 	if nsErr != nil {
-		PrintToTTY("✅ Namespace '%s' deleted\n", config.WorkloadClusterNamespace)
+		errMsg := strings.ToLower(nsOutput + " " + nsErr.Error())
+		if strings.Contains(errMsg, "not found") || strings.Contains(errMsg, "notfound") {
+			PrintToTTY("✅ Namespace '%s' deleted\n", config.WorkloadClusterNamespace)
+		} else {
+			PrintToTTY("⚠️  Could not determine namespace status: %v\n", nsErr)
+		}
 	} else {
 		PrintToTTY("⚠️  Namespace '%s' still exists\n", config.WorkloadClusterNamespace)
 	}

--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -349,6 +349,57 @@ func TestDeletion_VerifyAzureResourcesDeletion(t *testing.T) {
 	}
 }
 
+// TestDeletion_DeleteNamespace deletes the workload cluster namespace after all resources
+// have been deleted. Each test run creates a unique namespace (e.g., capz-test-20260202-135526)
+// that must be cleaned up to prevent namespace accumulation on the management cluster.
+func TestDeletion_DeleteNamespace(t *testing.T) {
+	config := NewTestConfig()
+
+	if config.IsExternalCluster() {
+		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
+	}
+
+	context := config.GetKubeContext()
+
+	PrintTestHeader(t, "TestDeletion_DeleteNamespace",
+		"Delete workload cluster namespace from management cluster")
+
+	// Check if namespace exists
+	_, err := RunCommandQuiet(t, "kubectl", "--context", context,
+		"get", "namespace", config.WorkloadClusterNamespace)
+	if err != nil {
+		PrintToTTY("Namespace '%s' not found (already deleted or never created)\n\n", config.WorkloadClusterNamespace)
+		t.Skipf("Namespace '%s' not found", config.WorkloadClusterNamespace)
+	}
+
+	// Check if namespace still has CAPI resources (safety check)
+	resources, resErr := GetNamespaceResources(t, context, config.WorkloadClusterNamespace)
+	if resErr == nil && resources != "" {
+		PrintToTTY("⚠️  Namespace '%s' still contains resources:\n%s\n\n", config.WorkloadClusterNamespace, resources)
+		t.Logf("Warning: namespace still contains resources, proceeding with deletion anyway")
+	}
+
+	PrintToTTY("Deleting namespace '%s'...\n", config.WorkloadClusterNamespace)
+	t.Logf("Deleting namespace '%s'", config.WorkloadClusterNamespace)
+
+	output, err := RunCommand(t, "kubectl", "--context", context,
+		"delete", "namespace", config.WorkloadClusterNamespace, "--wait=true", "--timeout=5m")
+	if err != nil {
+		PrintToTTY("❌ Failed to delete namespace: %v\n", err)
+		PrintToTTY("Output: %s\n\n", output)
+		t.Fatalf("Failed to delete namespace '%s': %v\nOutput: %s\n\n"+
+			"Troubleshooting:\n"+
+			"  1. Check for stuck finalizers: kubectl --context %s get namespace %s -o yaml\n"+
+			"  2. Manual cleanup: kubectl --context %s delete namespace %s",
+			config.WorkloadClusterNamespace, err, output,
+			context, config.WorkloadClusterNamespace,
+			context, config.WorkloadClusterNamespace)
+	}
+
+	PrintToTTY("✅ Namespace '%s' deleted successfully\n\n", config.WorkloadClusterNamespace)
+	t.Logf("Deleted namespace: %s", config.WorkloadClusterNamespace)
+}
+
 // TestDeletion_Summary provides a summary of the deletion process.
 func TestDeletion_Summary(t *testing.T) {
 	config := NewTestConfig()
@@ -395,6 +446,15 @@ func TestDeletion_Summary(t *testing.T) {
 		if machinePoolCount > 0 {
 			PrintToTTY("⚠️  %d MachinePool resource(s) remain\n", machinePoolCount)
 		}
+	}
+
+	// Check namespace status
+	_, nsErr := RunCommandQuiet(t, "kubectl", "--context", context,
+		"get", "namespace", config.WorkloadClusterNamespace)
+	if nsErr != nil {
+		PrintToTTY("✅ Namespace '%s' deleted\n", config.WorkloadClusterNamespace)
+	} else {
+		PrintToTTY("⚠️  Namespace '%s' still exists\n", config.WorkloadClusterNamespace)
 	}
 
 	// Summary message

--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -365,11 +365,15 @@ func TestDeletion_DeleteNamespace(t *testing.T) {
 		"Delete workload cluster namespace from management cluster")
 
 	// Check if namespace exists
-	_, err := RunCommandQuiet(t, "kubectl", "--context", context,
+	output, err := RunCommandQuiet(t, "kubectl", "--context", context,
 		"get", "namespace", config.WorkloadClusterNamespace)
 	if err != nil {
-		PrintToTTY("Namespace '%s' not found (already deleted or never created)\n\n", config.WorkloadClusterNamespace)
-		t.Skipf("Namespace '%s' not found", config.WorkloadClusterNamespace)
+		errMsg := strings.ToLower(output + " " + err.Error())
+		if strings.Contains(errMsg, "not found") || strings.Contains(errMsg, "notfound") {
+			PrintToTTY("Namespace '%s' not found (already deleted or never created)\n\n", config.WorkloadClusterNamespace)
+			t.Skipf("Namespace '%s' not found", config.WorkloadClusterNamespace)
+		}
+		t.Fatalf("Failed to check namespace '%s': %v (output: %s)", config.WorkloadClusterNamespace, err, output)
 	}
 
 	// Check if namespace still has CAPI resources (safety check)
@@ -382,7 +386,7 @@ func TestDeletion_DeleteNamespace(t *testing.T) {
 	PrintToTTY("Deleting namespace '%s'...\n", config.WorkloadClusterNamespace)
 	t.Logf("Deleting namespace '%s'", config.WorkloadClusterNamespace)
 
-	output, err := RunCommand(t, "kubectl", "--context", context,
+	output, err = RunCommand(t, "kubectl", "--context", context,
 		"delete", "namespace", config.WorkloadClusterNamespace, "--wait=true", "--timeout=5m")
 	if err != nil {
 		PrintToTTY("❌ Failed to delete namespace: %v\n", err)

--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -389,6 +389,12 @@ func TestDeletion_DeleteManagementClusterK8sTestNamespace(t *testing.T) {
 	output, err = RunCommand(t, "kubectl", "--context", context,
 		"delete", "namespace", config.WorkloadClusterNamespace, "--wait=true", "--timeout=5m")
 	if err != nil {
+		errMsg := strings.ToLower(output + " " + err.Error())
+		if strings.Contains(errMsg, "not found") || strings.Contains(errMsg, "notfound") {
+			PrintToTTY("Namespace '%s' already deleted\n\n", config.WorkloadClusterNamespace)
+			t.Logf("Namespace '%s' already deleted before delete call completed", config.WorkloadClusterNamespace)
+			return
+		}
 		PrintToTTY("❌ Failed to delete namespace: %v\n", err)
 		PrintToTTY("Output: %s\n\n", output)
 		t.Fatalf("Failed to delete namespace '%s': %v\nOutput: %s\n\n"+

--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -378,7 +378,10 @@ func TestDeletion_DeleteManagementClusterK8sTestNamespace(t *testing.T) {
 
 	// Check if namespace still has CAPI resources (safety check)
 	resources, resErr := GetManagementClusterK8sTestNamespaceResources(t, context, config.WorkloadClusterNamespace)
-	if resErr == nil && resources != "" {
+	if resErr != nil {
+		PrintToTTY("⚠️  Could not list resources in namespace '%s': %v\n\n", config.WorkloadClusterNamespace, resErr)
+		t.Logf("Warning: failed to list namespace resources before deletion: %v", resErr)
+	} else if resources != "" {
 		PrintToTTY("⚠️  Namespace '%s' still contains resources:\n%s\n\n", config.WorkloadClusterNamespace, resources)
 		t.Logf("Warning: namespace still contains resources, proceeding with deletion anyway")
 	}

--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -349,10 +349,10 @@ func TestDeletion_VerifyAzureResourcesDeletion(t *testing.T) {
 	}
 }
 
-// TestDeletion_DeleteNamespace deletes the workload cluster namespace after all resources
+// TestDeletion_DeleteManagementClusterK8sTestNamespace deletes the workload cluster namespace after all resources
 // have been deleted. Each test run creates a unique namespace (e.g., capz-test-20260202-135526)
 // that must be cleaned up to prevent namespace accumulation on the management cluster.
-func TestDeletion_DeleteNamespace(t *testing.T) {
+func TestDeletion_DeleteManagementClusterK8sTestNamespace(t *testing.T) {
 	config := NewTestConfig()
 
 	if config.IsExternalCluster() {
@@ -361,7 +361,7 @@ func TestDeletion_DeleteNamespace(t *testing.T) {
 
 	context := config.GetKubeContext()
 
-	PrintTestHeader(t, "TestDeletion_DeleteNamespace",
+	PrintTestHeader(t, "TestDeletion_DeleteManagementClusterK8sTestNamespace",
 		"Delete workload cluster namespace from management cluster")
 
 	// Check if namespace exists
@@ -377,7 +377,7 @@ func TestDeletion_DeleteNamespace(t *testing.T) {
 	}
 
 	// Check if namespace still has CAPI resources (safety check)
-	resources, resErr := GetNamespaceResources(t, context, config.WorkloadClusterNamespace)
+	resources, resErr := GetManagementClusterK8sTestNamespaceResources(t, context, config.WorkloadClusterNamespace)
 	if resErr == nil && resources != "" {
 		PrintToTTY("⚠️  Namespace '%s' still contains resources:\n%s\n\n", config.WorkloadClusterNamespace, resources)
 		t.Logf("Warning: namespace still contains resources, proceeding with deletion anyway")

--- a/test/08_cleanup_test.go
+++ b/test/08_cleanup_test.go
@@ -264,24 +264,27 @@ func TestCleanup_VerifyOrphanedNamespaces(t *testing.T) {
 		return
 	}
 
-	if len(namespaces) == 0 {
+	var orphaned []string
+	for _, ns := range namespaces {
+		if ns != config.WorkloadClusterNamespace {
+			orphaned = append(orphaned, ns)
+		}
+	}
+
+	if len(orphaned) == 0 {
 		PrintToTTY("No orphaned test namespaces found (clean state)\n\n")
 		t.Log("No orphaned test namespaces found")
 		return
 	}
 
-	PrintToTTY("Found %d test namespace(s):\n", len(namespaces))
-	for _, ns := range namespaces {
-		if ns == config.WorkloadClusterNamespace {
-			PrintToTTY("  - %s (current test run)\n", ns)
-		} else {
-			PrintToTTY("  - %s (orphaned from previous run)\n", ns)
-		}
+	PrintToTTY("Found %d orphaned test namespace(s):\n", len(orphaned))
+	for _, ns := range orphaned {
+		PrintToTTY("  - %s\n", ns)
 	}
 
-	PrintToTTY("\nTo clean up all test namespaces:\n")
+	PrintToTTY("\nTo clean up all orphaned test namespaces:\n")
 	PrintToTTY("  kubectl --context %s delete namespace -l %s=true\n\n", context, config.TestLabelPrefix)
-	t.Logf("Found %d test namespace(s) on management cluster", len(namespaces))
+	t.Logf("Found %d orphaned test namespace(s) on management cluster", len(orphaned))
 }
 
 // ============================================================================

--- a/test/08_cleanup_test.go
+++ b/test/08_cleanup_test.go
@@ -200,6 +200,85 @@ func TestCleanup_VerifyDeploymentStateFile(t *testing.T) {
 }
 
 // ============================================================================
+// Namespace Cleanup Tests
+// ============================================================================
+
+// TestCleanup_VerifyNamespaceRemoval verifies the current test run's namespace was cleaned up.
+func TestCleanup_VerifyNamespaceRemoval(t *testing.T) {
+	config := NewTestConfig()
+
+	PrintTestHeader(t, "TestCleanup_VerifyNamespaceRemoval",
+		"Verify workload cluster namespace was removed")
+
+	if config.IsExternalCluster() {
+		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
+	}
+
+	context := config.GetKubeContext()
+
+	_, err := RunCommandQuiet(t, "kubectl", "--context", context,
+		"get", "namespace", config.WorkloadClusterNamespace)
+	if err != nil {
+		PrintToTTY("Namespace '%s' not found (clean state)\n\n", config.WorkloadClusterNamespace)
+		t.Logf("Namespace '%s' does not exist - cleanup verified", config.WorkloadClusterNamespace)
+		return
+	}
+
+	PrintToTTY("⚠️  Namespace '%s' still exists on management cluster\n", config.WorkloadClusterNamespace)
+
+	resources, resErr := GetNamespaceResources(t, context, config.WorkloadClusterNamespace)
+	if resErr == nil && resources != "" {
+		PrintToTTY("Resources in namespace:\n%s\n", resources)
+	} else {
+		PrintToTTY("Namespace appears empty\n")
+	}
+
+	PrintToTTY("\nUse 'kubectl --context %s delete namespace %s' to remove\n\n", context, config.WorkloadClusterNamespace)
+	t.Logf("Namespace '%s' still exists after test run", config.WorkloadClusterNamespace)
+}
+
+// TestCleanup_VerifyOrphanedNamespaces checks for leftover test namespaces from previous runs.
+// These are identified by the test label (e.g., "capz-test=true" for ARO).
+func TestCleanup_VerifyOrphanedNamespaces(t *testing.T) {
+	config := NewTestConfig()
+
+	PrintTestHeader(t, "TestCleanup_VerifyOrphanedNamespaces",
+		fmt.Sprintf("Check for orphaned test namespaces (label: %s=true)", config.TestLabelPrefix))
+
+	if config.IsExternalCluster() {
+		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
+	}
+
+	context := config.GetKubeContext()
+
+	namespaces, err := GetTestNamespaces(t, context)
+	if err != nil {
+		PrintToTTY("⚠️  Could not list test namespaces: %v\n\n", err)
+		t.Logf("Warning: Could not list test namespaces: %v", err)
+		return
+	}
+
+	if len(namespaces) == 0 {
+		PrintToTTY("No orphaned test namespaces found (clean state)\n\n")
+		t.Log("No orphaned test namespaces found")
+		return
+	}
+
+	PrintToTTY("Found %d test namespace(s):\n", len(namespaces))
+	for _, ns := range namespaces {
+		if ns == config.WorkloadClusterNamespace {
+			PrintToTTY("  - %s (current test run)\n", ns)
+		} else {
+			PrintToTTY("  - %s (orphaned from previous run)\n", ns)
+		}
+	}
+
+	PrintToTTY("\nTo clean up all test namespaces:\n")
+	PrintToTTY("  kubectl --context %s delete namespace -l %s=true\n\n", context, config.TestLabelPrefix)
+	t.Logf("Found %d test namespace(s) on management cluster", len(namespaces))
+}
+
+// ============================================================================
 // Azure Cleanup Tests
 // ============================================================================
 
@@ -735,6 +814,26 @@ func TestCleanup_Summary(t *testing.T) {
 		PrintToTTY("  Deploy State:     EXISTS\n")
 	} else {
 		PrintToTTY("  Deploy State:     CLEAN\n")
+	}
+
+	// Management cluster namespaces
+	PrintToTTY("\n--- Management Cluster Namespaces ---\n")
+
+	if config.IsExternalCluster() {
+		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
+	}
+
+	context := config.GetKubeContext()
+	testNamespaces, nsErr := GetTestNamespaces(t, context)
+	if nsErr != nil {
+		PrintToTTY("  Test Namespaces:  (could not check: %v)\n", nsErr)
+	} else if len(testNamespaces) == 0 {
+		PrintToTTY("  Test Namespaces:  CLEAN\n")
+	} else {
+		PrintToTTY("  Test Namespaces:  %d found\n", len(testNamespaces))
+		for _, ns := range testNamespaces {
+			PrintToTTY("    - %s\n", ns)
+		}
 	}
 
 	PrintToTTY("\n--- Azure Resources ---\n")

--- a/test/08_cleanup_test.go
+++ b/test/08_cleanup_test.go
@@ -200,14 +200,14 @@ func TestCleanup_VerifyDeploymentStateFile(t *testing.T) {
 }
 
 // ============================================================================
-// Namespace Cleanup Tests
+// Management Cluster K8s Test Namespace Cleanup Tests
 // ============================================================================
 
-// TestCleanup_VerifyNamespaceRemoval verifies the current test run's namespace was cleaned up.
-func TestCleanup_VerifyNamespaceRemoval(t *testing.T) {
+// TestCleanup_VerifyManagementClusterK8sTestNamespaceRemoval verifies the current test run's namespace was cleaned up.
+func TestCleanup_VerifyManagementClusterK8sTestNamespaceRemoval(t *testing.T) {
 	config := NewTestConfig()
 
-	PrintTestHeader(t, "TestCleanup_VerifyNamespaceRemoval",
+	PrintTestHeader(t, "TestCleanup_VerifyManagementClusterK8sTestNamespaceRemoval",
 		"Verify workload cluster namespace was removed")
 
 	if config.IsExternalCluster() {
@@ -232,7 +232,7 @@ func TestCleanup_VerifyNamespaceRemoval(t *testing.T) {
 
 	PrintToTTY("⚠️  Namespace '%s' still exists on management cluster\n", config.WorkloadClusterNamespace)
 
-	resources, resErr := GetNamespaceResources(t, context, config.WorkloadClusterNamespace)
+	resources, resErr := GetManagementClusterK8sTestNamespaceResources(t, context, config.WorkloadClusterNamespace)
 	if resErr == nil && resources != "" {
 		PrintToTTY("Resources in namespace:\n%s\n", resources)
 	} else {
@@ -243,12 +243,12 @@ func TestCleanup_VerifyNamespaceRemoval(t *testing.T) {
 	t.Logf("Namespace '%s' still exists after test run", config.WorkloadClusterNamespace)
 }
 
-// TestCleanup_VerifyOrphanedNamespaces checks for leftover test namespaces from previous runs.
+// TestCleanup_VerifyOrphanedManagementClusterK8sTestNamespaces checks for leftover test namespaces from previous runs.
 // These are identified by the test label (e.g., "capz-test=true" for ARO).
-func TestCleanup_VerifyOrphanedNamespaces(t *testing.T) {
+func TestCleanup_VerifyOrphanedManagementClusterK8sTestNamespaces(t *testing.T) {
 	config := NewTestConfig()
 
-	PrintTestHeader(t, "TestCleanup_VerifyOrphanedNamespaces",
+	PrintTestHeader(t, "TestCleanup_VerifyOrphanedManagementClusterK8sTestNamespaces",
 		fmt.Sprintf("Check for orphaned test namespaces (label: %s=true)", config.TestLabelPrefix))
 
 	if config.IsExternalCluster() {
@@ -257,7 +257,7 @@ func TestCleanup_VerifyOrphanedNamespaces(t *testing.T) {
 
 	context := config.GetKubeContext()
 
-	namespaces, err := GetTestNamespaces(t, context)
+	namespaces, err := GetManagementClusterK8sTestNamespaces(t, context)
 	if err != nil {
 		PrintToTTY("⚠️  Could not list test namespaces: %v\n\n", err)
 		t.Logf("Warning: Could not list test namespaces: %v", err)
@@ -833,7 +833,7 @@ func TestCleanup_Summary(t *testing.T) {
 	}
 
 	context := config.GetKubeContext()
-	testNamespaces, nsErr := GetTestNamespaces(t, context)
+	testNamespaces, nsErr := GetManagementClusterK8sTestNamespaces(t, context)
 	if nsErr != nil {
 		PrintToTTY("  Test Namespaces:  (could not check: %v)\n", nsErr)
 	} else if len(testNamespaces) == 0 {

--- a/test/08_cleanup_test.go
+++ b/test/08_cleanup_test.go
@@ -216,11 +216,17 @@ func TestCleanup_VerifyNamespaceRemoval(t *testing.T) {
 
 	context := config.GetKubeContext()
 
-	_, err := RunCommandQuiet(t, "kubectl", "--context", context,
+	output, err := RunCommandQuiet(t, "kubectl", "--context", context,
 		"get", "namespace", config.WorkloadClusterNamespace)
 	if err != nil {
-		PrintToTTY("Namespace '%s' not found (clean state)\n\n", config.WorkloadClusterNamespace)
-		t.Logf("Namespace '%s' does not exist - cleanup verified", config.WorkloadClusterNamespace)
+		errMsg := strings.ToLower(output + " " + err.Error())
+		if strings.Contains(errMsg, "not found") || strings.Contains(errMsg, "notfound") {
+			PrintToTTY("Namespace '%s' not found (clean state)\n\n", config.WorkloadClusterNamespace)
+			t.Logf("Namespace '%s' does not exist - cleanup verified", config.WorkloadClusterNamespace)
+			return
+		}
+		PrintToTTY("⚠️  Could not check namespace '%s': %v\n\n", config.WorkloadClusterNamespace, err)
+		t.Logf("Warning: could not verify namespace removal: %v", err)
 		return
 	}
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3492,6 +3492,46 @@ func ReportDeletionProgress(t *testing.T, iteration int, elapsed, remaining time
 }
 
 // ============================================================================
+// Namespace Cleanup Functions
+// ============================================================================
+
+// GetTestNamespaces returns all namespaces created by the test suite, identified by the
+// provider-specific test label (e.g., "capz-test=true" for ARO, "capa-test=true" for ROSA).
+func GetTestNamespaces(t *testing.T, kubeContext string) ([]string, error) {
+	t.Helper()
+
+	config := NewTestConfig()
+	labelSelector := fmt.Sprintf("%s=true", config.TestLabelPrefix)
+
+	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
+		"get", "namespaces", "-l", labelSelector,
+		"-o", "jsonpath={.items[*].metadata.name}")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list test namespaces with label %s: %w", labelSelector, err)
+	}
+
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return []string{}, nil
+	}
+
+	return strings.Fields(trimmed), nil
+}
+
+// GetNamespaceResources returns a summary of resources remaining in a namespace.
+func GetNamespaceResources(t *testing.T, kubeContext, namespace string) (string, error) {
+	t.Helper()
+
+	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
+		"-n", namespace, "get", "all", "--no-headers", "--ignore-not-found")
+	if err != nil {
+		return "", fmt.Errorf("failed to list resources in namespace %s: %w", namespace, err)
+	}
+
+	return strings.TrimSpace(output), nil
+}
+
+// ============================================================================
 // Configuration Validation Functions
 // ============================================================================
 //

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3505,7 +3505,8 @@ func GetTestNamespaces(t *testing.T, kubeContext string) ([]string, error) {
 
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
 		"get", "namespaces", "-l", labelSelector,
-		"-o", "jsonpath={.items[*].metadata.name}")
+		"-o", "jsonpath={.items[*].metadata.name}",
+		"--request-timeout=10s")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list test namespaces with label %s: %w", labelSelector, err)
 	}
@@ -3527,7 +3528,7 @@ func GetNamespaceResources(t *testing.T, kubeContext, namespace string) (string,
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
 		"-n", namespace, "get",
 		"clusters.cluster.x-k8s.io,machinepools.cluster.x-k8s.io,secrets,configmaps,all",
-		"--no-headers", "--ignore-not-found")
+		"--no-headers", "--ignore-not-found", "--request-timeout=10s")
 	if err != nil {
 		return "", fmt.Errorf("failed to list resources in namespace %s: %w", namespace, err)
 	}

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3511,12 +3511,12 @@ func GetTestNamespaces(t *testing.T, kubeContext string) ([]string, error) {
 		return nil, fmt.Errorf("failed to list test namespaces with label %s: %w", labelSelector, err)
 	}
 
-	trimmed := strings.TrimSpace(output)
-	if trimmed == "" {
+	filtered := filterKubectlWarnings(output)
+	if filtered == "" {
 		return []string{}, nil
 	}
 
-	return strings.Fields(trimmed), nil
+	return strings.Fields(filtered), nil
 }
 
 // GetNamespaceResources returns a summary of resources remaining in a namespace.
@@ -3533,7 +3533,21 @@ func GetNamespaceResources(t *testing.T, kubeContext, namespace string) (string,
 		return "", fmt.Errorf("failed to list resources in namespace %s: %w", namespace, err)
 	}
 
-	return strings.TrimSpace(output), nil
+	return filterKubectlWarnings(output), nil
+}
+
+// filterKubectlWarnings removes kubectl "Warning:" lines from command output
+// to prevent them from being misinterpreted as resource names or data.
+func filterKubectlWarnings(output string) string {
+	var lines []string
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "Warning:") {
+			continue
+		}
+		lines = append(lines, trimmed)
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
 }
 
 // ============================================================================

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3519,11 +3519,15 @@ func GetTestNamespaces(t *testing.T, kubeContext string) ([]string, error) {
 }
 
 // GetNamespaceResources returns a summary of resources remaining in a namespace.
+// Queries both built-in resources and CAPI custom resources that are the primary
+// inhabitants of workload cluster namespaces.
 func GetNamespaceResources(t *testing.T, kubeContext, namespace string) (string, error) {
 	t.Helper()
 
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
-		"-n", namespace, "get", "all", "--no-headers", "--ignore-not-found")
+		"-n", namespace, "get",
+		"clusters.cluster.x-k8s.io,machinepools.cluster.x-k8s.io,secrets,configmaps,all",
+		"--no-headers", "--ignore-not-found")
 	if err != nil {
 		return "", fmt.Errorf("failed to list resources in namespace %s: %w", namespace, err)
 	}

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3492,12 +3492,12 @@ func ReportDeletionProgress(t *testing.T, iteration int, elapsed, remaining time
 }
 
 // ============================================================================
-// Namespace Cleanup Functions
+// Management Cluster K8s Test Namespace Functions
 // ============================================================================
 
-// GetTestNamespaces returns all namespaces created by the test suite, identified by the
+// GetManagementClusterK8sTestNamespaces returns all namespaces created by the test suite, identified by the
 // provider-specific test label (e.g., "capz-test=true" for ARO, "capa-test=true" for ROSA).
-func GetTestNamespaces(t *testing.T, kubeContext string) ([]string, error) {
+func GetManagementClusterK8sTestNamespaces(t *testing.T, kubeContext string) ([]string, error) {
 	t.Helper()
 
 	config := NewTestConfig()
@@ -3519,10 +3519,10 @@ func GetTestNamespaces(t *testing.T, kubeContext string) ([]string, error) {
 	return strings.Fields(filtered), nil
 }
 
-// GetNamespaceResources returns a summary of resources remaining in a namespace.
+// GetManagementClusterK8sTestNamespaceResources returns a summary of resources remaining in a namespace.
 // Queries both built-in resources and CAPI custom resources that are the primary
 // inhabitants of workload cluster namespaces.
-func GetNamespaceResources(t *testing.T, kubeContext, namespace string) (string, error) {
+func GetManagementClusterK8sTestNamespaceResources(t *testing.T, kubeContext, namespace string) (string, error) {
 	t.Helper()
 
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,

--- a/test/stall_detection_test.go
+++ b/test/stall_detection_test.go
@@ -9,14 +9,14 @@ func TestDetectStallPhase(t *testing.T) {
 	const baseTimeout = DefaultDeploymentStallTimeout
 
 	tests := []struct {
-		name             string
-		enabled          bool
-		stallTimeout     time.Duration
-		stallDuration    time.Duration
-		progress         stallProgressState
-		wantStalled      bool
-		wantPhase        string
-		wantEffective    time.Duration
+		name          string
+		enabled       bool
+		stallTimeout  time.Duration
+		stallDuration time.Duration
+		progress      stallProgressState
+		wantStalled   bool
+		wantPhase     string
+		wantEffective time.Duration
 	}{
 		{
 			name:    "disabled returns not stalled",


### PR DESCRIPTION
## Description

Add namespace cleanup to the deletion and cleanup validation phases. Previously, each test
run created a unique namespace (e.g., `capz-test-20260202-135526`) for workload cluster
resources, but the namespace was never deleted after the CAPI resources were removed. This
caused namespace pollution on the management cluster over time.

JIRA: https://redhat.atlassian.net/browse/ARO-26591

## Changes Made

- Add `TestDeletion_DeleteManagementClusterK8sTestNamespace` to Phase 07 — deletes the workload cluster namespace after all CAPI resources and Azure resources have been verified deleted
- Add `TestCleanup_VerifyManagementClusterK8sTestNamespaceRemoval` to Phase 08 — verifies the current test run's namespace was cleaned up
- Add `TestCleanup_VerifyOrphanedManagementClusterK8sTestNamespaces` to Phase 08 — discovers orphaned test namespaces from previous runs using the test label selector (e.g., `capz-test=true`), excluding the current run's namespace from orphan counts
- Add `GetManagementClusterK8sTestNamespaces`, `GetManagementClusterK8sTestNamespaceResources`, and `filterKubectlWarnings` helper functions to `helpers.go`
- Update `TestDeletion_Summary` and `TestCleanup_Summary` to report namespace status
- Fix `gofmt` alignment in `stall_detection_test.go`
- Distinguish "not found" from auth/API/connectivity errors in all namespace kubectl checks
- Include CAPI custom resources (clusters, machinepools) in namespace resource queries
- Add `--request-timeout=10s` to cleanup kubectl calls to prevent stalls
- Filter kubectl `Warning:` lines from command output to prevent misinterpretation

## Configuration Changes

No new environment variables.

## Additional Notes

- Namespace discovery uses the labels already applied during Phase 05 (`capz-test=true` for ARO, `capa-test=true` for ROSA), so no changes to namespace creation are needed
- The namespace deletion in Phase 07 includes a safety check that logs any remaining resources before deletion
- Orphaned namespace discovery in Phase 08 distinguishes between the current run's namespace and namespaces from previous runs
- Function names use the full `ManagementClusterK8sTest` prefix to unambiguously identify these as Kubernetes namespaces on the management cluster (not Azure namespaces or workload cluster namespaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added namespace-deletion and cleanup validation tests with bounded waits, optional diagnostics, and clear remediation guidance.
  * Added checks to detect and report orphaned test namespaces, listing leftovers and bulk-delete selectors when present.
  * Extended test summaries to report final namespace existence and include management-cluster namespace details.
  * Introduced helper-driven diagnostics to enumerate test namespaces and list remaining resources.

* **Style**
  * Adjusted test formatting and alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->