### PR TITLE
fix: use cached deployCharts and GetEnvOrDefault convention (ARO-27319)

### DIFF
--- a/test/config.go
+++ b/test/config.go
@@ -747,7 +747,7 @@ func NewTestConfig() *TestConfig {
 		MCEEnablementTimeout: parseMCEEnablementTimeout(),
 
 		// Chart deployment
-		DeployCharts: parseDeployCharts(),
+		DeployCharts: deployCharts,
 	}
 }
 
@@ -873,7 +873,7 @@ func parseMCEEnablementTimeout() time.Duration {
 // Returns true if DEPLOY_CHARTS=true, false otherwise.
 // Default: false
 func parseDeployCharts() bool {
-	return os.Getenv("DEPLOY_CHARTS") == "true"
+	return GetEnvOrDefault("DEPLOY_CHARTS", "false") == "true"
 }
 
 // GetOutputDirName returns the output directory name for generated infrastructure files


### PR DESCRIPTION
## Description

Use cached deployCharts variable and switch parseDeployCharts() to GetEnvOrDefault() convention.

Jira: https://redhat.atlassian.net/browse/ARO-27319

## Changes Made

- Use the already-cached `deployCharts` variable in the TestConfig struct literal instead of calling `parseDeployCharts()` a second time
- Switch `parseDeployCharts()` from `os.Getenv("DEPLOY_CHARTS")` to `GetEnvOrDefault("DEPLOY_CHARTS", "false")` to follow the project convention

## Configuration Changes

No new environment variables. No behavior change — `DEPLOY_CHARTS` default remains `false`.

## Additional Notes

CodeRabbit finding from PR #592, tracked as GitHub issue #596 (now closed).

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal test configuration improvements with refactored environment variable handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->