### PR TITLE
fix: use secrets inherit in branch-specific caller workflows

### DIFF
--- a/.github/workflows/workload-cluster-aro-backplane-2.11.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-2.11.yml
@@ -16,5 +16,4 @@ jobs:
     uses: ./.github/workflows/workload-cluster-aro.yml
     with:
       aro_repo_branch: backplane-2.11
-    secrets:
-      QUAY_AUTH: ${{ secrets.QUAY_AUTH }}
+    secrets: inherit

--- a/.github/workflows/workload-cluster-aro-backplane-2.17.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-2.17.yml
@@ -16,5 +16,4 @@ jobs:
     uses: ./.github/workflows/workload-cluster-aro.yml
     with:
       aro_repo_branch: backplane-2.17
-    secrets:
-      QUAY_AUTH: ${{ secrets.QUAY_AUTH }}
+    secrets: inherit

--- a/.github/workflows/workload-cluster-aro-backplane-5.x.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-5.x.yml
@@ -17,5 +17,4 @@ jobs:
     uses: ./.github/workflows/workload-cluster-aro.yml
     with:
       aro_repo_branch: backplane-5.x
-    secrets:
-      QUAY_AUTH: ${{ secrets.QUAY_AUTH }}
+    secrets: inherit


### PR DESCRIPTION
## Description

Branch-specific caller workflows (backplane-2.11, 2.17, 5.x) failed because
`AZURE_CLIENT_SECRET` (an environment secret in `aro-stage`) was not passed
through to the reusable workflow. Only `QUAY_AUTH` was explicitly forwarded.

Failure: https://github.com/stolostron/capi-tests/actions/runs/25430254468

## Changes Made

- Switch all three caller workflows from explicit `secrets: QUAY_AUTH` to `secrets: inherit`
- This passes through both repository secrets and environment secrets

## Configuration Changes

No new environment variables.

## Additional Notes

`secrets: inherit` is compatible with the reusable workflow's `secrets: QUAY_AUTH: required: true` declaration — inherited secrets satisfy declared requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions deployment workflows to automatically inherit all secrets from caller workflows instead of using explicit secret mappings, streamlining secret management across multiple deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->