### PR TITLE
fix: ensure Azure CLI login before resource tagging (ARO-26731)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Never hardcode values - always use `GetEnvOrDefault()` for new configuration.
 - `ExtractCurrentContext` / `GetExistingClusterNames` / `CheckForMismatchedClusters`
 
 **Azure utilities:**
-- `EnsureAzureCredentialsSet` / `DetectAzureAuthMode` / `HasServicePrincipalCredentials` / `GetAzureAuthDescription`
+- `EnsureAzureCredentialsSet` / `EnsureAzureCliLogin` / `DetectAzureAuthMode` / `HasServicePrincipalCredentials` / `GetAzureAuthDescription`
 - `DetectAzureError` / `FormatAzureError` - Azure error detection and formatting
 
 **AWS/ROSA utilities:**

--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -311,9 +311,13 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 		// Resource group may not exist yet (created by CAPI during deployment),
 		// so failure here is expected — Phase 05 will retry after deployment.
 		if len(config.AzureResourceTags) > 0 && CommandExists("az") {
-			PrintToTTY("🏷️  Tagging resource group %s...\n", config.ResourceGroupName)
-			if err := TagAzureResourceGroup(t, config); err != nil {
-				t.Logf("Resource group tagging deferred (RG may not exist yet, Phase 05 will retry): %v", err)
+			if err := EnsureAzureCliLogin(t); err != nil {
+				t.Logf("Resource group tagging deferred (Azure CLI auth unavailable, Phase 05 will retry): %v", err)
+			} else {
+				PrintToTTY("🏷️  Tagging resource group %s...\n", config.ResourceGroupName)
+				if err := TagAzureResourceGroup(t, config); err != nil {
+					t.Logf("Resource group tagging deferred (RG may not exist yet, Phase 05 will retry): %v", err)
+				}
 			}
 		}
 

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1248,7 +1248,7 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 	}
 
 	if err := EnsureAzureCliLogin(t); err != nil {
-		t.Fatalf("Azure CLI login required for resource tagging: %v", err)
+		t.Skipf("Skipping Azure resource tagging: Azure CLI auth unavailable: %v", err)
 	}
 
 	PrintToTTY("\n=== Tagging Azure Resources ===\n")

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1247,11 +1247,15 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 		return
 	}
 
+	if err := EnsureAzureCliLogin(t); err != nil {
+		t.Fatalf("Azure CLI login required for resource tagging: %v", err)
+	}
+
 	PrintToTTY("\n=== Tagging Azure Resources ===\n")
 
 	PrintToTTY("Tagging resource group %s...\n", config.ResourceGroupName)
 	if err := TagAzureResourceGroup(t, config); err != nil {
-		t.Logf("Warning: failed to tag resource group: %v", err)
+		t.Errorf("Failed to tag resource group: %v", err)
 	}
 	tagAzureADApplications(t, config)
 	tagAzureServicePrincipals(t, config)

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1255,7 +1255,7 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 
 	PrintToTTY("Tagging resource group %s...\n", config.ResourceGroupName)
 	if err := TagAzureResourceGroup(t, config); err != nil {
-		t.Errorf("Failed to tag resource group: %v", err)
+		t.Logf("Warning: failed to tag resource group: %v", err)
 	}
 	tagAzureADApplications(t, config)
 	tagAzureServicePrincipals(t, config)

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3248,6 +3248,44 @@ func GetAzureAuthDescription(mode AzureAuthMode) string {
 	}
 }
 
+// EnsureAzureCliLogin ensures the Azure CLI has an active login session.
+// If not already logged in, it attempts service principal login using
+// AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID env vars.
+// After login, sets the active subscription if AZURE_SUBSCRIPTION_ID is set.
+func EnsureAzureCliLogin(t *testing.T) error {
+	t.Helper()
+
+	if _, err := RunCommandQuiet(t, "az", "account", "show"); err == nil {
+		return nil
+	}
+
+	if !HasServicePrincipalCredentials() {
+		return fmt.Errorf("Azure CLI not logged in and no service principal credentials available (need AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID)")
+	}
+
+	clientID := os.Getenv("AZURE_CLIENT_ID")
+	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+	tenantID := os.Getenv("AZURE_TENANT_ID")
+
+	t.Log("Azure CLI not logged in, authenticating with service principal...")
+	if _, err := RunCommandQuiet(t, "az", "login",
+		"--service-principal",
+		"-u", clientID,
+		"-p", clientSecret,
+		"--tenant", tenantID); err != nil {
+		return fmt.Errorf("az login with service principal failed: %w", err)
+	}
+
+	if subID := os.Getenv("AZURE_SUBSCRIPTION_ID"); subID != "" {
+		if _, err := RunCommandQuiet(t, "az", "account", "set", "--subscription", subID); err != nil {
+			t.Logf("Warning: could not set subscription %s: %v", subID, err)
+		}
+	}
+
+	t.Log("Azure CLI authenticated via service principal")
+	return nil
+}
+
 // DeletionResourceStatus holds the status of resources being deleted.
 // ARODeletionStatus contains ARO-specific deletion status fields.
 type ARODeletionStatus struct {

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3272,7 +3272,8 @@ func EnsureAzureCliLogin(t *testing.T) error {
 		"--service-principal",
 		"-u", clientID,
 		"-p", clientSecret,
-		"--tenant", tenantID); err != nil {
+		"--tenant", tenantID,
+		"--allow-no-subscriptions"); err != nil {
 		return fmt.Errorf("az login with service principal failed: %w", err)
 	}
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3248,42 +3248,41 @@ func GetAzureAuthDescription(mode AzureAuthMode) string {
 	}
 }
 
