### PR TITLE
feat: add podman to Dockerfile.prow for k3s-in-podman CI step

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -28,7 +28,7 @@ RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
     if [ -d /etc/yum.repos.art/ci ]; then \
       cp /etc/yum.repos.d/azure-cli.repo /etc/yum.repos.art/ci/; \
     fi && \
-    dnf install -y azure-cli jq gettext libxml2 bc python3-cffi && dnf clean all
+    dnf install -y azure-cli jq gettext libxml2 bc python3-cffi podman && dnf clean all
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
## Summary
- Add `podman` to the `dnf install` line in `Dockerfile.prow`
- Required by the k3s e2e CI step which runs k3s inside a privileged podman container
- Cannot be installed at runtime because the ART yum wrapper has restrictive file permissions in CI pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added podman to the Docker build environment alongside existing development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->