### PR TITLE
fix: show Unknown for Azure RG status when lookup fails (fixes #587)

### DIFF
--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3311,6 +3311,7 @@ func EnsureAzureCliLogin(t *testing.T) error {
 type ARODeletionStatus struct {
 	ResourceGroup    string
 	RGExists         bool
+	RGChecked        bool
 	RGProvisionState string
 }
 
@@ -3419,13 +3420,23 @@ func GetDeletionResourceStatus(t *testing.T, kubeContext, namespace, clusterName
 				ResourceGroup: actualResourceGroup,
 			}
 
-			// Check Azure resource group status if az CLI is available
 			if CommandExists("az") {
 				output, err := RunCommandQuiet(t, "az", "group", "show", "--name", actualResourceGroup,
 					"--query", "properties.provisioningState", "-o", "tsv")
 				if err == nil && strings.TrimSpace(output) != "" {
 					aroStatus.RGExists = true
+					aroStatus.RGChecked = true
 					aroStatus.RGProvisionState = strings.TrimSpace(output)
+				} else if err != nil {
+					errOutput := strings.ToLower(output + " " + err.Error())
+					if strings.Contains(errOutput, "resourcegroupnotfound") ||
+						strings.Contains(errOutput, "could not be found") ||
+						(strings.Contains(errOutput, "resource group") && strings.Contains(errOutput, "not found")) {
+						aroStatus.RGExists = false
+						aroStatus.RGChecked = true
+					} else {
+						t.Logf("Warning: Could not determine Azure RG status: %v", err)
+					}
 				}
 			}
 
@@ -3505,11 +3516,12 @@ func FormatDeletionProgress(status DeletionResourceStatus) string {
 		sb.WriteString(formatRow("✅", "MachinePool", "Deleted"))
 	}
 
-	// ARO-specific: Azure resource group (only show for ARO provider)
 	if status.AROProviderSpecific != nil {
 		aroStatus := status.AROProviderSpecific
 		if aroStatus.ResourceGroup != "" {
-			if aroStatus.RGExists {
+			if !aroStatus.RGChecked {
+				sb.WriteString(formatRow("❓", "Azure RG", fmt.Sprintf("%s (unknown)", aroStatus.ResourceGroup)))
+			} else if aroStatus.RGExists {
 				stateInfo := aroStatus.RGProvisionState
 				if stateInfo == "" {
 					stateInfo = "exists"
@@ -3540,13 +3552,18 @@ func ReportDeletionProgress(t *testing.T, iteration int, elapsed, remaining time
 		iteration, elapsed.Round(time.Second), remaining.Round(time.Second), percentage)
 	PrintToTTY("%s", FormatDeletionProgress(status))
 
-	// Log summary for test output
-	azureRGExists := false
+	azureRGStatus := "n/a"
 	if status.AROProviderSpecific != nil {
-		azureRGExists = status.AROProviderSpecific.RGExists
+		if !status.AROProviderSpecific.RGChecked {
+			azureRGStatus = "unknown"
+		} else if status.AROProviderSpecific.RGExists {
+			azureRGStatus = "exists"
+		} else {
+			azureRGStatus = "deleted"
+		}
 	}
-	t.Logf("Deletion progress: cluster=%v, cp=%s(%d), mp=%d, azureRG=%v",
-		status.ClusterExists, status.ControlPlaneKind, status.ControlPlaneCount, status.MachinePoolCount, azureRGExists)
+	t.Logf("Deletion progress: cluster=%v, cp=%s(%d), mp=%d, azureRG=%s",
+		status.ClusterExists, status.ControlPlaneKind, status.ControlPlaneCount, status.MachinePoolCount, azureRGStatus)
 }
 
 // ============================================================================


### PR DESCRIPTION
## Description

When `az` CLI is unavailable or `az group show` fails transiently, `RGExists` stayed at its zero value (`false`), causing `FormatDeletionProgress` to render the resource group as "Deleted". This hid lookup failures as successful cleanup.

Fixes #587

## Changes Made

- Added `RGChecked` field to `ARODeletionStatus` to track whether the RG state was positively confirmed
- Updated `GetDeletionResourceStatus` to distinguish "not found" errors (confirmed deleted) from transient failures (unknown state)
- Updated `FormatDeletionProgress` to show `❓ Azure RG: <name> (unknown)` when the state could not be determined
- Updated `ReportDeletionProgress` log line to use descriptive string (`exists`/`deleted`/`unknown`/`n/a`) instead of boolean

## Configuration Changes

No configuration changes.

## Additional Notes

Three-state logic:
| `RGChecked` | `RGExists` | Display |
|-------------|------------|---------|
| `false` | `false` | ❓ `<name> (unknown)` |
| `true` | `true` | 🔄 `<name> (Succeeded)` |
| `true` | `false` | ✅ `Deleted` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Azure resource group deletion status reporting to accurately distinguish between confirmed deletion and undetermined status, preventing false "deleted" indications when status checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->