-// EnsureAzureCliLogin ensures the Azure CLI has an active login session.
-// If not already logged in, it attempts service principal login using
-// AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and AZURE_TENANT_ID env vars.
-// After login, sets the active subscription if AZURE_SUBSCRIPTION_ID is set.
+// EnsureAzureCliLogin ensures the Azure CLI has an active login session and
+// the correct subscription is selected. If not already logged in, it attempts
+// service principal login using AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, and
+// AZURE_TENANT_ID env vars. Always sets the active subscription if
+// AZURE_SUBSCRIPTION_ID is set, regardless of whether login was needed.
 func EnsureAzureCliLogin(t *testing.T) error {
 	t.Helper()
 
-	if _, err := RunCommandQuiet(t, "az", "account", "show"); err == nil {
-		return nil
-	}
+	if _, err := RunCommandQuiet(t, "az", "account", "show"); err != nil {
+		if !HasServicePrincipalCredentials() {
+			return fmt.Errorf("Azure CLI not logged in and no service principal credentials available (need AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID)")
+		}
 
-	if !HasServicePrincipalCredentials() {
-		return fmt.Errorf("Azure CLI not logged in and no service principal credentials available (need AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID)")
-	}
+		clientID := os.Getenv("AZURE_CLIENT_ID")
+		clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+		tenantID := os.Getenv("AZURE_TENANT_ID")
 
-	clientID := os.Getenv("AZURE_CLIENT_ID")
-	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
-	tenantID := os.Getenv("AZURE_TENANT_ID")
-
-	t.Log("Azure CLI not logged in, authenticating with service principal...")
-	if _, err := RunCommandQuiet(t, "az", "login",
-		"--service-principal",
-		"-u", clientID,
-		"-p", clientSecret,
-		"--tenant", tenantID,
-		"--allow-no-subscriptions"); err != nil {
-		return fmt.Errorf("az login with service principal failed: %w", err)
+		t.Log("Azure CLI not logged in, authenticating with service principal...")
+		if _, err := RunCommandQuiet(t, "az", "login",
+			"--service-principal",
+			"-u", clientID,
+			"-p", clientSecret,
+			"--tenant", tenantID,
+			"--allow-no-subscriptions"); err != nil {
+			return fmt.Errorf("az login with service principal failed: %w", err)
+		}
 	}
 
 	if subID := os.Getenv("AZURE_SUBSCRIPTION_ID"); subID != "" {
 		if _, err := RunCommandQuiet(t, "az", "account", "set", "--subscription", subID); err != nil {
-			t.Logf("Warning: could not set subscription %s: %v", subID, err)
+			return fmt.Errorf("az account set --subscription %s failed: %w", subID, err)
 		}
 	}
 
-	t.Log("Azure CLI authenticated via service principal")
+	t.Log("Azure CLI authenticated and subscription selected")
 	return nil
 }
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3258,7 +3258,7 @@ func EnsureAzureCliLogin(t *testing.T) error {
 
 	if _, err := RunCommandQuiet(t, "az", "account", "show"); err != nil {
 		if !HasServicePrincipalCredentials() {
-			return fmt.Errorf("Azure CLI not logged in and no service principal credentials available (need AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID)")
+			return fmt.Errorf("azure CLI not logged in and no service principal credentials available (need AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID)")
 		}
 
 		clientID := os.Getenv("AZURE_CLIENT_ID")


### PR DESCRIPTION
## Description

Azure resource tagging fails silently in GHA Full Cluster Deployment workflows because the Azure CLI is not authenticated. Environment variables (`AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, etc.) are set but `az login` is never called, so all `az group update` calls fail with exit status 1. Failures are treated as warnings, so tests pass without tags applied.

JIRA: https://redhat.atlassian.net/browse/ARO-26731

## Changes Made

- Add `EnsureAzureCliLogin` helper in `helpers.go` that checks for an active `az` session and falls back to service principal login when credentials are available as env vars
- Subscription selection (`az account set`) always runs regardless of whether login was needed, ensuring the correct subscription context
- Phase 04: call `EnsureAzureCliLogin` before tagging attempt (keeps deferral behavior since RG may not exist yet)
- Phase 05: call `EnsureAzureCliLogin` before tagging, skip the test if Azure CLI auth is unavailable (consistent with the documented non-fatal contract)
- Update CLAUDE.md helper function list

## Configuration Changes

No new environment variables. Uses existing `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID`.

## Additional Notes

Implements Option A from the JIRA ticket: fix the auth issue with `az login` in the Go test code. Tagging remains non-fatal — failures are logged as warnings since tagging is for cleanup convenience only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)