### PR TITLE
fix: correct management-cluster ref.yaml top-level documentation (ARO-27389)

### DIFF
--- a/openshift-ci/step-registry/capz-test-management-cluster-ref.yaml
+++ b/openshift-ci/step-registry/capz-test-management-cluster-ref.yaml
@@ -19,5 +19,6 @@ ref:
       use this value instead of generating a timestamp-based namespace.
   timeout: 45m
   documentation: |-
-    Validates the IPI-provisioned cluster and deploys CAPI/CAPZ/ASO
-    controllers via DEPLOY_CHARTS=true using deploy-charts.sh.
+    Validates the IPI-provisioned cluster as a CAPI management cluster.
+    When DEPLOY_CHARTS is true, deploys CAPI/CAPZ/ASO controllers via
+    deploy-charts.sh; otherwise expects pre-installed controllers.


### PR DESCRIPTION
## Description

The top-level documentation in `capz-test-management-cluster-ref.yaml` hardcodes the assumption
that `DEPLOY_CHARTS=true`, but the ref's default is `"false"`. Updated to describe both modes.

JIRA: https://redhat.atlassian.net/browse/ARO-27389

## Changes Made

- Updated top-level `documentation` block to describe both `DEPLOY_CHARTS=true` and `false` modes
- Now consistent with the already-correct per-env-var documentation in the same file

## Configuration Changes

No configuration changes.

## Additional Notes

The per-env-var documentation (lines 12-14) was already fixed previously and correctly describes
both modes — this PR fixes the remaining top-level documentation block that was missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation regarding cluster validation and controller deployment behavior, distinguishing between scenarios where controllers are deployed automatically versus pre-installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->