### PR TITLE
feat: add user identity detection for local-run stale resources (ARO-27388)

### DIFF
--- a/scripts/check-stale-resources.sh
+++ b/scripts/check-stale-resources.sh
@@ -250,9 +250,11 @@ check_azure_resource_groups_by_convention() {
     local stale_convention_rgs="[]"
 
     while IFS= read -r rg; do
-        local rg_name rg_location
+        local rg_name rg_location rg_user rg_env
         rg_name=$(echo "$rg" | jq -r '.name')
         rg_location=$(echo "$rg" | jq -r '.location')
+        rg_user=$(echo "$rg" | jq -r '.tags."capi-test-user" // "-"')
+        rg_env=$(echo "$rg" | jq -r '.tags."capi-test-env" // "-"')
 
         # Skip if already found by tagged detection
         if echo "$tagged_rg_names" | grep -qx "$rg_name" 2>/dev/null; then
@@ -287,8 +289,8 @@ check_azure_resource_groups_by_convention() {
                 --arg name "$rg_name" \
                 --arg location "$rg_location" \
                 --arg createdAt "unknown" \
-                --arg user "-" \
-                --arg env "-" \
+                --arg user "$rg_user" \
+                --arg env "$rg_env" \
                 --arg detection "convention (unknown age)" \
                 --argjson resourceCount "$resource_count" \
                 '{name: $name, location: $location, createdAt: $createdAt, user: $user, env: $env, detection: $detection, resourceCount: $resourceCount}')
@@ -305,8 +307,8 @@ check_azure_resource_groups_by_convention() {
                 --arg name "$rg_name" \
                 --arg location "$rg_location" \
                 --arg createdAt "$created_at" \
-                --arg user "-" \
-                --arg env "-" \
+                --arg user "$rg_user" \
+                --arg env "$rg_env" \
                 --arg detection "convention" \
                 --argjson resourceCount "$resource_count" \
                 '{name: $name, location: $location, createdAt: $createdAt, user: $user, env: $env, detection: $detection, resourceCount: $resourceCount}')
@@ -325,10 +327,10 @@ check_azure_resource_groups_by_convention() {
             echo ""
             print_warning "Found ${stale_count} stale untagged Azure resource group(s) (by naming convention):"
             echo ""
-            printf "%-45s | %-15s | %-25s | %-5s | %-25s\n" "NAME" "LOCATION" "CREATED AT" "RES#" "DETECTION"
-            printf "%s\n" "$(printf '%.0s-' {1..122})"
-            echo "$stale_convention_rgs" | jq -r '.[] | "\(.name)|\(.location)|\(.createdAt)|\(.resourceCount)|\(.detection)"' | while IFS='|' read -r name loc created rescount detection; do
-                printf "%-45s | %-15s | %-25s | %-5s | %-25s\n" "${name:0:45}" "${loc:0:15}" "${created:0:25}" "${rescount:0:5}" "${detection:0:25}"
+            printf "%-45s | %-15s | %-25s | %-10s | %-5s | %-25s\n" "NAME" "LOCATION" "CREATED AT" "USER" "RES#" "DETECTION"
+            printf "%s\n" "$(printf '%.0s-' {1..135})"
+            echo "$stale_convention_rgs" | jq -r '.[] | "\(.name)|\(.location)|\(.createdAt)|\(.user // "-")|\(.resourceCount)|\(.detection)"' | while IFS='|' read -r name loc created user rescount detection; do
+                printf "%-45s | %-15s | %-25s | %-10s | %-5s | %-25s\n" "${name:0:45}" "${loc:0:15}" "${created:0:25}" "${user:0:10}" "${rescount:0:5}" "${detection:0:25}"
             done
             echo ""
         fi

--- a/test/config.go
+++ b/test/config.go
@@ -276,9 +276,10 @@ func getDefaultRepoDir() string {
 }
 
 // getCAPIUser returns the user identifier from CAPI_USER env var,
-// falling back to DefaultCAPIUser.
+// falling back to the OS username ($USER) for local-run attribution,
+// then to DefaultCAPIUser as a last resort.
 func getCAPIUser() string {
-	return GetEnvOrDefault("CAPI_USER", DefaultCAPIUser)
+	return GetEnvOrDefault("CAPI_USER", GetEnvOrDefault("USER", DefaultCAPIUser))
 }
 
 // getWorkloadClusterNamespace returns the namespace for workload cluster resources.

--- a/test/config.go
+++ b/test/config.go
@@ -276,10 +276,18 @@ func getDefaultRepoDir() string {
 }
 
 // getCAPIUser returns the user identifier from CAPI_USER env var,
-// falling back to the OS username ($USER) for local-run attribution,
+// falling back to the OS username ($USER) sanitized for RFC 1123 compliance,
 // then to DefaultCAPIUser as a last resort.
 func getCAPIUser() string {
-	return GetEnvOrDefault("CAPI_USER", GetEnvOrDefault("USER", DefaultCAPIUser))
+	if v := os.Getenv("CAPI_USER"); v != "" {
+		return v
+	}
+	if v := os.Getenv("USER"); v != "" {
+		if s := SanitizeToRFC1123(v); s != "" {
+			return s
+		}
+	}
+	return DefaultCAPIUser
 }
 
 // getWorkloadClusterNamespace returns the namespace for workload cluster resources.

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -673,6 +673,51 @@ func TestTestConfig_AllRequiredScripts(t *testing.T) {
 	}
 }
 
+func TestGetCAPIUser_FallbackToOSUser(t *testing.T) {
+	testCases := []struct {
+		name     string
+		capiUser string
+		osUser   string
+		expected string
+	}{
+		{
+			name:     "CAPI_USER takes precedence",
+			capiUser: "custom",
+			osUser:   "rcap",
+			expected: "custom",
+		},
+		{
+			name:     "falls back to USER when CAPI_USER unset",
+			capiUser: "",
+			osUser:   "rcap",
+			expected: "rcap",
+		},
+		{
+			name:     "falls back to DefaultCAPIUser when both unset",
+			capiUser: "",
+			osUser:   "",
+			expected: DefaultCAPIUser,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CAPI_USER", tc.capiUser)
+			if tc.osUser != "" {
+				t.Setenv("USER", tc.osUser)
+			} else {
+				t.Setenv("USER", "")
+			}
+
+			result := getCAPIUser()
+			if result != tc.expected {
+				t.Errorf("getCAPIUser() = %q, expected %q (CAPI_USER=%q, USER=%q)",
+					result, tc.expected, tc.capiUser, tc.osUser)
+			}
+		})
+	}
+}
+
 func TestClusterMode_Kind(t *testing.T) {
 	// Save and restore environment
 	origClusterMode := os.Getenv("CLUSTER_MODE")

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -698,6 +698,24 @@ func TestGetCAPIUser_FallbackToOSUser(t *testing.T) {
 			osUser:   "",
 			expected: DefaultCAPIUser,
 		},
+		{
+			name:     "sanitizes USER with underscores",
+			capiUser: "",
+			osUser:   "john_doe",
+			expected: "john-doe",
+		},
+		{
+			name:     "sanitizes USER with uppercase",
+			capiUser: "",
+			osUser:   "Jane",
+			expected: "jane",
+		},
+		{
+			name:     "CAPI_USER is NOT sanitized (user responsibility)",
+			capiUser: "John_Doe",
+			osUser:   "rcap",
+			expected: "John_Doe",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -713,6 +731,31 @@ func TestGetCAPIUser_FallbackToOSUser(t *testing.T) {
 			if result != tc.expected {
 				t.Errorf("getCAPIUser() = %q, expected %q (CAPI_USER=%q, USER=%q)",
 					result, tc.expected, tc.capiUser, tc.osUser)
+			}
+		})
+	}
+}
+
+func TestSanitizeToRFC1123(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"rcap", "rcap"},
+		{"john_doe", "john-doe"},
+		{"Jane", "jane"},
+		{"user.name", "user-name"},
+		{"ADMIN", "admin"},
+		{"a__b--c", "a-b-c"},
+		{"---", ""},
+		{"", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := SanitizeToRFC1123(tc.input)
+			if result != tc.expected {
+				t.Errorf("SanitizeToRFC1123(%q) = %q, expected %q", tc.input, result, tc.expected)
 			}
 		})
 	}

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1863,6 +1863,17 @@ func ValidateNamePrefix(namePrefix string) error {
 // and end with an alphanumeric character.
 var RFC1123NameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
+// SanitizeToRFC1123 converts an arbitrary string into an RFC 1123 compliant name.
+// Lowercases, replaces non-alphanumeric characters with hyphens, collapses
+// consecutive hyphens, and trims leading/trailing hyphens.
+// Returns empty string if the input sanitizes to nothing.
+func SanitizeToRFC1123(name string) string {
+	s := strings.ToLower(name)
+	s = regexp.MustCompile(`[^a-z0-9]+`).ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	return s
+}
+
 // ValidateRFC1123Name validates that a name complies with RFC 1123 subdomain naming.
 // RFC 1123 subdomain names must:
 // - Consist of lowercase alphanumeric characters or '-'


### PR DESCRIPTION
## Summary

Adds automatic user identity detection for resources created by local test runs, enabling cleanup accountability.

JIRA: https://redhat.atlassian.net/browse/ARO-27388

## Problem

The stale resource detection identifies resources from local runs but cannot determine **which developer** created them:
- `DefaultCAPIUser` was hardcoded to `"cate"` — all local runs without explicit `CAPI_USER` looked identical
- Convention-detected (untagged) resources always showed `user="-"` even when partial tags existed on the resource group

## Solution

1. **`getCAPIUser()` fallback chain**: `CAPI_USER` → `SanitizeToRFC1123($USER)` → `"cate"` (last resort). Local runs now automatically carry the developer's identity in tags and resource group naming without requiring any env var to be set. The `$USER` value is sanitized (lowercased, non-alphanumeric replaced with hyphens) to comply with RFC 1123 naming rules.

2. **`SanitizeToRFC1123()` helper**: New utility in `helpers.go` that converts arbitrary strings to RFC 1123 compliant names. Used by `getCAPIUser()` to safely transform OS usernames like `john_doe` → `john-doe` and `Jane` → `jane`.

3. **Partial tag extraction in convention detection**: When scanning untagged resource groups by naming convention, the script now reads `capi-test-user` and `capi-test-env` tags if present (covers partial tagging from crashed runs). The human-readable table also gained a USER column.

## Changes

- `test/config.go` — `getCAPIUser()` now tries `$USER` env var (sanitized for RFC 1123) before falling back to `DefaultCAPIUser`
- `test/helpers.go` — Added `SanitizeToRFC1123()` helper function
- `scripts/check-stale-resources.sh` — Convention-detected RGs extract user/env from partial tags; table output includes USER column
- `test/config_test.go` — Added `TestGetCAPIUser_FallbackToOSUser` (6 cases) and `TestSanitizeToRFC1123` (8 cases)

## Testing

- [x] `TestGetCAPIUser_FallbackToOSUser` — 6 cases pass (precedence, $USER fallback, default, underscore sanitization, uppercase sanitization, CAPI_USER passthrough)
- [x] `TestSanitizeToRFC1123` — 8 cases pass (normal, underscores, uppercase, dots, all-caps, mixed, all-hyphens, empty)
- [x] Existing config tests pass
- [x] CI runs unaffected — they set `CAPI_USER` explicitly

Ref: ARO-27388

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stale resource scanning now extracts and displays user information from resource group tags.
  * Enhanced user identifier resolution with improved fallback logic.

* **Tests**
  * Added comprehensive test coverage for user identifier resolution and name sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->