### PR TITLE
feat: add GHA workflows for cluster-installer branch testing (ARO-26778)

### DIFF
--- a/.github/workflows/workload-cluster-aro-backplane-2.11.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-2.11.yml
@@ -6,6 +6,11 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
 
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
 jobs:
   deploy:
     uses: ./.github/workflows/workload-cluster-aro.yml

--- a/.github/workflows/workload-cluster-aro-backplane-2.11.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-2.11.yml
@@ -1,0 +1,15 @@
+name: Full Cluster Deployment (ARO)(backplane-2.11)
+
+# Runs Full Cluster Deployment against the backplane-2.11 branch of cluster-api-installer.
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/workload-cluster-aro.yml
+    with:
+      aro_repo_branch: backplane-2.11
+    secrets:
+      QUAY_AUTH: ${{ secrets.QUAY_AUTH }}

--- a/.github/workflows/workload-cluster-aro-backplane-2.17.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-2.17.yml
@@ -6,6 +6,11 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
 jobs:
   deploy:
     uses: ./.github/workflows/workload-cluster-aro.yml

--- a/.github/workflows/workload-cluster-aro-backplane-2.17.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-2.17.yml
@@ -1,0 +1,15 @@
+name: Full Cluster Deployment (ARO)(backplane-2.17)
+
+# Runs Full Cluster Deployment against the backplane-2.17 branch of cluster-api-installer.
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/workload-cluster-aro.yml
+    with:
+      aro_repo_branch: backplane-2.17
+    secrets:
+      QUAY_AUTH: ${{ secrets.QUAY_AUTH }}

--- a/.github/workflows/workload-cluster-aro-backplane-5.x.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-5.x.yml
@@ -1,0 +1,16 @@
+name: Full Cluster Deployment (ARO)(backplane-5.x)
+
+# Runs Full Cluster Deployment against the backplane-5.x branch of cluster-api-installer.
+# Prepared for upcoming backplane 5.x branches.
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/workload-cluster-aro.yml
+    with:
+      aro_repo_branch: backplane-5.x
+    secrets:
+      QUAY_AUTH: ${{ secrets.QUAY_AUTH }}

--- a/.github/workflows/workload-cluster-aro-backplane-5.x.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-5.x.yml
@@ -7,6 +7,11 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
 
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
 jobs:
   deploy:
     uses: ./.github/workflows/workload-cluster-aro.yml

--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -1,4 +1,4 @@
-name: Full Cluster Deployment (ARO)
+name: Full Cluster Deployment (ARO)(main)
 
 # Full end-to-end cluster deployment workflow (management cluster + workload cluster).
 # This workflow deploys a Kind management cluster and provisions an ARO HCP workload cluster.
@@ -6,6 +6,7 @@ name: Full Cluster Deployment (ARO)
 # Triggers:
 #   - Nightly at 2:00 AM UTC (cancelled/grey if no code changes since last successful run)
 #   - Manual dispatch
+#   - Reusable workflow call (used by branch-specific caller workflows)
 #
 # Requires:
 #   - Environment (aro-stage) with:
@@ -37,6 +38,31 @@ on:
         options:
           - kind
           - mce
+      aro_repo_branch:
+        description: 'cluster-api-installer branch to test against'
+        required: false
+        type: string
+        default: ''
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: false
+        type: string
+        default: 'aro-stage'
+      cluster_mode:
+        description: 'Management cluster mode'
+        required: false
+        type: string
+        default: 'kind'
+      aro_repo_branch:
+        description: 'cluster-api-installer branch to test against'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      QUAY_AUTH:
+        required: true
 
 permissions:
   contents: read
@@ -45,6 +71,7 @@ permissions:
 env:
   INFRA_PROVIDER: aro
   ARO_REPO_DIR: /tmp/cluster-api-installer-aro
+  ARO_REPO_BRANCH: ${{ inputs.aro_repo_branch }}
   TEST_TIMEOUT_MINUTES: 120
   # Global variables (not environment-specific)
   QUAY_AUTH: ${{ secrets.QUAY_AUTH }}
@@ -102,7 +129,7 @@ jobs:
         sleep 5
 
   management-cluster:
-    name: Full Cluster (${{ inputs.cluster_mode || 'kind' }} → ARO)
+    name: Full Cluster (${{ inputs.cluster_mode || 'kind' }} → ARO)(${{ inputs.aro_repo_branch || 'main' }})
     needs: check-changes
     if: needs.check-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
@@ -298,7 +325,7 @@ jobs:
         if not files:
             summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
             with open(summary_path, "a") as s:
-                s.write("# Full Cluster (ARO) Results\n\n")
+                s.write("# Full Cluster (ARO)(${{ inputs.aro_repo_branch || 'main' }}) Results\n\n")
                 s.write("No test results found\n")
             sys.exit(0)
 
@@ -306,7 +333,7 @@ jobs:
         summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
 
         with open(summary_path, "a") as summary:
-            summary.write("# Full Cluster (ARO) Results\n\n")
+            summary.write("# Full Cluster (ARO)(${{ inputs.aro_repo_branch || 'main' }}) Results\n\n")
 
             for f in files:
                 phase_key = os.path.basename(f).replace("junit-", "").replace(".xml", "")
@@ -386,7 +413,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: test-results-full-cluster-aro
+        name: test-results-full-cluster-aro${{ inputs.aro_repo_branch && format('-{0}', inputs.aro_repo_branch) || '' }}
         path: results/
         retention-days: 30
 
