### PR TITLE
ci: add CAPZ and ASO PR number inputs to ARO workflow (ARO-26748)

### DIFF
--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -43,6 +43,16 @@ on:
         required: false
         type: string
         default: ''
+      capz_pr_no:
+        description: 'CAPZ PR number for image override (optional)'
+        required: false
+        type: string
+        default: ''
+      aso_pr_no:
+        description: 'ASO PR number for image override (optional)'
+        required: false
+        type: string
+        default: ''
   workflow_call:
     inputs:
       environment:
@@ -60,6 +70,16 @@ on:
         required: false
         type: string
         default: ''
+      capz_pr_no:
+        description: 'CAPZ PR number for image override (optional)'
+        required: false
+        type: string
+        default: ''
+      aso_pr_no:
+        description: 'ASO PR number for image override (optional)'
+        required: false
+        type: string
+        default: ''
     secrets:
       QUAY_AUTH:
         required: true
@@ -72,6 +92,8 @@ env:
   INFRA_PROVIDER: aro
   ARO_REPO_DIR: /tmp/cluster-api-installer-aro
   ARO_REPO_BRANCH: ${{ inputs.aro_repo_branch }}
+  CAPZ_PR_NO: ${{ inputs.capz_pr_no }}
+  ASO_PR_NO: ${{ inputs.aso_pr_no }}
   TEST_TIMEOUT_MINUTES: 120
   # Global variables (not environment-specific)
   QUAY_AUTH: ${{ secrets.QUAY_AUTH }}


### PR DESCRIPTION
## Description

Add `capz_pr_no` and `aso_pr_no` workflow inputs to enable automated PR-based image override testing for CAPZ and ASO components.

Jira: https://issues.redhat.com/browse/ARO-26748

## Changes Made

- Add `capz_pr_no` input to `workflow_dispatch` and `workflow_call` triggers (optional, defaults to empty)
- Add `aso_pr_no` input to `workflow_dispatch` and `workflow_call` triggers (optional, defaults to empty)
- Set `CAPZ_PR_NO` and `ASO_PR_NO` environment variables from the new inputs

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `CAPZ_PR_NO` | CAPZ PR number for Konflux image override | `''` (empty, uses default images) |
| `ASO_PR_NO` | ASO PR number for Konflux image override | `''` (empty, uses default images) |

## Additional Notes

Companion PRs:
- stolostron/cluster-api-provider-azure#279 — dispatch workflow that triggers capi-tests after Konflux build
- stolostron/cluster-api-installer#688, #689, #690 — replace-params support for PR-specific image URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)