### PR TITLE
cleanup: remove unreachable return statements after t.Fatalf (fixes #588)

### DIFF
--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -253,7 +253,6 @@ func TestCheckDependencies_DockerDaemonRunning(t *testing.T) {
 		}
 
 		t.Fatalf("Docker daemon is not running or not accessible.\n%s\n\nError: %v", helpMessage, err)
-		return
 	}
 
 	serverVersion := strings.TrimSpace(output)
@@ -283,14 +282,12 @@ func TestCheckDependencies_PythonVersion(t *testing.T) {
 			"  - Using pyenv: pyenv install 3.14.2 && pyenv global 3.14.2\n" +
 			"  - Using dnf (Fedora): sudo dnf install python3\n" +
 			"  - Using apt (Ubuntu/Debian): sudo apt install python3")
-		return
 	}
 
 	// Get Python version
 	output, err := RunCommand(t, pythonCmd, "--version")
 	if err != nil {
 		t.Fatalf("Failed to get Python version: %v", err)
-		return
 	}
 
 	// Parse version string (e.g., "Python 3.12.4" or "Python 3.13.0")
@@ -302,13 +299,11 @@ func TestCheckDependencies_PythonVersion(t *testing.T) {
 	parts := strings.Fields(versionStr)
 	if len(parts) < 2 {
 		t.Fatalf("Could not parse Python version from: %s", versionStr)
-		return
 	}
 
 	versionParts := strings.Split(parts[1], ".")
 	if len(versionParts) < 2 {
 		t.Fatalf("Could not parse Python version numbers from: %s", parts[1])
-		return
 	}
 
 	// Parse major, minor, and patch version
@@ -316,12 +311,10 @@ func TestCheckDependencies_PythonVersion(t *testing.T) {
 	_, err = Sscanf(versionParts[0], "%d", &major)
 	if err != nil {
 		t.Fatalf("Could not parse Python major version from: %s", versionParts[0])
-		return
 	}
 	_, err = Sscanf(versionParts[1], "%d", &minor)
 	if err != nil {
 		t.Fatalf("Could not parse Python minor version from: %s", versionParts[1])
-		return
 	}
 	// Parse patch version if present (default to 0)
 	if len(versionParts) >= 3 {
@@ -341,7 +334,6 @@ func TestCheckDependencies_PythonVersion(t *testing.T) {
 			"  - Using pyenv: pyenv install 3.14.2 && pyenv global 3.14.2\n"+
 			"  - Update your system Python to a newer patch version",
 			versionStr)
-		return
 	}
 
 	// Python 3.14.2 is the tested version - pass without warning
@@ -640,7 +632,6 @@ func TestCheckDependencies_Clusterctl_IsAvailable(t *testing.T) {
 		t.Fatalf("clusterctl is required on macOS but was not found.\n\n" +
 			"Install with: brew install clusterctl\n\n" +
 			"See the warning above for detailed instructions.")
-		return
 	}
 
 	// On Linux/other platforms, warn but don't fail

--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -184,7 +184,6 @@ func TestExternalCluster_01b_MCEBaselineStatus(t *testing.T) {
 				PrintToTTY("   - %s\n", e)
 			}
 			t.Fatalf("Failed to configure MCE components: %v", fixErrors)
-			return
 		}
 
 		// Report successful changes
@@ -392,7 +391,6 @@ func TestKindCluster_01_ClusterReady(t *testing.T) {
 			if err != nil {
 				PrintToTTY("❌ Failed to generate Kind config: %v\n", err)
 				t.Fatalf("Failed to generate Kind config: %v", err)
-				return
 			}
 			if kindConfigPath != "" {
 				PrintToTTY("✅ Kind config generated: %s\n", kindConfigPath)

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -49,7 +49,6 @@ func TestDeployment_00_CreateNamespace(t *testing.T) {
 	if err != nil {
 		PrintToTTY("❌ Failed to create namespace: %v\n", err)
 		t.Fatalf("Failed to create namespace '%s': %v\nOutput: %s", config.WorkloadClusterNamespace, err, output)
-		return
 	}
 
 	PrintToTTY("✅ Namespace '%s' created successfully\n\n", config.WorkloadClusterNamespace)
@@ -308,7 +307,6 @@ func TestDeployment_ProviderCredentialsConfigured(t *testing.T) {
 				PrintToTTY("\nThe YAML generation did not create the credentials secret.\n")
 				PrintToTTY("Please check that TestDeployment_ApplyClusterYAMLs completed successfully.\n\n")
 				t.Fatalf("%s secret not found: %v", secretName, err)
-				return
 			}
 			PrintToTTY("✅ Secret exists\n\n")
 
@@ -332,7 +330,6 @@ func TestDeployment_ProviderCredentialsConfigured(t *testing.T) {
 				PrintToTTY("\n❌ %s credentials validation FAILED\n", provider.Name)
 				PrintToTTY("Missing fields: %v\n\n", missingFields)
 				t.Fatalf("%s credentials not configured: missing %v", provider.Name, missingFields)
-				return
 			}
 
 			PrintToTTY("\n✅ %s credentials validation PASSED\n\n", provider.Name)
@@ -545,7 +542,6 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 				"Check cluster status:\n"+
 				"  kubectl --context %s -n %s get cluster %s -o yaml",
 				context, config.WorkloadClusterNamespace, provisionedClusterName)
-			return
 		}
 
 		// Fail-fast: check ControlPlane conditions for permanent failures
@@ -557,7 +553,6 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 				"  kubectl --context %s -n %s get %s %s -o yaml",
 				controlPlaneKind, err,
 				context, config.WorkloadClusterNamespace, strings.ToLower(controlPlaneKind), controlPlaneName)
-			return
 		}
 
 		// Fail-fast: check MachinePool infrastructure conditions for permanent failures
