### PR TITLE
fix: validate jq-extracted Azure credentials for null values (ARO-27322)

### DIFF
--- a/openshift-ci/capz-test-env.sh
+++ b/openshift-ci/capz-test-env.sh
@@ -11,6 +11,12 @@ if [[ -n "${CLUSTER_PROFILE_DIR:-}" && -f "${CLUSTER_PROFILE_DIR}/osServicePrinc
   AZURE_CLIENT_SECRET=$(jq -r .clientSecret "${CLUSTER_PROFILE_DIR}/osServicePrincipal.json")
   AZURE_TENANT_ID=$(jq -r .tenantId "${CLUSTER_PROFILE_DIR}/osServicePrincipal.json")
   AZURE_SUBSCRIPTION_ID=$(jq -r .subscriptionId "${CLUSTER_PROFILE_DIR}/osServicePrincipal.json")
+  for var in AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID; do
+    if [[ -z "${!var}" || "${!var}" == "null" ]]; then
+      echo "[capz-test-env] ERROR: ${var} is missing or null in ${CLUSTER_PROFILE_DIR}/osServicePrincipal.json" >&2
+      exit 1
+    fi
+  done
   export AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
   echo "[capz-test-env] Azure credentials loaded from cluster profile"
   set -o xtrace

--- a/openshift-ci/capz-test-env.sh
+++ b/openshift-ci/capz-test-env.sh
@@ -35,6 +35,12 @@ if [[ -d "${CAPZ_CREDS_DIR}" && -f "${CAPZ_CREDS_DIR}/AZURE_CLIENT_ID" ]]; then
   AZURE_CLIENT_SECRET=$(cat "${CAPZ_CREDS_DIR}/AZURE_CLIENT_SECRET")
   AZURE_TENANT_ID=$(cat "${CAPZ_CREDS_DIR}/AZURE_TENANT_ID")
   AZURE_SUBSCRIPTION_ID=$(cat "${CAPZ_CREDS_DIR}/AZURE_SUBSCRIPTION_ID")
+  for var in AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID; do
+    if [[ -z "${!var}" || "${!var}" == "null" ]]; then
+      echo "[capz-test-env] ERROR: ${var} is missing or null in ${CAPZ_CREDS_DIR}" >&2
+      exit 1
+    fi
+  done
   export AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
   echo "[capz-test-env] Azure credentials overridden with CAPZ vault credentials"
   set -o xtrace


### PR DESCRIPTION
## Description

`jq -r .fieldName` returns the literal string `"null"` when a JSON field is missing from
`osServicePrincipal.json`. This silently propagates as a credential value, causing a confusing
Azure auth failure minutes into the CI run instead of failing fast.

Add a validation loop after extraction that checks each credential variable for empty or `"null"`
values and exits with a clear error message. Applied to both credential sources:
the `osServicePrincipal.json` path and the CAPZ vault flat-file path.

Ref: [ARO-27322](https://redhat.atlassian.net/browse/ARO-27322)

## Changes Made

- Add post-extraction validation loop in `openshift-ci/capz-test-env.sh` that checks all four
  Azure credential variables (`AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`,
  `AZURE_SUBSCRIPTION_ID`) for empty or literal `"null"` values
- Applied to both credential sources: `osServicePrincipal.json` (jq extraction) and
  `CAPZ_CREDS_DIR` (cat from flat files)
- Fail fast with a descriptive error message identifying the missing field and source

## Configuration Changes

No new environment variables.

## Additional Notes

The validation runs inside the existing `set +o xtrace` guard, so credential values
are never exposed in build logs. Error messages print only the variable name, not its value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-27322]: https://redhat.atlassian.net/browse/ARO-27322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