### PR TITLE
fix(rosa): pass OCP_VERSION from environment to fix semver validation (ARO-25886)

### DIFF
--- a/.github/workflows/workload-cluster-rosa.yml
+++ b/.github/workflows/workload-cluster-rosa.yml
@@ -110,6 +110,7 @@ jobs:
       OCM_CLIENT_ID: ${{ vars.OCM_CLIENT_ID }}
       OCM_CLIENT_SECRET: ${{ secrets.OCM_CLIENT_SECRET }}
       DEPLOYMENT_ENV: ${{ vars.DEPLOYMENT_ENV }}
+      OCP_VERSION: ${{ vars.OCP_VERSION }}
 
       # MCE credentials (only required when cluster_mode=mce)
       MCE_API_URL: ${{ vars.MCE_API_URL }}


### PR DESCRIPTION
## Description

Fix rosa-stage nightly deployment failure caused by ROSA CRD semver validation.

JIRA: https://redhat.atlassian.net/browse/ARO-25886

## Changes Made

- Pass `OCP_VERSION` from the GitHub environment to the ROSA workflow so the full semantic version reaches the generation script

## Root Cause

The ROSA CRDs (`ROSARoleConfig`, `ROSAControlPlane`) now validate that version fields are valid semantic versions. The workflow was not passing `OCP_VERSION`, so the Go test default `"4.20"` was used — which is not valid semver. This caused `kubectl apply` to reject both `is.yaml` and `rosa.yaml`:

```
The ROSARoleConfig "role-config" is invalid: spec.accountRoleConfig.version: Invalid value: "4.20": must be a valid semantic version
The ROSAControlPlane "capa-tests-control-plane" is invalid: spec.version: Invalid value: "4.20": must be a valid semantic version
```

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `OCP_VERSION` | Full semver OpenShift version for ROSA CRDs | `4.20` (from Go defaults) |

## Additional Notes

@marek-veber I've already set `OCP_VERSION=4.20.17` in the `rosa-stage` GitHub environment variables. After this PR is merged, the next nightly run should pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to include OpenShift version management for cluster operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->