### PR TITLE
fix: skip verification tests when prior deployment phase failed (ARO-25471)

### DIFF
--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -796,6 +796,8 @@ func TestDeployment_WaitForExternalAuthReady(t *testing.T) {
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()
 
+	RequireClusterResource(t, context, config.WorkloadClusterNamespace, provisionedClusterName)
+
 	timeout := 10 * time.Minute
 	pollInterval := 15 * time.Second
 	startTime := time.Now()
@@ -890,6 +892,8 @@ func TestDeployment_VerifyInfrastructureResources(t *testing.T) {
 
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()
+
+	RequireClusterResource(t, context, config.WorkloadClusterNamespace, provisionedClusterName)
 
 	timeout := config.DeploymentTimeout
 	pollInterval := 30 * time.Second
@@ -998,6 +1002,8 @@ func TestDeployment_VerifyAROClusterReady(t *testing.T) {
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()
 
+	RequireClusterResource(t, context, config.WorkloadClusterNamespace, provisionedClusterName)
+
 	timeout := 5 * time.Minute
 	pollInterval := 10 * time.Second
 	startTime := time.Now()
@@ -1081,6 +1087,8 @@ func TestDeployment_VerifyClusterProvisioned(t *testing.T) {
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()
 
+	RequireClusterResource(t, context, config.WorkloadClusterNamespace, provisionedClusterName)
+
 	timeout := 5 * time.Minute
 	pollInterval := 10 * time.Second
 	startTime := time.Now()
@@ -1158,6 +1166,8 @@ func TestDeployment_VerifyClusterInfrastructureReady(t *testing.T) {
 
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()
+
+	RequireClusterResource(t, context, config.WorkloadClusterNamespace, provisionedClusterName)
 
 	timeout := 5 * time.Minute
 	pollInterval := 10 * time.Second

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2325,9 +2325,13 @@ func FormatAzureError(info *AzureErrorInfo) string {
 func RequireClusterResource(t *testing.T, kubeContext, namespace, clusterName string) {
 	t.Helper()
 
-	_, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext, "-n", namespace, "get", "cluster", clusterName)
+	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext, "-n", namespace, "get", "cluster", clusterName)
 	if err != nil {
-		t.Skipf("Cluster resource %q not found in namespace %s (prior deployment phase may have failed)", clusterName, namespace)
+		errText := strings.ToLower(output + " " + err.Error())
+		if strings.Contains(errText, "not found") || strings.Contains(errText, "no resources found") {
+			t.Skipf("Cluster resource %q not found in namespace %s (prior deployment phase may have failed)", clusterName, namespace)
+		}
+		t.Fatalf("Failed to check Cluster resource %q in namespace %s: %v\nOutput: %s", clusterName, namespace, err, output)
 	}
 
 	phase, err := GetClusterPhase(t, kubeContext, namespace, clusterName)

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2320,6 +2320,22 @@ func FormatAzureError(info *AzureErrorInfo) string {
 	return result.String()
 }
 
+// RequireClusterResource skips the test if the CAPI Cluster resource does not exist or is in a Failed phase.
+// Use this at the top of verification tests that depend on earlier deployment phases succeeding.
+func RequireClusterResource(t *testing.T, kubeContext, namespace, clusterName string) {
+	t.Helper()
+
+	_, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext, "-n", namespace, "get", "cluster", clusterName)
+	if err != nil {
+		t.Skipf("Cluster resource %q not found in namespace %s (prior deployment phase may have failed)", clusterName, namespace)
+	}
+
+	phase, err := GetClusterPhase(t, kubeContext, namespace, clusterName)
+	if err == nil && phase == ClusterPhaseFailed {
+		t.Skipf("Cluster %q is in Failed phase — skipping (deployment failed in a prior phase)", clusterName)
+	}
+}
+
 // GetClusterPhase retrieves the current phase of a CAPI Cluster resource.
 // Returns the phase string (e.g., "Provisioning", "Provisioned", "Failed") or an error.
 // This is useful for checking if a cluster is ready before attempting operations that


### PR DESCRIPTION
## Description

Verification tests in phase 05 (ExternalAuthReady, InfrastructureResources, AROClusterReady, ClusterProvisioned, ClusterInfrastructureReady) run unconditionally even when prior deployment phases have failed. This causes them to poll for minutes before timing out with misleading errors, producing red CI badges that obscure the actual failure.

JIRA: https://redhat.atlassian.net/browse/ARO-25471

## Changes Made

- Added `RequireClusterResource` helper to `test/helpers.go` — checks that the CAPI Cluster resource exists and is not in Failed phase, skipping the test otherwise
- Added `RequireClusterResource` guard to 5 verification tests in `test/05_deploy_crs_test.go`:
  - `TestDeployment_WaitForExternalAuthReady`
  - `TestDeployment_VerifyInfrastructureResources`
  - `TestDeployment_VerifyAROClusterReady`
  - `TestDeployment_VerifyClusterProvisioned`
  - `TestDeployment_VerifyClusterInfrastructureReady`

## Configuration Changes

N/A

## Additional Notes

When a prior phase (e.g., `TestDeployment_WaitForControlPlane`) fails, Go's `testing` package continues running subsequent test functions. The new guard ensures downstream tests skip immediately with a clear message instead of wasting time polling non-existent resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added precondition checks to deployment verification tests so they fail fast or skip when the target cluster resource is missing or in a failed state.
  * Introduced a new test helper that verifies cluster resource existence and phase before running deployment validation, improving test stability and clearer early outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->