@@ -575,7 +570,6 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 						"  kubectl --context %s -n %s get %s %s -o yaml",
 						mp.Infrastructure.Kind, err,
 						context, config.WorkloadClusterNamespace, strings.ToLower(mp.Infrastructure.Kind), infraName)
-					return
 				}
 			}
 		}
@@ -815,7 +809,6 @@ func TestDeployment_WaitForExternalAuthReady(t *testing.T) {
 				"Check control plane conditions:\n"+
 				"  kubectl --context %s -n %s get arocontrolplane -o yaml",
 				elapsed.Round(time.Second), context, config.WorkloadClusterNamespace)
-			return
 		}
 
 		data, err := MonitorCluster(t, context, config.WorkloadClusterNamespace, provisionedClusterName)
@@ -834,7 +827,6 @@ func TestDeployment_WaitForExternalAuthReady(t *testing.T) {
 				"  kubectl --context %s -n %s get %s -o yaml",
 				data.ControlPlane.Kind, err,
 				context, config.WorkloadClusterNamespace, strings.ToLower(data.ControlPlane.Kind))
-			return
 		}
 
 		// Search for ExternalAuthReady in control plane conditions
@@ -919,7 +911,6 @@ func TestDeployment_VerifyInfrastructureResources(t *testing.T) {
 				"Check AROCluster status:\n"+
 				"  kubectl --context %s -n %s get arocluster %s -o yaml",
 				elapsed.Round(time.Second), context, config.WorkloadClusterNamespace, provisionedClusterName)
-			return
 		}
 
 		iteration++
@@ -945,7 +936,6 @@ func TestDeployment_VerifyInfrastructureResources(t *testing.T) {
 				"  kubectl --context %s -n %s get %s %s -o yaml",
 				data.Infrastructure.Kind, err,
 				context, config.WorkloadClusterNamespace, strings.ToLower(data.Infrastructure.Kind), infraName)
-			return
 		}
 
 		// Get infrastructure status from already-parsed data
@@ -1030,7 +1020,6 @@ func TestDeployment_VerifyAROClusterReady(t *testing.T) {
 			t.Fatalf("Timeout after %v waiting for %s.Ready=true.\n"+
 				"  kubectl --context %s -n %s get %s %s -o yaml",
 				elapsed.Round(time.Second), infraKind, context, config.WorkloadClusterNamespace, infraResourceType, provisionedClusterName)
-			return
 		}
 
 		// Use monitoring script to get infrastructure status
