### PR TITLE
feat: configure Slack reporter for Prow CI (ARO-25823)

### DIFF
--- a/openshift-ci/.config.prowgen
+++ b/openshift-ci/.config.prowgen
@@ -1,0 +1,14 @@
+slack_reporter:
+- channel: "#aro-hcp-capz-health"
+  job_states_to_report:
+  - failure
+  - error
+  report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>'
+  job_names:
+  - capz-e2e
+- channel: "#aro-hcp-capz-health"
+  job_states_to_report:
+  - success
+  report_template: ':done-circle-check: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>'
+  job_names:
+  - capz-e2e

--- a/openshift-ci/README.md
+++ b/openshift-ci/README.md
@@ -7,6 +7,7 @@ This directory contains reference copies of the OpenShift CI configuration files
 ```
 openshift-ci/
 ├── README.md                          # This file
+├── .config.prowgen                    # Slack reporter configuration
 ├── ci-operator-config.yaml            # ci-operator config reference
 └── step-registry/
     ├── capz-test-check-dependencies-ref.yaml        # Step reference YAML
@@ -20,6 +21,7 @@ openshift-ci/
 
 | Local reference file | openshift/release destination |
 |---------------------|-------------------------------|
+| `.config.prowgen` | `ci-operator/config/stolostron/capi-tests/.config.prowgen` |
 | `ci-operator-config.yaml` | `ci-operator/config/stolostron/capi-tests/stolostron-capi-tests-main.yaml` |
 | `step-registry/capz-test-check-dependencies-ref.yaml` | `ci-operator/step-registry/capz/test/check-dependencies/capz-test-check-dependencies-ref.yaml` |
 | `step-registry/capz-test-check-dependencies-commands.sh` | `ci-operator/step-registry/capz/test/check-dependencies/capz-test-check-dependencies-commands.sh` |
@@ -49,8 +51,10 @@ cd release
 ### 2. Copy files to their destinations
 
 ```bash
-# ci-operator config
+# ci-operator config + Slack reporter
 mkdir -p ci-operator/config/stolostron/capi-tests
+cp <path-to-capi-tests>/openshift-ci/.config.prowgen \
+   ci-operator/config/stolostron/capi-tests/.config.prowgen
 cp <path-to-capi-tests>/openshift-ci/ci-operator-config.yaml \
    ci-operator/config/stolostron/capi-tests/stolostron-capi-tests-main.yaml
 


### PR DESCRIPTION
## Description

Configure Prow Slack reporter to send `capz-e2e` job results to the `#aro-hcp-capz-health` Slack channel, following the [ARO-HCP `.config.prowgen` pattern](https://github.com/openshift/release/blob/main/ci-operator/config/Azure/ARO-HCP/.config.prowgen).

JIRA: https://redhat.atlassian.net/browse/ARO-25823

## Changes Made

- Add `openshift-ci/.config.prowgen` with Slack reporter configuration for the `capz-e2e` job
  - Failures and errors reported with `:failed:` emoji
  - Successes reported with `:done-circle-check:` emoji
- Update `openshift-ci/README.md`:
  - Add `.config.prowgen` to directory structure listing
  - Add destination mapping (`ci-operator/config/stolostron/capi-tests/.config.prowgen`)
  - Add copy command in the setup instructions

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| N/A | No new env vars — this is a Prow-level config consumed by `ci-operator-prowgen` | N/A |

## Additional Notes

- The `.config.prowgen` file is a reference copy stored alongside the ci-operator config; it must be copied to `ci-operator/config/stolostron/capi-tests/.config.prowgen` in openshift/release
- The `#aro-hcp-capz-health` Slack channel must exist before the reporter can post to it
- Two separate reporter entries are used (failure/error vs success) so each state gets a distinct emoji in Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Slack notifications for job status updates with automated alerts for both successful and failed runs, including relevant log information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->