### PR TITLE
fix: pin container image dependency by hash in Dockerfile.prow (ARO-26758)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,21 @@ updates:
           - "minor"
           - "patch"
 
+  # Docker (Dockerfile.prow) — keep pinned image digests up to date
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(docker):"
+    labels:
+      - "dependencies"
+      - "docker"
+
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20@sha256:fbb858fcea45f9d382a7163734cf10983b48584cd163175050a5397aa176ea18
 
 # Tool versions - pin all versions for reproducible builds
 ARG KUBECTL_VERSION=v1.35.2


### PR DESCRIPTION
## Description

Pin the base image in `Dockerfile.prow` to its SHA256 digest to prevent supply-chain attacks from compromised tags. Addresses OpenSSF Scorecard [Pinned-Dependencies finding #8](https://github.com/stolostron/capi-tests/security/code-scanning/8) (Medium severity, score 9/10).

Ref: [ARO-26758](https://redhat.atlassian.net/browse/ARO-26758)

## Changes Made

- Pin `registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20` by `@sha256:` digest in `Dockerfile.prow`
- Add `docker` package ecosystem to `.github/dependabot.yml` to auto-update the pinned digest weekly

## Configuration Changes

No new environment variables.

## Additional Notes

- The tag is preserved alongside the digest for readability (`tag@sha256:...` format)
- Dependabot's `docker` ecosystem will create PRs when the digest changes, keeping the pin current
- Note: Dependabot may need registry credentials configured in repo settings to access `registry.ci.openshift.org` — if it can't authenticate, the digest can be updated manually via `skopeo inspect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-26758]: https://redhat.atlassian.net/browse/ARO-26758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Docker dependency update checks on a weekly schedule with enhanced controls to manage update frequency.
  * Improved Docker build reproducibility by pinning the base image to a specific immutable content digest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->