@@ -1062,7 +1051,6 @@ func TestDeployment_VerifyAROClusterReady(t *testing.T) {
 					"  kubectl --context %s -n %s get %s %s -o yaml",
 					data.Infrastructure.Kind, failErr,
 					context, config.WorkloadClusterNamespace, infraResourceType, provisionedClusterName)
-				return
 			}
 		}
 
@@ -1107,7 +1095,6 @@ func TestDeployment_VerifyClusterProvisioned(t *testing.T) {
 			t.Fatalf("Timeout after %v waiting for cluster.status.initialization.infrastructureProvisioned=true.\n"+
 				"  kubectl --context %s -n %s get cluster %s -o yaml",
 				elapsed.Round(time.Second), context, config.WorkloadClusterNamespace, provisionedClusterName)
-			return
 		}
 
 		// Use monitoring script to get cluster infrastructure status
@@ -1137,7 +1124,6 @@ func TestDeployment_VerifyClusterProvisioned(t *testing.T) {
 					"Check cluster status:\n"+
 					"  kubectl --context %s -n %s get cluster %s -o yaml",
 					context, config.WorkloadClusterNamespace, provisionedClusterName)
-				return
 			}
 			if failErr := CheckK8sConditionsForPermanentFailure(data.Cluster.Conditions); failErr != nil {
 				PrintToTTY("\n❌ Permanent failure detected in Cluster conditions — aborting early\n")
@@ -1146,7 +1132,6 @@ func TestDeployment_VerifyClusterProvisioned(t *testing.T) {
 					"Check cluster status:\n"+
 					"  kubectl --context %s -n %s get cluster %s -o yaml",
 					failErr, context, config.WorkloadClusterNamespace, provisionedClusterName)
-				return
 			}
 		}
 
@@ -1187,7 +1172,6 @@ func TestDeployment_VerifyClusterInfrastructureReady(t *testing.T) {
 			t.Fatalf("Timeout after %v waiting for Cluster InfrastructureReady=True.\n"+
 				"  kubectl --context %s -n %s get cluster %s -o yaml",
 				elapsed.Round(time.Second), context, config.WorkloadClusterNamespace, provisionedClusterName)
-			return
 		}
 
 		// Use monitoring script to get cluster infrastructure ready condition
@@ -1217,7 +1201,6 @@ func TestDeployment_VerifyClusterInfrastructureReady(t *testing.T) {
 					"Check cluster status:\n"+
 					"  kubectl --context %s -n %s get cluster %s -o yaml",
 					context, config.WorkloadClusterNamespace, provisionedClusterName)
-				return
 			}
 			if failErr := CheckK8sConditionsForPermanentFailure(data.Cluster.Conditions); failErr != nil {
 				PrintToTTY("\n❌ Permanent failure detected in Cluster conditions — aborting early\n")
@@ -1226,7 +1209,6 @@ func TestDeployment_VerifyClusterInfrastructureReady(t *testing.T) {
 					"Check cluster status:\n"+
 					"  kubectl --context %s -n %s get cluster %s -o yaml",
 					failErr, context, config.WorkloadClusterNamespace, provisionedClusterName)
-				return
 			}
 		}
 


### PR DESCRIPTION
## Description

Remove unreachable `return` statements after `t.Fatalf()` calls across test files.

Since `t.Fatalf` calls `runtime.Goexit()` and never returns, any code after it is dead code.

Fixes #588

Ref: [ARO-27304](https://redhat.atlassian.net/browse/ARO-27304)

## Changes Made

- Removed 18 unreachable `return` statements in `test/05_deploy_crs_test.go`
- Removed 9 unreachable `return` statements in `test/01_check_dependencies_test.go`
- Removed 2 unreachable `return` statements in `test/03_cluster_test.go`

## Configuration Changes

N/A

## Additional Notes

The original issue identified 2 instances in `TestDeployment_ProviderCredentialsConfigured` (CodeRabbit finding #8 for PR #578). This PR fixes all 29 occurrences of the same pattern across the entire test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-27304]: https://redhat.atlassian.net/browse/ARO-27304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