### PR TITLE
fix: exclude Azure-managed resource groups from stale detection (ARO-26908)

### DIFF
--- a/scripts/check-stale-resources.sh
+++ b/scripts/check-stale-resources.sh
@@ -217,7 +217,7 @@ check_azure_resource_groups_by_convention() {
 
     local all_rgs_json
     all_rgs_json=$(az group list \
-        --query "[].{name: name, location: location, tags: tags}" \
+        --query "[].{name: name, location: location, tags: tags, managedBy: managedBy}" \
         -o json 2>/dev/null) || {
         print_warning "Failed to list Azure resource groups for convention check"
         return 0
@@ -225,16 +225,16 @@ check_azure_resource_groups_by_convention() {
 
     # Match resource groups created by our test suite:
     #   capz-tests-resgroup, capz-tests-abc12-resgroup, capa-tests-d3a0f-resgroup
-    #   capz_node_*_rg (Azure-managed node resource groups)
-    # Exclude RGs that already have capi-test-created-at tag (handled by tagged detection)
+    # Exclude:
+    #   - RGs with capi-test-created-at tag (handled by tagged detection)
+    #   - RGs with managedBy set (Azure-managed node RGs like capz_node_*_rg)
     local convention_rgs
     convention_rgs=$(echo "$all_rgs_json" | jq '[
         .[] | select(
             (.name | test("^cap[az]-tests(-[a-f0-9]+)?-resgroup$"))
-            or
-            (.name | test("^capz_node_.*_rg$"))
         )
         | select(.tags == null or .tags."capi-test-created-at" == null)
+        | select(.managedBy == null or .managedBy == "")
     ]')
 
     local total


### PR DESCRIPTION
## Description

The stale resource detection script falsely reports Azure-managed node resource groups (`capz_node_*_rg`) as stale. These are created and managed by the ARO HCP platform — they have deny assignments preventing deletion and are automatically cleaned up when the parent resource group is deleted.

Jira: [ARO-26908](https://redhat.atlassian.net/browse/ARO-26908)

## Changes Made

- Added `managedBy` field to the `az group list` query in convention-based detection
- Filter out resource groups with a non-null `managedBy` field (Azure-managed RGs)
- Removed the `capz_node_.*_rg` regex pattern that was explicitly matching platform-managed RGs

## Configuration Changes

No configuration changes.

## Additional Notes

Verified locally against Azure — the `capz_node_*` groups are no longer reported and the script exits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-26908]: https://redhat.atlassian.net/browse/ARO-26908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Azure resource group stale detection to properly exclude Azure-managed resources, improving accuracy and preventing false positives during cleanup operations
  * Updated filtering criteria to refine candidate identification, ensuring only appropriate resource groups are flagged for potential cleanup based on naming conventions and management status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->