### PR TITLE
fix: remove workflow self-cancellation that causes red CI badges (ARO-27116)

### DIFF
--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -116,7 +116,6 @@ jobs:
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
         fi
 
-
   management-cluster:
     name: Full Cluster (${{ inputs.cluster_mode || 'kind' }} → ARO)(${{ inputs.aro_repo_branch || 'main' }})
     needs: check-changes

--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -4,7 +4,7 @@ name: Full Cluster Deployment (ARO)(main)
 # This workflow deploys a Kind management cluster and provisions an ARO HCP workload cluster.
 #
 # Triggers:
-#   - Nightly at 2:00 AM UTC (cancelled/grey if no code changes since last successful run)
+#   - Nightly at 2:00 AM UTC (skipped if no code changes since last successful run)
 #   - Manual dispatch
 #   - Reusable workflow call (used by branch-specific caller workflows)
 #
@@ -81,7 +81,6 @@ jobs:
     name: Check for code changes
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: read
     if: github.event_name != 'schedule' || true
     outputs:
@@ -117,16 +116,6 @@ jobs:
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Cancel workflow if no changes
-      if: github.event_name == 'schedule' && steps.check.outputs.has_changes == 'false'
-      env:
-        GH_TOKEN: ${{ github.token }}
-        RUN_ID: ${{ github.run_id }}
-        REPO: ${{ github.repository }}
-      run: |
-        echo "No code changes detected — cancelling workflow run"
-        gh run cancel "$RUN_ID" --repo "$REPO"
-        sleep 5
 
   management-cluster:
     name: Full Cluster (${{ inputs.cluster_mode || 'kind' }} → ARO)(${{ inputs.aro_repo_branch || 'main' }})

--- a/.github/workflows/workload-cluster-rosa.yml
+++ b/.github/workflows/workload-cluster-rosa.yml
@@ -4,7 +4,7 @@ name: Full Cluster Deployment (ROSA)
 # This workflow deploys a Kind management cluster and provisions a ROSA workload cluster.
 #
 # Triggers:
-#   - Nightly at 2:00 AM UTC (cancelled/grey if no code changes since last successful run)
+#   - Nightly at 2:00 AM UTC (skipped if no code changes since last successful run)
 #   - Manual dispatch
 #
 # Requires:
@@ -56,7 +56,6 @@ jobs:
     name: Check for code changes
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: read
     if: github.event_name != 'schedule' || true
     outputs:
@@ -92,16 +91,6 @@ jobs:
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Cancel workflow if no changes
-      if: github.event_name == 'schedule' && steps.check.outputs.has_changes == 'false'
-      env:
-        GH_TOKEN: ${{ github.token }}
-        RUN_ID: ${{ github.run_id }}
-        REPO: ${{ github.repository }}
-      run: |
-        echo "No code changes detected — cancelling workflow run"
-        gh run cancel "$RUN_ID" --repo "$REPO"
-        sleep 5
 
   management-cluster:
     name: Full Cluster (${{ inputs.cluster_mode || 'kind' }} → ROSA)

--- a/.github/workflows/workload-cluster-rosa.yml
+++ b/.github/workflows/workload-cluster-rosa.yml
@@ -91,7 +91,6 @@ jobs:
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
         fi
 
-
   management-cluster:
     name: Full Cluster (${{ inputs.cluster_mode || 'kind' }} → ROSA)
     needs: check-changes


### PR DESCRIPTION
## Description

The nightly scheduled workflows (`workload-cluster-aro.yml`, `workload-cluster-rosa.yml`) cancel themselves via `gh run cancel` when no code changes are detected since the last successful run. GitHub renders cancelled runs as red/failing badges, making the CI status misleading.

The deployment job already has a job-level `if: needs.check-changes.outputs.has_changes == 'true'` condition that cleanly skips execution when there are no changes. Removing the self-cancellation step lets the workflow complete with a success status, keeping badges green.

Fixes ARO-27116

## Changes Made

- Removed "Cancel workflow if no changes" step from both ARO and ROSA full deployment workflows
- Removed `actions: write` permission from `check-changes` job (was only needed for `gh run cancel`)
- Updated workflow header comments to say "skipped" instead of "cancelled/grey"

## Configuration Changes

N/A

## Additional Notes

The `check-changes` job and its `has_changes` output remain intact — only the self-cancellation mechanism is removed. The downstream job-level `if` condition continues to skip the deployment when no changes are detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced CI/CD job permissions to tighten security.
  * Adjusted scheduled pipeline behavior so nightly runs are skipped when no code changes are detected.
  * Removed automatic self-cancellation of scheduled runs; downstream job conditions now govern execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->