### PR TITLE
feat: add AWS resource tagging for stale resource detection (ARO-27386)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -562,6 +562,28 @@ clean: ## Clean up test resources (interactive, use FORCE=1 to skip prompts)
 			echo "Skipping Azure cleanup (INFRA_PROVIDER=$(INFRA_PROVIDER), not aro)"; \
 		fi; \
 		echo ""; \
+		if [ "$(INFRA_PROVIDER)" = "rosa" ]; then \
+			echo "--- AWS Resources ---"; \
+			echo ""; \
+		if ! command -v aws >/dev/null 2>&1; then \
+			echo "⚠️  AWS CLI (aws) not available - skipping AWS cleanup"; \
+		elif ! aws sts get-caller-identity >/dev/null 2>&1; then \
+			echo "⚠️  Not authenticated to AWS - skipping AWS cleanup"; \
+			echo "   Run 'aws configure' to authenticate"; \
+		else \
+			read -p "Search for and delete tagged AWS resources? [y/N] " -n 1 -r; \
+			echo ""; \
+			if [[ $$REPLY =~ ^[Yy]$$ ]]; then \
+				./scripts/cleanup-aws-resources.sh || echo "AWS resources cleanup encountered an error"; \
+			else \
+				echo "Skipped AWS resource cleanup."; \
+				echo "Tip: Run 'make clean-aws' to clean all AWS resources."; \
+			fi; \
+		fi; \
+		else \
+			echo "Skipping AWS cleanup (INFRA_PROVIDER=$(INFRA_PROVIDER), not rosa)"; \
+		fi; \
+		echo ""; \
 		if [ -f "$(DEPLOYMENT_STATE_FILE)" ]; then \
 			echo "Removing deployment state file..."; \
 			rm -f "$(DEPLOYMENT_STATE_FILE)"; \

--- a/scripts/check-stale-resources.sh
+++ b/scripts/check-stale-resources.sh
@@ -561,7 +561,7 @@ check_aws_cloudformation() {
     local stacks_json
     stacks_json=$(aws cloudformation describe-stacks \
         --region "$region" \
-        --query "Stacks[?StackStatus=='CREATE_COMPLETE' || StackStatus=='UPDATE_COMPLETE' || StackStatus=='ROLLBACK_COMPLETE'].{StackName: StackName, CreationTime: CreationTime, StackStatus: StackStatus, Tags: Tags}" \
+        --query "Stacks[?StackStatus=='CREATE_COMPLETE' || StackStatus=='UPDATE_COMPLETE' || StackStatus=='ROLLBACK_COMPLETE' || StackStatus=='UPDATE_ROLLBACK_COMPLETE' || StackStatus=='CREATE_FAILED' || StackStatus=='DELETE_FAILED'].{StackName: StackName, CreationTime: CreationTime, StackStatus: StackStatus, Tags: Tags}" \
         --output json 2>/dev/null) || {
         print_warning "Failed to query AWS CloudFormation stacks"
         return 0

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1271,6 +1271,11 @@ func TestDeployment_TagAWSResources(t *testing.T) {
 		return
 	}
 
+	if err := EnsureAWSCredentialsSet(t); err != nil {
+		t.Skipf("Skipping AWS resource tagging: %v", err)
+		return
+	}
+
 	if config.InfraProviderName != "rosa" {
 		t.Skipf("AWS resource tagging only applies to ROSA provider")
 		return


### PR DESCRIPTION
## Description

Add AWS resource tagging with `capi-test-*` ownership metadata, mirroring the existing Azure pattern. The shared AWS account caused false positives in stale resource detection — we couldn't distinguish our test resources from other teams' resources.

JIRA: https://redhat.atlassian.net/browse/ARO-27386

## Changes Made

- Rename `AzureResourceTags` → `ResourceTags` throughout the codebase (provider-agnostic naming, backward-compatible JSON deserialization for existing state files)
- Add `TagAWSCloudFormationStacks()` and `TagAWSVPCs()` helpers using the Resource Groups Tagging API (additive — preserves existing tags)
- Add `TestDeployment_TagAWSResources` Phase 05 test function with AWS credential validation
- Update `scripts/check-stale-resources.sh` to filter AWS resources by `capi-test-*` tags and include rollback/failure CloudFormation states
- Create `scripts/cleanup-aws-resources.sh` for tag-based AWS resource cleanup with correct dependency ordering (NAT gateways before subnets)
- Add `clean-aws`, `_clean-aws-conditional` Makefile targets
- Update `clean-all` and interactive `clean` to include AWS cleanup for ROSA provider

## Configuration Changes

No new environment variables. Existing `capi-test-user`, `capi-test-env`, `capi-test-run-id`, `capi-test-created-at` tags are now applied to AWS resources in addition to Azure.

## Additional Notes

- VPC tagging is scoped to the current cluster via the specific CAPA tag key (`sigs.k8s.io/cluster-api-provider-aws/cluster/<cluster-name>`) to prevent cross-cluster tag corruption in shared accounts
- CloudFormation tagging uses `resourcegroupstaggingapi tag-resources` (additive, no stack update triggered) instead of `update-stack --tags`
- Stale detection now covers failure states (ROLLBACK_COMPLETE, UPDATE_ROLLBACK_COMPLETE, CREATE_FAILED, DELETE_FAILED)
- AWS tagging is non-fatal (warnings only) — same pattern as Azure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced interactive `make clean` command with AWS resource cleanup capabilities, including CLI validation and authentication verification for ROSA deployments
  * Improved CloudFormation stack status detection to capture additional resource states during cleanup operations

* **Tests**
  * Added AWS credential validation to resource tagging tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->