### PR TITLE
fix: add pull_request trigger to Security Scorecard workflow (ARO-26962)

### DIFF
--- a/.github/workflows/security-scorecard.yml
+++ b/.github/workflows/security-scorecard.yml
@@ -3,6 +3,8 @@ name: Security Scorecard
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   schedule:
     # Run weekly on Monday at 4:30 AM UTC
     - cron: '30 4 * * 1'


### PR DESCRIPTION
## Summary
- Add `pull_request` trigger for `main` branch to Security Scorecard workflow
- Previously only ran on `push` and `schedule`, missing PR-time security checks
- Part of workflow branch coverage audit (ARO-26962)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security scanning by extending the OpenSSF Scorecard workflow to run on pull requests targeting the main branch, in addition to existing push event checks. This provides earlier detection of potential security concerns during the review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->