@@ -394,7 +421,7 @@ jobs:
       if: always() && steps.secrets.outputs.configured == 'true' && (steps.phase3.outcome == 'failure')
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WORKFLOW_NAME: Full Cluster (ARO)
+        WORKFLOW_NAME: Full Cluster (ARO)(${{ inputs.aro_repo_branch || 'main' }})
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         REF_NAME: ${{ github.ref_name }}
         COMMIT_SHA: ${{ github.sha }}

--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -304,10 +304,14 @@ jobs:
 
     - name: Generate test summary
       if: always()
+      env:
+        BRANCH_LABEL: ${{ inputs.aro_repo_branch || 'main' }}
       run: |
         python3 - << 'PYEOF'
         import xml.etree.ElementTree as ET
         import glob, os, sys
+
+        branch_label = os.environ.get("BRANCH_LABEL", "main")
 
         phase_names = {
             "check-dep": "Check Dependencies",
@@ -325,7 +329,7 @@ jobs:
         if not files:
             summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
             with open(summary_path, "a") as s:
-                s.write("# Full Cluster (ARO)(${{ inputs.aro_repo_branch || 'main' }}) Results\n\n")
+                s.write(f"# Full Cluster (ARO)({branch_label}) Results\n\n")
                 s.write("No test results found\n")
             sys.exit(0)
 
@@ -333,7 +337,7 @@ jobs:
         summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
 
         with open(summary_path, "a") as summary:
-            summary.write("# Full Cluster (ARO)(${{ inputs.aro_repo_branch || 'main' }}) Results\n\n")
+            summary.write(f"# Full Cluster (ARO)({branch_label}) Results\n\n")
 
             for f in files:
                 phase_key = os.path.basename(f).replace("junit-", "").replace(".xml", "")

--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -415,10 +415,13 @@ jobs:
 
     - name: Sanitize branch name for artifact
       if: always()
+      env:
+        ARO_REPO_BRANCH_INPUT: ${{ inputs.aro_repo_branch }}
       run: |
-        BRANCH="${{ inputs.aro_repo_branch }}"
+        BRANCH="$ARO_REPO_BRANCH_INPUT"
         if [ -n "$BRANCH" ]; then
-          echo "ARTIFACT_BRANCH_SUFFIX=-${BRANCH//\//-}" >> "$GITHUB_ENV"
+          SANITIZED=$(printf '%s' "$BRANCH" | sed -E 's/[^A-Za-z0-9._-]+/-/g')
+          echo "ARTIFACT_BRANCH_SUFFIX=-${SANITIZED}" >> "$GITHUB_ENV"
         else
           echo "ARTIFACT_BRANCH_SUFFIX=" >> "$GITHUB_ENV"
         fi

--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -413,11 +413,21 @@ jobs:
                     print(f"::error file={test_file},title=Test Failed::{name} failed")
         PYEOF
 
+    - name: Sanitize branch name for artifact
+      if: always()
+      run: |
+        BRANCH="${{ inputs.aro_repo_branch }}"
+        if [ -n "$BRANCH" ]; then
+          echo "ARTIFACT_BRANCH_SUFFIX=-${BRANCH//\//-}" >> "$GITHUB_ENV"
+        else
+          echo "ARTIFACT_BRANCH_SUFFIX=" >> "$GITHUB_ENV"
+        fi
+
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: test-results-full-cluster-aro${{ inputs.aro_repo_branch && format('-{0}', inputs.aro_repo_branch) || '' }}
+        name: test-results-full-cluster-aro${{ env.ARTIFACT_BRANCH_SUFFIX }}
         path: results/
         retention-days: 30
 

--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -85,7 +85,7 @@ jobs:
       contents: read
     if: github.event_name != 'schedule' || true
     outputs:
-      has_changes: ${{ github.event_name != 'schedule' || steps.check.outputs.has_changes == 'true' }}
+      has_changes: ${{ inputs.aro_repo_branch != '' || github.event_name != 'schedule' || steps.check.outputs.has_changes == 'true' }}
     steps:
     - name: Check for changes since last successful run
       id: check


### PR DESCRIPTION
## Description

Add GitHub Actions workflows to run Full Cluster Deployment tests against different
cluster-api-installer branches, enabling CI validation across backplane release branches.

JIRA: https://redhat.atlassian.net/browse/ARO-26778

## Changes Made

- Renamed existing workflow to "Full Cluster Deployment (ARO)(main)"
- Made it reusable via `workflow_call` with `aro_repo_branch` input
- Added `aro_repo_branch` to `workflow_dispatch` inputs for manual testing
- Created minimal caller workflows for:
  - `backplane-2.11` (nightly at 3:00 AM UTC)
  - `backplane-2.17` (nightly at 4:00 AM UTC)
  - `backplane-5.x` (nightly at 5:00 AM UTC, prepared for upcoming branches)
- Branch-aware artifact names, issue titles, and test summaries
- Skip change-detection for branch-specific caller workflows (code changes in this repo are irrelevant when testing external branches)
- Added explicit permissions (`actions: write`, `contents: read`, `issues: write`) to caller workflows
- Passed branch label via env var to Python summary script instead of direct interpolation
- Sanitized branch name in artifact name to replace `/` with `-` for upload-artifact compatibility

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `aro_repo_branch` (workflow input) | cluster-api-installer branch to test against | `''` (uses test default: `main`) |

## Additional Notes

Each caller workflow is minimal — only sets `ARO_REPO_BRANCH` and invokes the existing
deployment workflow. No duplication of deployment logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated full cluster deployment workflows for backplane versions 2.11, 2.17, and 5.x with daily schedule and manual dispatch triggers.
  * Enhanced main deployment workflow with support for branch-specific configuration, test result reporting, and failure notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->