### PR TITLE
fix: enable ip_forward sysctl before starting k3s rootless

### DIFF
--- a/openshift-ci/step-registry/capz-test-k3s-e2e-commands.sh
+++ b/openshift-ci/step-registry/capz-test-k3s-e2e-commands.sh
@@ -43,6 +43,11 @@ chmod +x /tmp/k3s
 export PATH="/tmp:${PATH}"
 echo "[k3s] Installed: $(k3s --version)"
 
+# ---- Prepare network and kernel settings ----
+# k3s requires ip_forward; enable it (needs NET_ADMIN from nested_podman).
+sysctl -w net.ipv4.ip_forward=1 2>/dev/null || echo "[k3s] WARNING: could not set ip_forward"
+sysctl -w net.ipv6.conf.all.forwarding=1 2>/dev/null || true
+
 # ---- Start k3s in rootless mode ----
 # CI pods run as non-root; k3s requires --rootless in this case.
 echo "[k3s] Starting k3s server (rootless mode)"


### PR DESCRIPTION
## Summary
- k3s rootless mode requires `net.ipv4.ip_forward=1` but CI pods have it set to `0`
- Enable the sysctl before starting k3s — the `nested_podman` capability provides `NET_ADMIN` which should allow this
- Also enable IPv6 forwarding for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved k3s test environment initialization with explicit network kernel settings configuration, including IPv4 and IPv6 forwarding enablement to enhance cluster setup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->