### PR TITLE
ARO-26781 - fix workload-cluster-aro-backplane-5.0.yml and add workload-cluster-aro-backplane-5.1.yml 

### DIFF
--- a/.github/workflows/workload-cluster-aro-backplane-5.1.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-5.1.yml
@@ -4,7 +4,7 @@ name: Full Cluster Deployment (ARO)(backplane-5.1)
 # Prepared for upcoming backplane 5.1 branches.
 on:
   schedule:
-    - cron: '0 5 * * *'
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/workload-cluster-aro-backplane-5.1.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-5.1.yml
@@ -1,7 +1,7 @@
-name: Full Cluster Deployment (ARO)(backplane-5.0)
+name: Full Cluster Deployment (ARO)(backplane-5.1)
 
-# Runs Full Cluster Deployment against the backplane-5.0 branch of cluster-api-installer.
-# Prepared for upcoming backplane 5.0 branches.
+# Runs Full Cluster Deployment against the backplane-5.1 branch of cluster-api-installer.
+# Prepared for upcoming backplane 5.1 branches.
 on:
   schedule:
     - cron: '0 5 * * *'
@@ -16,5 +16,5 @@ jobs:
   deploy:
     uses: ./.github/workflows/workload-cluster-aro.yml
     with:
-      aro_repo_branch: backplane-5.0
+      aro_repo_branch: backplane-5.1
     secrets: inherit


### PR DESCRIPTION

## Description
* fix workload-cluster-aro-backplane-5.0.yml
* workload-cluster-aro-backplane-5.1.yml 

Jira: [ARO-26781](https://redhat.atlassian.net/browse/ARO-26781)

[ARO-26781]: https://redhat.atlassian.net/browse/ARO-26781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment automation configuration for backplane version 5.0
  * Added automated deployment workflow for backplane version 5.1 with daily schedule and manual trigger options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->