### PR TITLE
test: add coverage for ASO_CREDENTIAL_NAME env var override (ARO-27321)

### DIFF
--- a/test/config_test.go
+++ b/test/config_test.go
@@ -349,6 +349,19 @@ func TestNewAzureProvider(t *testing.T) {
 	}
 }
 
+func TestNewAzureProvider_ASOCredentialNameOverride(t *testing.T) {
+	t.Setenv("ASO_CREDENTIAL_NAME", "custom-credential")
+
+	p := NewAzureProvider("capz-system")
+
+	if p.CredentialSecret == nil {
+		t.Fatal("Expected credential secret to be defined")
+	}
+	if p.CredentialSecret.Name != "custom-credential" {
+		t.Errorf("Expected custom-credential, got %q", p.CredentialSecret.Name)
+	}
+}
+
 func TestNewAzureProvider_Namespace(t *testing.T) {
 	p := NewAzureProvider("custom-namespace")
 


### PR DESCRIPTION
## Description

Add test for `ASO_CREDENTIAL_NAME` environment variable override in `NewAzureProvider`.

Ref: [ARO-27321](https://redhat.atlassian.net/browse/ARO-27321)

## Changes Made

- Add `TestNewAzureProvider_ASOCredentialNameOverride` subtest that sets `ASO_CREDENTIAL_NAME=custom-credential` and verifies the override is picked up

## Configuration Changes

No new configuration — this tests an existing env var (`ASO_CREDENTIAL_NAME`).

## Additional Notes

Originated from PR #610 review. The existing `TestNewAzureProvider` only asserted the default `"aso-credential"` value without exercising the `GetEnvOrDefault` override path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-27321]: https://redhat.atlassian.net/browse/ARO-27321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for Azure provider credential name override functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->