### PR TITLE
fix: make JUnit enrichment non-fatal in summary target (ARO-27384)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -748,11 +748,11 @@ fix-docker-config: ## Fix Docker credential helper configuration issues
 
 summary: ## Generate test results summary from latest results
 	@if [ -d "$(LATEST_RESULTS_DIR)" ]; then \
-		./scripts/enrich-junit-xml.sh $(LATEST_RESULTS_DIR); \
+		./scripts/enrich-junit-xml.sh $(LATEST_RESULTS_DIR) || echo "WARNING: JUnit enrichment failed, continuing with summary"; \
 		./scripts/generate-summary.sh $(LATEST_RESULTS_DIR); \
 	elif [ -n "$$(ls -d results/2* 2>/dev/null | tail -1)" ]; then \
 		LATEST_RUN=$$(ls -d results/2* 2>/dev/null | tail -1); \
-		./scripts/enrich-junit-xml.sh "$$LATEST_RUN"; \
+		./scripts/enrich-junit-xml.sh "$$LATEST_RUN" || echo "WARNING: JUnit enrichment failed, continuing with summary"; \
 		./scripts/generate-summary.sh "$$LATEST_RUN"; \
 	else \
 		echo "Error: No test results found. Run 'make test-all' first."; \


### PR DESCRIPTION
## Description

Make JUnit enrichment non-fatal in the Makefile `summary` target so that
`generate-summary.sh` still runs even when `enrich-junit-xml.sh` fails
(e.g., missing `xmllint`, malformed XML).

Ref: [ARO-27384](https://redhat.atlassian.net/browse/ARO-27384)
Closes #619

## Changes Made

- Guard both `enrich-junit-xml.sh` calls in the `summary` target with
  `|| echo "WARNING: ..."` so enrichment failure doesn't kill the shell
  before `generate-summary.sh` runs

## Configuration Changes

No configuration changes.

## Additional Notes

The original GitHub issue (#619) pointed at `capz-test-summary-commands.sh`,
but that script was since refactored to just call `make summary`. The bug
moved to the Makefile `summary` target, where the same sequential-with-errexit
pattern existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-27384]: https://redhat.atlassian.net/browse/ARO-27384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process resilience: the summary generation now handles failures in intermediate enrichment operations gracefully by continuing execution with warning messages. This applies to both standard and fallback result directory paths, ensuring the build completes and generates final summaries even when upstream processing steps encounter errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->