### PR TITLE
fix: recognize "could not find" as transient waiting pattern (ARO-27266)

### DIFF
--- a/test/helpers.go
+++ b/test/helpers.go
@@ -865,6 +865,7 @@ var waitingPatterns = []WaitingPattern{
 	{Pattern: "waiting for", Description: "Waiting for dependency"},
 	{Pattern: "will be requeued", Description: "Waiting (will retry)"},
 	{Pattern: "not found", Description: "Waiting for resource creation"},
+	{Pattern: "could not find", Description: "Waiting for resource creation"},
 	{Pattern: "is not ready", Description: "Waiting for dependency"},
 	{Pattern: "not yet available", Description: "Waiting for availability"},
 	{Pattern: "still being created", Description: "Waiting for creation"},

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -1060,6 +1060,17 @@ func TestIsWaitingCondition(t *testing.T) {
 			expectedDesc:    "",
 		},
 		{
+			name: "False with could not find message",
+			condition: ControlPlaneCondition{
+				Type:    "HcpClusterReady",
+				Status:  "False",
+				Reason:  "Failed",
+				Message: `[Warning] extension failed to produce resources for export: could not find secret to save to 'Name: "capz-tests-kubeconfig", Key: "value"'`,
+			},
+			expectedWaiting: true,
+			expectedDesc:    "Waiting for resource creation",
+		},
+		{
 			name: "Case insensitive matching",
 			condition: ControlPlaneCondition{
 				Type:    "SomeCondition",
@@ -1155,6 +1166,16 @@ func TestIsPermanentFailure(t *testing.T) {
 				Status:  "False",
 				Reason:  "Failed",
 				Message: "waiting for dependency to be available",
+			},
+			expectedFailed: false,
+		},
+		{
+			name: "Failed reason but 'could not find' in message - not permanent",
+			condition: ControlPlaneCondition{
+				Type:    "HcpClusterReady",
+				Status:  "False",
+				Reason:  "Failed",
+				Message: `[Warning] extension failed to produce resources for export: could not find secret to save to 'Name: "capz-tests-kubeconfig", Key: "value"'`,
 			},
 			expectedFailed: false,
 		},


### PR DESCRIPTION
## Description

On the backplane-2.11 branch, the AROControlPlane controller temporarily sets
`HcpClusterReady: False (Failed)` with the message "could not find secret" during
early HCP provisioning. The test suite's permanent failure detection incorrectly
classified this as non-recoverable, aborting the deployment after ~10 minutes at
only 8% progress.

The existing `"not found"` waiting pattern didn't match `"could not find"` — they're
different strings. Adding `"could not find"` as a waiting pattern fixes the false
positive.

JIRA: https://redhat.atlassian.net/browse/ARO-27266

## Changes Made

- Add `"could not find"` to `waitingPatterns` in `test/helpers.go`
- Add test cases in `test/helpers_test.go` verifying the exact backplane-2.11 condition
  (`HcpClusterReady: Failed - could not find secret`) is recognized as transient

## Configuration Changes

No configuration changes.

## Additional Notes

The backplane-2.11 daily workflow has failed consistently since at least May 22
due to this false positive. Backplane-2.17 is unaffected (its controller doesn't
emit this condition message during provisioning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classification of control-plane conditions to correctly treat messages about missing resources as temporary waiting states rather than permanent failures, enabling more accurate status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->