### PR TITLE
ci: add scorecard annotation for token-permissions check

### DIFF
--- a/.scorecard.yml
+++ b/.scorecard.yml
@@ -1,0 +1,9 @@
+annotations:
+  - checks:
+      - token-permissions
+    reasons:
+      - reason: not-applicable
+        details: >-
+          security-events:write is required for uploading SARIF results from
+          security scanners (gosec, scorecard). issues:write is required for
+          auto-creating GitHub issues on security findings.

--- a/.scorecard.yml
+++ b/.scorecard.yml
@@ -2,8 +2,6 @@ annotations:
   - checks:
       - token-permissions
     reasons:
+      # security-events:write is required for uploading SARIF results (gosec, scorecard).
+      # issues:write is required by gosec for auto-creating GitHub issues on findings.
       - reason: not-applicable
-        details: >-
-          security-events:write is required for uploading SARIF results from
-          security scanners (gosec, scorecard). issues:write is required for
-          auto-creating GitHub issues on security findings.


### PR DESCRIPTION
## Description

Add OpenSSF Scorecard maintainer annotation for the token-permissions check ([code scanning alert #16](https://github.com/stolostron/capi-tests/security/code-scanning/16)).

The Scorecard flags `security-events: write` and `issues: write` in `security-gosec.yml` as overly permissive, but both are legitimately required — `security-events: write` for SARIF uploads and `issues: write` for auto-creating GitHub issues on security findings.

## Changes Made

- Add `.scorecard.yml` with `not-applicable` annotation for `token-permissions` check, providing context alongside the Scorecard finding

## Configuration Changes

No configuration changes.

## Additional Notes

- The annotation adds context to the check results but does not suppress the check from running
- If the alert persists after this, we may need to exclude the check via `--checks` in the Scorecard workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)