### PR TITLE
fix: point DEPLOYMENT_STATE_FILE to repo dir where Go tests write it (ARO-27345)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,7 +466,7 @@ clean: ## Clean up test resources (interactive, use FORCE=1 to skip prompts)
 			echo "Management cluster '$(CLEANUP_MANAGEMENT_CLUSTER)' not found (already clean)."; \
 		fi; \
 		echo ""; \
-	REPO_DIR="$${TMPDIR:-/tmp}/cluster-api-installer-aro"; \
+	REPO_DIR="$(ARO_REPO_DIR)"; \
 		if [ -d "$$REPO_DIR" ]; then \
 			echo "Directory $$REPO_DIR exists."; \
 			read -p "Delete $$REPO_DIR? [y/N] " -n 1 -r; \
@@ -595,7 +595,7 @@ clean-all: ## Clean up ALL test resources without prompting (local + Azure)
 	fi
 	@echo ""
 	@# Delete cluster-api-installer directory (use TMPDIR for cross-platform support)
-	@REPO_DIR="$${TMPDIR:-/tmp}/cluster-api-installer-aro"; \
+	@REPO_DIR="$(ARO_REPO_DIR)"; \
 	if [ -d "$$REPO_DIR" ]; then \
 		echo "Deleting $$REPO_DIR..."; \
 		rm -rf "$$REPO_DIR" || echo "Failed to delete directory"; \

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,12 @@ else
 AZURE_RESOURCE_GROUP ?= $(WORKLOAD_CLUSTER_NAME)-resgroup
 endif
 
-# Deployment state file - written by tests to record actual deployed configuration
-DEPLOYMENT_STATE_FILE := .deployment-state.json
+# Repository directory for cluster-api-installer (matches Go default in test/config.go:getDefaultRepoDir)
+ARO_REPO_DIR ?= $(shell echo $${TMPDIR:-/tmp})/cluster-api-installer-aro
+
+# Deployment state file - written by Go tests to config.RepoDir during execution.
+# Must point to the repo dir because Go tests os.Chdir(config.RepoDir) before writing.
+DEPLOYMENT_STATE_FILE := $(ARO_REPO_DIR)/.deployment-state.json
 
 # Read from deployment state file if it exists (for cleanup to target correct resources)
 # This ensures cleanup targets the same resources that were actually deployed,


### PR DESCRIPTION
## Description

`make clean-all` in CI fails to delete unique per-run Azure resource groups because it can't
find the deployment state file. Go tests `os.Chdir(config.RepoDir)` before writing
`.deployment-state.json`, so it lands at e.g. `/tmp/cluster-api-installer-aro/.deployment-state.json`.
The Makefile was looking for `.deployment-state.json` in the project root, so `CLEANUP_RESOURCE_GROUP`
always fell back to the static default (e.g., `capz-tests-resgroup`) instead of the unique per-run
name (e.g., `capz-tests-c7d4e-resgroup`).

Observed in [run 26505418358](https://github.com/stolostron/capi-tests/actions/runs/26505418358) —
cancelled job left orphaned RG `capz-tests-c7d4e-resgroup` because cleanup searched for
`capz-tests-resgroup`.

Ref: [ARO-27345](https://redhat.atlassian.net/browse/ARO-27345)

## Changes Made

- Added `ARO_REPO_DIR` Make variable (matching Go's `getDefaultRepoDir()` in `test/config.go`)
- Updated `DEPLOYMENT_STATE_FILE` to `$(ARO_REPO_DIR)/.deployment-state.json`
- Unified `clean` and `clean-all` targets to use `$(ARO_REPO_DIR)` instead of hardcoded paths

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `ARO_REPO_DIR` | Repository directory for cluster-api-installer (also used for state file path) | `$TMPDIR/cluster-api-installer-aro` or `/tmp/cluster-api-installer-aro` |

## Additional Notes

No Go code changes needed — the Go tests already write to the correct location. Only the Makefile
needed to be pointed to the right path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-27345]: https://redhat.atlassian.net/browse/ARO-27345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