### PR TITLE
Revert "fix: exclude Azure-managed resource groups from stale detection (ARO-26908)"

### DIFF
--- a/scripts/check-stale-resources.sh
+++ b/scripts/check-stale-resources.sh
@@ -217,7 +217,7 @@ check_azure_resource_groups_by_convention() {
 
     local all_rgs_json
     all_rgs_json=$(az group list \
-        --query "[].{name: name, location: location, tags: tags, managedBy: managedBy}" \
+        --query "[].{name: name, location: location, tags: tags}" \
         -o json 2>/dev/null) || {
         print_warning "Failed to list Azure resource groups for convention check"
         return 0
@@ -225,16 +225,16 @@ check_azure_resource_groups_by_convention() {
 
     # Match resource groups created by our test suite:
     #   capz-tests-resgroup, capz-tests-abc12-resgroup, capa-tests-d3a0f-resgroup
-    # Exclude:
-    #   - RGs with capi-test-created-at tag (handled by tagged detection)
-    #   - RGs with managedBy set (Azure-managed node RGs like capz_node_*_rg)
+    #   capz_node_*_rg (Azure-managed node resource groups)
+    # Exclude RGs that already have capi-test-created-at tag (handled by tagged detection)
     local convention_rgs
     convention_rgs=$(echo "$all_rgs_json" | jq '[
         .[] | select(
             (.name | test("^cap[az]-tests(-[a-f0-9]+)?-resgroup$"))
+            or
+            (.name | test("^capz_node_.*_rg$"))
         )
         | select(.tags == null or .tags."capi-test-created-at" == null)
-        | select(.managedBy == null or .managedBy == "")
     ]')
 
     local total


### PR DESCRIPTION
## Description

Reverts #705. The `managedBy`-based filtering approach needs further investigation to ensure it doesn't exclude resource groups that should be reported as stale.

## Changes Made

- Reverts all changes from PR #705
- Restores `capz_node_*_rg` regex pattern for convention-based detection
- Removes `managedBy` field from `az group list` query
- Removes `managedBy`-based filtering logic

## Configuration Changes

No configuration changes.

## Additional Notes

This is a clean `git revert` of commit 10bc180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced stale Azure resource detection to cover additional resource group patterns for more comprehensive cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->