### PR TITLE
feat: add AWS resource tagging, cleanup, and stale detection (ARO-27408, ARO-27386)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ CAPI_USER_DEFAULT := $(shell grep 'DefaultCAPIUser = ' test/config.go | grep -o 
 CAPI_USER ?= $(CAPI_USER_DEFAULT)
 DEPLOYMENT_ENV ?= stage
 REGION ?= uksouth
+AWS_REGION ?= us-east-1
 INFRA_PROVIDER ?= aro
 ifeq ($(INFRA_PROVIDER),rosa)
 MANAGEMENT_CLUSTER_NAME ?= capa-tests-stage
@@ -669,15 +670,15 @@ _clean-azure-conditional:
 
 clean-aws: ## Delete all AWS resources tagged with capi-test-* ownership tags
 	@if [ "$(FORCE)" = "1" ]; then \
-		./scripts/cleanup-aws-resources.sh --region "$(REGION)" --force; \
+		./scripts/cleanup-aws-resources.sh --region "$(AWS_REGION)" --force; \
 	else \
-		./scripts/cleanup-aws-resources.sh --region "$(REGION)"; \
+		./scripts/cleanup-aws-resources.sh --region "$(AWS_REGION)"; \
 	fi
 
 # Internal target: force delete all AWS resources without prompting
 .PHONY: _clean-aws-force
 _clean-aws-force:
-	@./scripts/cleanup-aws-resources.sh --region "$(REGION)" --force 2>/dev/null || true
+	@./scripts/cleanup-aws-resources.sh --region "$(AWS_REGION)" --force 2>/dev/null || true
 
 # Internal target: conditionally clean AWS resources (only for ROSA)
 .PHONY: _clean-aws-conditional

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test _check-dep _setup _management_cluster _generate-yamls _deploy-crs _verify-workload-cluster _delete-workload-cluster _mce-teardown _validate-cleanup test-all _test-all-impl clean clean-all clean-azure clean-my-resources check-stale help summary scheduled-review fuzz
+.PHONY: test _check-dep _setup _management_cluster _generate-yamls _deploy-crs _verify-workload-cluster _delete-workload-cluster _mce-teardown _validate-cleanup test-all _test-all-impl clean clean-all clean-azure clean-aws clean-my-resources check-stale help summary scheduled-review fuzz
 
 # Use bash for shell commands (required for PIPESTATUS in test-all target)
 SHELL := /bin/bash
@@ -583,8 +583,9 @@ clean-all: ## Clean up ALL test resources without prompting (local + Azure)
 	fi
 	@echo "Deleting all test resources without prompts..."
 	@echo ""
-	@# Delete all Azure resources (resource group + orphaned resources + AD apps + SPs) - only for ARO
+	@# Delete cloud resources (Azure for ARO, AWS for ROSA)
 	@$(MAKE) --no-print-directory _clean-azure-conditional
+	@$(MAKE) --no-print-directory _clean-aws-conditional
 	@echo ""
 	@# Delete management cluster
 	@if kind get clusters 2>/dev/null | grep -q "^$(CLEANUP_MANAGEMENT_CLUSTER)$$"; then \
@@ -631,8 +632,12 @@ clean-all: ## Clean up ALL test resources without prompting (local + Azure)
 	@echo "=== All Resources Cleaned ==="
 	@echo "======================================="
 
-clean-my-resources: ## List all Azure resources tagged as mine (capi-test-user=$CAPI_USER)
-	@./scripts/cleanup-azure-resources.sh --my-resources
+clean-my-resources: ## List all cloud resources tagged as mine (capi-test-user=$CAPI_USER)
+	@echo "=== Azure Resources ==="
+	@./scripts/cleanup-azure-resources.sh --my-resources 2>/dev/null || echo "Azure check skipped (az CLI not available or not authenticated)"
+	@echo ""
+	@echo "=== AWS Resources ==="
+	@./scripts/cleanup-aws-resources.sh --my-resources 2>/dev/null || echo "AWS check skipped (aws CLI not available or not authenticated)"
 
 check-stale: ## Check for stale cloud resources left by tests (default: older than 24h)
 	@./scripts/check-stale-resources.sh --max-age 24
@@ -660,6 +665,27 @@ _clean-azure-conditional:
 		$(MAKE) --no-print-directory _clean-azure-force; \
 	else \
 		echo "Skipping Azure cleanup (INFRA_PROVIDER=$(INFRA_PROVIDER), not aro)"; \
+	fi
+
+clean-aws: ## Delete all AWS resources tagged with capi-test-* ownership tags
+	@if [ "$(FORCE)" = "1" ]; then \
+		./scripts/cleanup-aws-resources.sh --region "$(REGION)" --force; \
+	else \
+		./scripts/cleanup-aws-resources.sh --region "$(REGION)"; \
+	fi
+
+# Internal target: force delete all AWS resources without prompting
+.PHONY: _clean-aws-force
+_clean-aws-force:
+	@./scripts/cleanup-aws-resources.sh --region "$(REGION)" --force 2>/dev/null || true
+
+# Internal target: conditionally clean AWS resources (only for ROSA)
+.PHONY: _clean-aws-conditional
+_clean-aws-conditional:
+	@if [ "$(INFRA_PROVIDER)" = "rosa" ]; then \
+		$(MAKE) --no-print-directory _clean-aws-force; \
+	else \
+		echo "Skipping AWS cleanup (INFRA_PROVIDER=$(INFRA_PROVIDER), not rosa)"; \
 	fi
 
 setup-submodule: ## Add cluster-api-installer as a git submodule

--- a/openshift-ci/step-registry/capz-test-management-cluster-commands.sh
+++ b/openshift-ci/step-registry/capz-test-management-cluster-commands.sh
@@ -7,8 +7,8 @@ set -o xtrace
 source openshift-ci/capz-test-env.sh
 
 # Phase 03: Management Cluster
-# With USE_KUBECONFIG set, skips Kind creation and validates the external cluster
-# with CAPI/CAPZ/ASO controllers (deployed via DEPLOY_CHARTS=true).
+# With USE_KUBECONFIG set, skips Kind creation and validates the external cluster.
+# If DEPLOY_CHARTS=true, also deploys CAPI/CAPZ/ASO controllers via deploy-charts.sh.
 export TEST_RESULTS_DIR="${ARTIFACT_DIR}"
 script -e -q -c "make _management_cluster RESULTS_DIR=\"${ARTIFACT_DIR}\"" /dev/null
 

--- a/openshift-ci/step-registry/capz-test-management-cluster-commands.sh
+++ b/openshift-ci/step-registry/capz-test-management-cluster-commands.sh
@@ -7,7 +7,7 @@ set -o xtrace
 source openshift-ci/capz-test-env.sh
 
 # Phase 03: Management Cluster
-# With USE_KUBECONFIG set, skips Kind creation and validates the external cluster.
+# With USE_KUBECONFIG set, skips Kind creation and validates pre-installed CAPI/CAPZ/ASO controllers.
 # If DEPLOY_CHARTS=true, also deploys CAPI/CAPZ/ASO controllers via deploy-charts.sh.
 export TEST_RESULTS_DIR="${ARTIFACT_DIR}"
 script -e -q -c "make _management_cluster RESULTS_DIR=\"${ARTIFACT_DIR}\"" /dev/null

--- a/scripts/check-stale-resources.sh
+++ b/scripts/check-stale-resources.sh
@@ -476,12 +476,13 @@ check_aws_vpcs() {
     local region="$1"
     print_info "Scanning AWS VPCs for stale CAPI test resources..."
 
-    # Look for VPCs tagged with sigs.k8s.io/cluster-api-provider-aws/cluster/* keys
-    # which are created by CAPA during ROSA cluster provisioning
+    # Look for VPCs tagged with capi-test-created-at (our ownership tag).
+    # This replaces the previous approach of matching CAPA's sigs.k8s.io tags,
+    # which couldn't distinguish our resources from other teams' resources.
     local vpcs_json
     vpcs_json=$(aws ec2 describe-vpcs \
         --region "$region" \
-        --filters "Name=tag-key,Values=sigs.k8s.io/cluster-api-provider-aws/cluster/*" \
+        --filters "Name=tag-key,Values=capi-test-created-at" \
         --query "Vpcs[].{VpcId: VpcId, Tags: Tags, State: State}" \
         --output json 2>/dev/null) || {
         print_warning "Failed to query AWS VPCs"
@@ -492,7 +493,7 @@ check_aws_vpcs() {
     total=$(echo "$vpcs_json" | jq 'length')
 
     if [[ "$total" -eq 0 ]]; then
-        print_success "No CAPA-tagged VPCs found"
+        print_success "No capi-test-tagged VPCs found"
         return 0
     fi
 
@@ -502,30 +503,28 @@ check_aws_vpcs() {
         local vpc_id
         vpc_id=$(echo "$vpc" | jq -r '.VpcId')
 
-        # Get VPC creation time from its flow logs or use the Name tag timestamp
-        # VPCs don't have a native creation timestamp, so we check the creation time
-        # of the associated CAPA cluster tag
         local name_tag
         name_tag=$(echo "$vpc" | jq -r '[.Tags[] | select(.Key == "Name")] | .[0].Value // "unknown"')
 
-        # Use the VPC's earliest network interface creation as a proxy for VPC age
-        local earliest_eni
-        earliest_eni=$(aws ec2 describe-network-interfaces \
-            --region "$region" \
-            --filters "Name=vpc-id,Values=${vpc_id}" \
-            --query "sort_by(NetworkInterfaces, &Attachment.AttachTime)[0].Attachment.AttachTime" \
-            --output text 2>/dev/null) || earliest_eni=""
+        # Use capi-test-created-at tag as authoritative age source
+        local created_at
+        created_at=$(echo "$vpc" | jq -r '[.Tags[] | select(.Key == "capi-test-created-at")] | .[0].Value // empty')
+        [[ -z "$created_at" ]] && continue
 
-        if [[ -n "$earliest_eni" && "$earliest_eni" != "None" && "$earliest_eni" != "null" ]]; then
-            local created_epoch
-            created_epoch=$(date -d "$earliest_eni" +%s 2>/dev/null) || continue
+        local created_epoch
+        created_epoch=$(date -d "$created_at" +%s 2>/dev/null) || continue
 
-            if [[ "$created_epoch" -lt "$THRESHOLD_EPOCH" ]]; then
-                local enriched
-                enriched=$(jq -n --arg id "$vpc_id" --arg name "$name_tag" --arg created "$earliest_eni" \
-                    '{vpcId: $id, name: $name, createdAt: $created}')
-                stale_vpcs=$(echo "$stale_vpcs" | jq --argjson vpc "$enriched" '. + [$vpc]')
-            fi
+        if [[ "$created_epoch" -lt "$THRESHOLD_EPOCH" ]]; then
+            local user env run_id
+            user=$(echo "$vpc" | jq -r '[.Tags[] | select(.Key == "capi-test-user")] | .[0].Value // "-"')
+            env=$(echo "$vpc" | jq -r '[.Tags[] | select(.Key == "capi-test-env")] | .[0].Value // "-"')
+            run_id=$(echo "$vpc" | jq -r '[.Tags[] | select(.Key == "capi-test-run-id")] | .[0].Value // "-"')
+
+            local enriched
+            enriched=$(jq -n --arg id "$vpc_id" --arg name "$name_tag" --arg created "$created_at" \
+                --arg user "$user" --arg env "$env" --arg runId "$run_id" \
+                '{vpcId: $id, name: $name, createdAt: $created, user: $user, env: $env, runId: $runId}')
+            stale_vpcs=$(echo "$stale_vpcs" | jq --argjson vpc "$enriched" '. + [$vpc]')
         fi
     done < <(echo "$vpcs_json" | jq -c '.[]')
 
@@ -540,15 +539,15 @@ check_aws_vpcs() {
             echo ""
             print_warning "Found ${stale_count} stale AWS VPC(s):"
             echo ""
-            printf "%-25s | %-40s | %-25s\n" "VPC ID" "NAME" "CREATED AT"
-            printf "%s\n" "$(printf '%.0s-' {1..95})"
-            echo "$stale_vpcs" | jq -r '.[] | "\(.vpcId)|\(.name)|\(.createdAt)"' | while IFS='|' read -r id name created; do
-                printf "%-25s | %-40s | %-25s\n" "$id" "${name:0:40}" "${created:0:25}"
+            printf "%-25s | %-30s | %-25s | %-10s | %-8s\n" "VPC ID" "NAME" "CREATED AT" "USER" "ENV"
+            printf "%s\n" "$(printf '%.0s-' {1..105})"
+            echo "$stale_vpcs" | jq -r '.[] | "\(.vpcId)|\(.name)|\(.createdAt)|\(.user // "-")|\(.env // "-")"' | while IFS='|' read -r id name created user env; do
+                printf "%-25s | %-30s | %-25s | %-10s | %-8s\n" "$id" "${name:0:30}" "${created:0:25}" "${user:0:10}" "${env:0:8}"
             done
             echo ""
         fi
     else
-        print_success "No stale VPCs (checked ${total} CAPA-tagged VPCs)"
+        print_success "No stale VPCs (checked ${total} tagged VPCs)"
     fi
 }
 
@@ -556,36 +555,53 @@ check_aws_cloudformation() {
     local region="$1"
     print_info "Scanning AWS CloudFormation stacks for stale CAPI resources..."
 
+    # Use describe-stacks to get full tag information (list-stacks doesn't include tags)
     local stacks_json
-    stacks_json=$(aws cloudformation list-stacks \
+    stacks_json=$(aws cloudformation describe-stacks \
         --region "$region" \
-        --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE ROLLBACK_COMPLETE \
-        --query "StackSummaries[?contains(StackName, 'capa-') || contains(StackName, 'rosa-')].{StackName: StackName, CreationTime: CreationTime, StackStatus: StackStatus}" \
+        --query "Stacks[?StackStatus=='CREATE_COMPLETE' || StackStatus=='UPDATE_COMPLETE' || StackStatus=='ROLLBACK_COMPLETE'].{StackName: StackName, CreationTime: CreationTime, StackStatus: StackStatus, Tags: Tags}" \
         --output json 2>/dev/null) || {
         print_warning "Failed to query AWS CloudFormation stacks"
         return 0
     }
 
+    # Filter to stacks tagged with capi-test-created-at (our ownership tag)
+    local tagged_stacks
+    tagged_stacks=$(echo "$stacks_json" | jq '[.[] | select(.Tags != null) | select([.Tags[] | select(.Key == "capi-test-created-at")] | length > 0)]')
+
     local total
-    total=$(echo "$stacks_json" | jq 'length')
+    total=$(echo "$tagged_stacks" | jq 'length')
 
     if [[ "$total" -eq 0 ]]; then
-        print_success "No CAPI-related CloudFormation stacks found"
+        print_success "No capi-test-tagged CloudFormation stacks found"
         return 0
     fi
 
     local stale_stacks="[]"
 
     while IFS= read -r stack; do
+        # Use capi-test-created-at tag as authoritative age source
         local created_at
-        created_at=$(echo "$stack" | jq -r '.CreationTime')
+        created_at=$(echo "$stack" | jq -r '[.Tags[] | select(.Key == "capi-test-created-at")] | .[0].Value // empty')
+        if [[ -z "$created_at" ]]; then
+            created_at=$(echo "$stack" | jq -r '.CreationTime')
+        fi
         local created_epoch
         created_epoch=$(date -d "$created_at" +%s 2>/dev/null) || continue
 
         if [[ "$created_epoch" -lt "$THRESHOLD_EPOCH" ]]; then
-            stale_stacks=$(echo "$stale_stacks" | jq --argjson stack "$stack" '. + [$stack]')
+            # Extract ownership tags
+            local user env run_id
+            user=$(echo "$stack" | jq -r '[.Tags[] | select(.Key == "capi-test-user")] | .[0].Value // "-"')
+            env=$(echo "$stack" | jq -r '[.Tags[] | select(.Key == "capi-test-env")] | .[0].Value // "-"')
+            run_id=$(echo "$stack" | jq -r '[.Tags[] | select(.Key == "capi-test-run-id")] | .[0].Value // "-"')
+
+            local enriched
+            enriched=$(echo "$stack" | jq --arg user "$user" --arg env "$env" --arg runId "$run_id" --arg created "$created_at" \
+                '{StackName: .StackName, CreationTime: $created, StackStatus: .StackStatus, user: $user, env: $env, runId: $runId}')
+            stale_stacks=$(echo "$stale_stacks" | jq --argjson stack "$enriched" '. + [$stack]')
         fi
-    done < <(echo "$stacks_json" | jq -c '.[]')
+    done < <(echo "$tagged_stacks" | jq -c '.[]')
 
     local stale_count
     stale_count=$(echo "$stale_stacks" | jq 'length')
@@ -598,15 +614,15 @@ check_aws_cloudformation() {
             echo ""
             print_warning "Found ${stale_count} stale CloudFormation stack(s):"
             echo ""
-            printf "%-50s | %-25s | %-20s\n" "STACK NAME" "CREATED AT" "STATUS"
-            printf "%s\n" "$(printf '%.0s-' {1..100})"
-            echo "$stale_stacks" | jq -r '.[] | "\(.StackName)|\(.CreationTime)|\(.StackStatus)"' | while IFS='|' read -r name created status; do
-                printf "%-50s | %-25s | %-20s\n" "${name:0:50}" "${created:0:25}" "$status"
+            printf "%-40s | %-25s | %-15s | %-10s | %-8s\n" "STACK NAME" "CREATED AT" "STATUS" "USER" "ENV"
+            printf "%s\n" "$(printf '%.0s-' {1..105})"
+            echo "$stale_stacks" | jq -r '.[] | "\(.StackName)|\(.CreationTime)|\(.StackStatus)|\(.user // "-")|\(.env // "-")"' | while IFS='|' read -r name created status user env; do
+                printf "%-40s | %-25s | %-15s | %-10s | %-8s\n" "${name:0:40}" "${created:0:25}" "$status" "${user:0:10}" "${env:0:8}"
             done
             echo ""
         fi
     else
-        print_success "No stale CloudFormation stacks (checked ${total} stacks)"
+        print_success "No stale CloudFormation stacks (checked ${total} tagged stacks)"
     fi
 }
 

--- a/scripts/cleanup-aws-resources.sh
+++ b/scripts/cleanup-aws-resources.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# cleanup-aws-resources.sh - Clean up AWS resources created during CAPI testing
+#
+# This script finds and deletes AWS resources tagged with capi-test-* ownership
+# metadata. It cleans up:
+#   - CloudFormation stacks (tagged with capi-test-created-at)
+#   - VPCs and their dependencies (tagged with capi-test-created-at)
+#
+# Usage:
+#   ./scripts/cleanup-aws-resources.sh [OPTIONS]
+#
+# Options:
+#   --region REGION     AWS region to scan (default: AWS_REGION env var, else us-east-1)
+#   --tag KEY=VALUE     Find resources by tag (e.g., 'capi-test-user=alice')
+#   --my-resources      Find all resources tagged with capi-test-user=$CAPI_USER (or $USER fallback)
+#   --dry-run           Show what would be deleted without actually deleting
+#   --force             Skip confirmation prompts
+#   --help              Show this help message
+#
+# Environment variables:
+#   AWS_REGION             AWS region to scan (default: us-east-1)
+#   AWS_ACCESS_KEY_ID      AWS credentials
+#   AWS_SECRET_ACCESS_KEY  AWS credentials
+#   CAPI_USER              User prefix for --my-resources (default: $USER)
+#
+# Examples:
+#   ./scripts/cleanup-aws-resources.sh --dry-run
+#   ./scripts/cleanup-aws-resources.sh --force
+#   ./scripts/cleanup-aws-resources.sh --my-resources
+#   ./scripts/cleanup-aws-resources.sh --tag capi-test-user=alice --force
+#   ./scripts/cleanup-aws-resources.sh --region us-west-2 --force
+
+set -euo pipefail
+
+# Defaults
+REGION="${AWS_REGION:-us-east-1}"
+DRY_RUN=false
+FORCE=false
+TAG_FILTER=""
+MY_RESOURCES=false
+
+# ANSI colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+print_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+print_warning() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+usage() {
+    local exit_code="${1:-0}"
+    sed -n '2,/^$/p' "$0" | grep '^#' | sed 's/^# \?//'
+    exit "$exit_code"
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --region)
+            [[ $# -lt 2 ]] && { print_error "Missing value for --region"; exit 2; }
+            REGION="$2"
+            shift 2
+            ;;
+        --tag)
+            [[ $# -lt 2 ]] && { print_error "Missing value for --tag"; exit 2; }
+            TAG_FILTER="$2"
+            shift 2
+            ;;
+        --my-resources)
+            MY_RESOURCES=true
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            usage 2
+            ;;
+    esac
+done
+
+# Handle --my-resources
+if [[ "$MY_RESOURCES" == "true" ]]; then
+    CAPI_USER="${CAPI_USER:-${USER:-cate}}"
+    TAG_FILTER="capi-test-user=${CAPI_USER}"
+    DRY_RUN=true
+    print_info "Listing resources tagged with capi-test-user=${CAPI_USER} (dry-run)"
+fi
+
+# Validate prerequisites
+if ! command -v aws >/dev/null 2>&1; then
+    print_error "AWS CLI (aws) not installed"
+    exit 2
+fi
+
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+    print_error "Not authenticated to AWS. Run: aws configure"
+    exit 2
+fi
+
+echo "========================================"
+echo "=== AWS Resource Cleanup ==="
+echo "========================================"
+echo ""
+print_info "Region: ${REGION}"
+[[ -n "$TAG_FILTER" ]] && print_info "Tag filter: ${TAG_FILTER}"
+[[ "$DRY_RUN" == "true" ]] && print_info "Mode: DRY RUN (no deletions)"
+echo ""
+
+# ─── CloudFormation Stacks ──────────────────────────────────────────────────────
+
+cleanup_cloudformation_stacks() {
+    print_info "Scanning CloudFormation stacks..."
+
+    local stacks_json
+    stacks_json=$(aws cloudformation describe-stacks \
+        --region "$REGION" \
+        --query "Stacks[?StackStatus=='CREATE_COMPLETE' || StackStatus=='UPDATE_COMPLETE'].{StackName: StackName, Tags: Tags, CreationTime: CreationTime}" \
+        --output json 2>/dev/null) || {
+        print_warning "Failed to query CloudFormation stacks"
+        return 0
+    }
+
+    # Filter to stacks with capi-test-created-at tag
+    local tagged_stacks
+    tagged_stacks=$(echo "$stacks_json" | jq '[.[] | select(.Tags != null) | select([.Tags[] | select(.Key == "capi-test-created-at")] | length > 0)]')
+
+    # Apply tag filter if specified
+    if [[ -n "$TAG_FILTER" ]]; then
+        local filter_key filter_value
+        filter_key="${TAG_FILTER%%=*}"
+        filter_value="${TAG_FILTER#*=}"
+        tagged_stacks=$(echo "$tagged_stacks" | jq --arg key "$filter_key" --arg val "$filter_value" \
+            '[.[] | select([.Tags[] | select(.Key == $key and .Value == $val)] | length > 0)]')
+    fi
+
+    local count
+    count=$(echo "$tagged_stacks" | jq 'length')
+
+    if [[ "$count" -eq 0 ]]; then
+        print_success "No matching CloudFormation stacks found"
+        return 0
+    fi
+
+    echo ""
+    print_warning "Found ${count} CloudFormation stack(s) to delete:"
+    echo ""
+    echo "$tagged_stacks" | jq -r '.[] | "  \(.StackName) (created: \(.CreationTime))"'
+    echo ""
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        print_info "Dry run — skipping deletion"
+        return 0
+    fi
+
+    if [[ "$FORCE" != "true" ]]; then
+        read -r -p "Delete these CloudFormation stacks? [y/N] " confirm
+        if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+            print_info "Skipped CloudFormation stack deletion"
+            return 0
+        fi
+    fi
+
+    while IFS= read -r stack_name; do
+        print_info "Deleting stack: ${stack_name}..."
+        if aws cloudformation delete-stack --stack-name "$stack_name" --region "$REGION" 2>/dev/null; then
+            print_success "Initiated deletion of ${stack_name}"
+        else
+            print_warning "Failed to delete ${stack_name}"
+        fi
+    done < <(echo "$tagged_stacks" | jq -r '.[].StackName')
+}
+
+# ─── VPCs ───────────────────────────────────────────────────────────────────────
+
+cleanup_vpcs() {
+    print_info "Scanning VPCs..."
+
+    local vpcs_json
+    vpcs_json=$(aws ec2 describe-vpcs \
+        --region "$REGION" \
+        --filters "Name=tag-key,Values=capi-test-created-at" \
+        --query "Vpcs[].{VpcId: VpcId, Tags: Tags}" \
+        --output json 2>/dev/null) || {
+        print_warning "Failed to query VPCs"
+        return 0
+    }
+
+    # Apply tag filter if specified
+    if [[ -n "$TAG_FILTER" ]]; then
+        local filter_key filter_value
+        filter_key="${TAG_FILTER%%=*}"
+        filter_value="${TAG_FILTER#*=}"
+        vpcs_json=$(echo "$vpcs_json" | jq --arg key "$filter_key" --arg val "$filter_value" \
+            '[.[] | select([.Tags[] | select(.Key == $key and .Value == $val)] | length > 0)]')
+    fi
+
+    local count
+    count=$(echo "$vpcs_json" | jq 'length')
+
+    if [[ "$count" -eq 0 ]]; then
+        print_success "No matching VPCs found"
+        return 0
+    fi
+
+    echo ""
+    print_warning "Found ${count} VPC(s) to delete:"
+    echo ""
+    echo "$vpcs_json" | jq -r '.[] | "  \(.VpcId) (\([.Tags[] | select(.Key == "Name")] | .[0].Value // "unnamed"))"'
+    echo ""
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        print_info "Dry run — skipping deletion"
+        return 0
+    fi
+
+    if [[ "$FORCE" != "true" ]]; then
+        read -r -p "Delete these VPCs and their dependencies? [y/N] " confirm
+        if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+            print_info "Skipped VPC deletion"
+            return 0
+        fi
+    fi
+
+    while IFS= read -r vpc_id; do
+        delete_vpc "$vpc_id"
+    done < <(echo "$vpcs_json" | jq -r '.[].VpcId')
+}
+
+delete_vpc() {
+    local vpc_id="$1"
+    print_info "Deleting VPC ${vpc_id} and dependencies..."
+
+    # Delete internet gateways
+    local igws
+    igws=$(aws ec2 describe-internet-gateways \
+        --region "$REGION" \
+        --filters "Name=attachment.vpc-id,Values=${vpc_id}" \
+        --query "InternetGateways[].InternetGatewayId" \
+        --output text 2>/dev/null) || igws=""
+    for igw in $igws; do
+        aws ec2 detach-internet-gateway --internet-gateway-id "$igw" --vpc-id "$vpc_id" --region "$REGION" 2>/dev/null || true
+        aws ec2 delete-internet-gateway --internet-gateway-id "$igw" --region "$REGION" 2>/dev/null || true
+    done
+
+    # Delete subnets
+    local subnets
+    subnets=$(aws ec2 describe-subnets \
+        --region "$REGION" \
+        --filters "Name=vpc-id,Values=${vpc_id}" \
+        --query "Subnets[].SubnetId" \
+        --output text 2>/dev/null) || subnets=""
+    for subnet in $subnets; do
+        aws ec2 delete-subnet --subnet-id "$subnet" --region "$REGION" 2>/dev/null || true
+    done
+
+    # Delete route tables (skip main)
+    local route_tables
+    route_tables=$(aws ec2 describe-route-tables \
+        --region "$REGION" \
+        --filters "Name=vpc-id,Values=${vpc_id}" \
+        --query "RouteTables[?Associations[0].Main != \`true\`].RouteTableId" \
+        --output text 2>/dev/null) || route_tables=""
+    for rt in $route_tables; do
+        aws ec2 delete-route-table --route-table-id "$rt" --region "$REGION" 2>/dev/null || true
+    done
+
+    # Delete security groups (skip default)
+    local sgs
+    sgs=$(aws ec2 describe-security-groups \
+        --region "$REGION" \
+        --filters "Name=vpc-id,Values=${vpc_id}" \
+        --query "SecurityGroups[?GroupName != 'default'].GroupId" \
+        --output text 2>/dev/null) || sgs=""
+    for sg in $sgs; do
+        aws ec2 delete-security-group --group-id "$sg" --region "$REGION" 2>/dev/null || true
+    done
+
+    # Delete NAT gateways
+    local nat_gws
+    nat_gws=$(aws ec2 describe-nat-gateways \
+        --region "$REGION" \
+        --filter "Name=vpc-id,Values=${vpc_id}" "Name=state,Values=available" \
+        --query "NatGateways[].NatGatewayId" \
+        --output text 2>/dev/null) || nat_gws=""
+    for nat in $nat_gws; do
+        aws ec2 delete-nat-gateway --nat-gateway-id "$nat" --region "$REGION" 2>/dev/null || true
+    done
+
+    # Delete the VPC
+    if aws ec2 delete-vpc --vpc-id "$vpc_id" --region "$REGION" 2>/dev/null; then
+        print_success "Deleted VPC ${vpc_id}"
+    else
+        print_warning "Failed to delete VPC ${vpc_id} (may have remaining dependencies)"
+    fi
+}
+
+# ─── Main ───────────────────────────────────────────────────────────────────────
+
+cleanup_cloudformation_stacks
+echo ""
+cleanup_vpcs
+echo ""
+
+echo "========================================"
+if [[ "$DRY_RUN" == "true" ]]; then
+    print_info "Dry run complete — no resources were deleted"
+else
+    print_success "AWS cleanup complete"
+fi
+echo "========================================"

--- a/scripts/cleanup-aws-resources.sh
+++ b/scripts/cleanup-aws-resources.sh
@@ -289,16 +289,35 @@ delete_vpc() {
         aws ec2 delete-security-group --group-id "$sg" --region "$REGION" 2>/dev/null || true
     done
 
-    # Delete NAT gateways
+    # Delete NAT gateways (async — must wait before VPC deletion)
     local nat_gws
     nat_gws=$(aws ec2 describe-nat-gateways \
         --region "$REGION" \
         --filter "Name=vpc-id,Values=${vpc_id}" "Name=state,Values=available" \
         --query "NatGateways[].NatGatewayId" \
         --output text 2>/dev/null) || nat_gws=""
+    local has_nat_gws=false
     for nat in $nat_gws; do
         aws ec2 delete-nat-gateway --nat-gateway-id "$nat" --region "$REGION" 2>/dev/null || true
+        has_nat_gws=true
     done
+
+    # Wait for NAT gateways to finish deleting before removing the VPC
+    if [[ "$has_nat_gws" == "true" ]]; then
+        print_info "Waiting for NAT gateways to delete (up to 2 minutes)..."
+        local wait_attempts=0
+        while [[ $wait_attempts -lt 12 ]]; do
+            local active_nats
+            active_nats=$(aws ec2 describe-nat-gateways \
+                --region "$REGION" \
+                --filter "Name=vpc-id,Values=${vpc_id}" "Name=state,Values=deleting,available" \
+                --query "NatGateways[].NatGatewayId" \
+                --output text 2>/dev/null) || break
+            [[ -z "$active_nats" || "$active_nats" == "None" ]] && break
+            sleep 10
+            wait_attempts=$((wait_attempts + 1))
+        done
+    fi
 
     # Delete the VPC
     if aws ec2 delete-vpc --vpc-id "$vpc_id" --region "$REGION" 2>/dev/null; then

--- a/scripts/cleanup-aws-resources.sh
+++ b/scripts/cleanup-aws-resources.sh
@@ -128,7 +128,7 @@ cleanup_cloudformation_stacks() {
     local stacks_json
     stacks_json=$(aws cloudformation describe-stacks \
         --region "$REGION" \
-        --query "Stacks[?StackStatus=='CREATE_COMPLETE' || StackStatus=='UPDATE_COMPLETE'].{StackName: StackName, Tags: Tags, CreationTime: CreationTime}" \
+        --query "Stacks[?StackStatus=='CREATE_COMPLETE' || StackStatus=='UPDATE_COMPLETE' || StackStatus=='ROLLBACK_COMPLETE'].{StackName: StackName, Tags: Tags, CreationTime: CreationTime}" \
         --output json 2>/dev/null) || {
         print_warning "Failed to query CloudFormation stacks"
         return 0

--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -310,7 +310,7 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 		// Tag Azure resource group for parallel run cleanup queries.
 		// Resource group may not exist yet (created by CAPI during deployment),
 		// so failure here is expected — Phase 05 will retry after deployment.
-		if len(config.AzureResourceTags) > 0 && CommandExists("az") {
+		if len(config.ResourceTags) > 0 && CommandExists("az") {
 			if err := EnsureAzureCliLogin(t); err != nil {
 				t.Logf("Resource group tagging deferred (Azure CLI auth unavailable, Phase 05 will retry): %v", err)
 			} else {

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -1224,7 +1224,7 @@ func TestDeployment_VerifyClusterInfrastructureReady(t *testing.T) {
 func TestDeployment_TagAzureResources(t *testing.T) {
 	config := NewTestConfig()
 
-	if len(config.AzureResourceTags) == 0 {
+	if len(config.ResourceTags) == 0 {
 		t.Skipf("No Azure resource tags configured")
 		return
 	}
@@ -1253,6 +1253,44 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 	tagAzureServicePrincipals(t, config)
 
 	PrintToTTY("✅ Azure resource tagging completed\n\n")
+}
+
+// TestDeployment_TagAWSResources tags AWS resources (CloudFormation stacks and VPCs) created
+// by the CAPA controller with ownership metadata for stale resource detection and cleanup.
+// Non-fatal: failures are logged as warnings since tagging is for cleanup convenience only.
+func TestDeployment_TagAWSResources(t *testing.T) {
+	config := NewTestConfig()
+
+	if len(config.ResourceTags) == 0 {
+		t.Skipf("No resource tags configured")
+		return
+	}
+
+	if !CommandExists("aws") {
+		t.Skipf("AWS CLI not available, skipping AWS resource tagging")
+		return
+	}
+
+	if config.InfraProviderName != "rosa" {
+		t.Skipf("AWS resource tagging only applies to ROSA provider")
+		return
+	}
+
+	PrintToTTY("\n=== Tagging AWS Resources ===\n")
+
+	region := config.Region
+
+	PrintToTTY("Tagging CloudFormation stacks in %s...\n", region)
+	if err := TagAWSCloudFormationStacks(t, config, region); err != nil {
+		t.Logf("Warning: failed to tag CloudFormation stacks: %v", err)
+	}
+
+	PrintToTTY("Tagging CAPA VPCs in %s...\n", region)
+	if err := TagAWSVPCs(t, config, region); err != nil {
+		t.Logf("Warning: failed to tag VPCs: %v", err)
+	}
+
+	PrintToTTY("✅ AWS resource tagging completed\n\n")
 }
 
 // tagAzureADApplications finds and tags Azure AD Applications matching our prefix.
@@ -1288,7 +1326,7 @@ func tagAzureADApplications(t *testing.T, config *TestConfig) {
 	}
 
 	// Build tag strings for AD apps (string array format: "key:value")
-	tagStrings := sortedTagPairs(config.AzureResourceTags, ":")
+	tagStrings := sortedTagPairs(config.ResourceTags, ":")
 	tagsJSON, err := toJSONArray(tagStrings)
 	if err != nil {
 		t.Logf("Warning: %v — skipping AD Application tagging", err)
@@ -1338,7 +1376,7 @@ func tagAzureServicePrincipals(t *testing.T, config *TestConfig) {
 	}
 
 	// Build tag strings for SPs (string array format: "key:value")
-	tagStrings := sortedTagPairs(config.AzureResourceTags, ":")
+	tagStrings := sortedTagPairs(config.ResourceTags, ":")
 	tagsJSON, err := toJSONArray(tagStrings)
 	if err != nil {
 		t.Logf("Warning: %v — skipping Service Principal tagging", err)

--- a/test/config.go
+++ b/test/config.go
@@ -251,10 +251,10 @@ var (
 	resourceGroupName     string
 	resourceGroupNameOnce sync.Once
 
-	// cachedAzureResourceTags holds tags loaded from the deployment state file on resume.
+	// cachedResourceTags holds tags loaded from the deployment state file on resume.
 	// nil means tags were not loaded from state (fresh run or explicit CS_CLUSTER_NAME),
 	// so fresh tags will be generated.
-	cachedAzureResourceTags map[string]string
+	cachedResourceTags map[string]string
 )
 
 // getDefaultRepoDir returns the default repository directory path.
@@ -358,17 +358,21 @@ func getClusterNamePrefix(capiUser string) string {
 		if data, err := os.ReadFile(stateFilePath); err == nil {
 			var state struct {
 				ClusterNamePrefix string            `json:"cluster_name_prefix"`
+				ResourceTags      map[string]string `json:"resource_tags,omitempty"`
 				AzureResourceTags map[string]string `json:"azure_resource_tags,omitempty"`
 			}
 			if unmarshalErr := json.Unmarshal(data, &state); unmarshalErr != nil {
 				errMsg := fmt.Sprintf("deployment state file %s exists but cannot be parsed: %v\n"+
-					"Generating a new prefix would orphan Azure resources from the previous run.\n"+
+					"Generating a new prefix would orphan cloud resources from the previous run.\n"+
 					"Delete the file to start fresh, or fix the JSON to resume.", stateFilePath, unmarshalErr)
 				configError = &errMsg
 				return
 			} else if state.ClusterNamePrefix != "" {
 				clusterNamePrefix = state.ClusterNamePrefix
-				cachedAzureResourceTags = state.AzureResourceTags
+				cachedResourceTags = state.ResourceTags
+				if cachedResourceTags == nil {
+					cachedResourceTags = state.AzureResourceTags
+				}
 				return
 			}
 		} else if !os.IsNotExist(err) {
@@ -462,7 +466,7 @@ type TestConfig struct {
 	WorkloadClusterNamespace string            // Namespace for workload cluster resources on management cluster (unique per test run)
 	TestLabelPrefix          string            // Provider-specific label prefix for test namespaces (e.g., "capz-test" for ARO, "capa-test" for ROSA)
 	TestRunID                string            // Unique run identifier extracted from ClusterNamePrefix (the part after CAPI_USER-). Empty when prefix does not start with CAPI_USER-.
-	AzureResourceTags        map[string]string // Azure tags applied to all created resources for cleanup queries
+	ResourceTags             map[string]string // Tags applied to all created cloud resources (Azure RGs, AWS stacks/VPCs) for ownership tracking and cleanup
 	ResourceGroupName        string            // Azure resource group name (env: RESOURCEGROUPNAME, default: ${WorkloadClusterName}-${runID}-resgroup)
 	CAPINamespace            string            // Namespace for CAPI controller (default: "capi-system", or "multicluster-engine" when USE_K8S=true)
 	CAPZNamespace            string            // Namespace for CAPZ/ASO controllers (default: "capz-system", or "multicluster-engine" when USE_K8S=true)
@@ -679,11 +683,11 @@ func NewTestConfig() *TestConfig {
 	workloadClusterName := GetEnvOrDefault("WORKLOAD_CLUSTER_NAME", defaultWorkloadCluster)
 	rgName := getResourceGroupName(workloadClusterName, testRunID)
 
-	// Build Azure resource tags for cleanup and ownership tracking.
+	// Build resource tags for cleanup and ownership tracking (used for both Azure and AWS).
 	// On resume, use cached tags from the deployment state to preserve the original created-at timestamp.
-	azureTags := cachedAzureResourceTags
-	if azureTags == nil {
-		azureTags = map[string]string{
+	resourceTags := cachedResourceTags
+	if resourceTags == nil {
+		resourceTags = map[string]string{
 			"capi-test-user":       capiUser,
 			"capi-test-env":        environment,
 			"capi-test-run-id":     prefix,
@@ -711,7 +715,7 @@ func NewTestConfig() *TestConfig {
 		WorkloadClusterNamespace: getWorkloadClusterNamespace(testLabelPrefix),
 		TestLabelPrefix:          testLabelPrefix,
 		TestRunID:                testRunID,
-		AzureResourceTags:        azureTags,
+		ResourceTags:             resourceTags,
 		ResourceGroupName:        rgName,
 		CAPINamespace:            getControllerNamespace("CAPI_NAMESPACE", "capi-system"),
 		CAPZNamespace:            providerNamespace,

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2666,7 +2666,7 @@ type DeploymentState struct {
 	User                     string            `json:"user"`
 	Environment              string            `json:"environment"`
 	TestRunID                string            `json:"test_run_id,omitempty"`
-	AzureResourceTags        map[string]string `json:"azure_resource_tags,omitempty"`
+	ResourceTags             map[string]string `json:"resource_tags,omitempty"`
 	MCEOriginalStates        map[string]bool   `json:"mce_original_states,omitempty"`
 }
 
@@ -2691,7 +2691,7 @@ func WriteDeploymentState(config *TestConfig) error {
 		User:                     config.CAPIUser,
 		Environment:              config.Environment,
 		TestRunID:                config.TestRunID,
-		AzureResourceTags:        config.AzureResourceTags,
+		ResourceTags:             config.ResourceTags,
 	}
 
 	if existing != nil && len(existing.MCEOriginalStates) > 0 {
@@ -2717,7 +2717,7 @@ func TagAzureResourceGroup(t *testing.T, config *TestConfig) error {
 
 	resourceGroup := config.ResourceGroupName
 
-	tagPairs := sortedTagPairs(config.AzureResourceTags, "=")
+	tagPairs := sortedTagPairs(config.ResourceTags, "=")
 
 	args := []string{"group", "update", "--name", resourceGroup, "--tags"}
 	args = append(args, tagPairs...)
@@ -2726,6 +2726,100 @@ func TagAzureResourceGroup(t *testing.T, config *TestConfig) error {
 		return fmt.Errorf("could not tag resource group %s: %w", resourceGroup, err)
 	}
 	t.Logf("Tagged resource group %s with %d tags", resourceGroup, len(tagPairs))
+	return nil
+}
+
+// TagAWSCloudFormationStacks tags CloudFormation stacks in the given region with ownership metadata.
+// Discovers stacks by name pattern (contains "capa-" or "rosa-") and applies capi-test-* tags.
+func TagAWSCloudFormationStacks(t *testing.T, config *TestConfig, region string) error {
+	t.Helper()
+
+	output, err := RunCommandQuiet(t, "aws", "cloudformation", "describe-stacks",
+		"--region", region,
+		"--query", "Stacks[?StackStatus=='CREATE_COMPLETE' || StackStatus=='UPDATE_COMPLETE'].{StackName: StackName, StackId: StackId}",
+		"--output", "json")
+	if err != nil {
+		return fmt.Errorf("failed to list CloudFormation stacks: %w", err)
+	}
+
+	var stacks []struct {
+		StackName string `json:"StackName"`
+		StackID   string `json:"StackId"`
+	}
+	if err := json.Unmarshal([]byte(output), &stacks); err != nil {
+		return fmt.Errorf("failed to parse CloudFormation stacks: %w", err)
+	}
+
+	tagged := 0
+	for _, stack := range stacks {
+		if !strings.Contains(stack.StackName, "capa-") && !strings.Contains(stack.StackName, "rosa-") {
+			continue
+		}
+
+		args := []string{"cloudformation", "update-stack",
+			"--stack-name", stack.StackName,
+			"--use-previous-template",
+			"--region", region,
+			"--tags"}
+		for _, pair := range sortedTagPairs(config.ResourceTags, "=") {
+			parts := strings.SplitN(pair, "=", 2)
+			args = append(args, fmt.Sprintf("Key=%s,Value=%s", parts[0], parts[1]))
+		}
+
+		if _, err := RunCommandQuiet(t, "aws", args...); err != nil {
+			t.Logf("Warning: could not tag CloudFormation stack %s: %v", stack.StackName, err)
+		} else {
+			tagged++
+			PrintToTTY("  Tagged CloudFormation stack: %s\n", stack.StackName)
+		}
+	}
+	if tagged > 0 {
+		t.Logf("Tagged %d CloudFormation stack(s)", tagged)
+	}
+	return nil
+}
+
+// TagAWSVPCs tags CAPA-created VPCs in the given region with ownership metadata.
+// Discovers VPCs by CAPA tag key pattern and applies capi-test-* tags.
+func TagAWSVPCs(t *testing.T, config *TestConfig, region string) error {
+	t.Helper()
+
+	output, err := RunCommandQuiet(t, "aws", "ec2", "describe-vpcs",
+		"--region", region,
+		"--filters", "Name=tag-key,Values=sigs.k8s.io/cluster-api-provider-aws/cluster/*",
+		"--query", "Vpcs[].VpcId",
+		"--output", "json")
+	if err != nil {
+		return fmt.Errorf("failed to list CAPA VPCs: %w", err)
+	}
+
+	var vpcIDs []string
+	if err := json.Unmarshal([]byte(output), &vpcIDs); err != nil {
+		return fmt.Errorf("failed to parse VPC list: %w", err)
+	}
+
+	if len(vpcIDs) == 0 {
+		t.Log("No CAPA-tagged VPCs found to tag")
+		return nil
+	}
+
+	args := []string{"ec2", "create-tags",
+		"--region", region,
+		"--resources"}
+	args = append(args, vpcIDs...)
+	args = append(args, "--tags")
+	for _, pair := range sortedTagPairs(config.ResourceTags, "=") {
+		parts := strings.SplitN(pair, "=", 2)
+		args = append(args, fmt.Sprintf("Key=%s,Value=%s", parts[0], parts[1]))
+	}
+
+	if _, err := RunCommandQuiet(t, "aws", args...); err != nil {
+		return fmt.Errorf("failed to tag VPCs: %w", err)
+	}
+	t.Logf("Tagged %d VPC(s)", len(vpcIDs))
+	for _, id := range vpcIDs {
+		PrintToTTY("  Tagged VPC: %s\n", id)
+	}
 	return nil
 }
 
@@ -2759,6 +2853,16 @@ func ReadDeploymentState() (*DeploymentState, error) {
 	var state DeploymentState
 	if err := json.Unmarshal(data, &state); err != nil {
 		return nil, fmt.Errorf("failed to parse deployment state file: %w", err)
+	}
+
+	// Backward compatibility: older state files use "azure_resource_tags" instead of "resource_tags".
+	if state.ResourceTags == nil {
+		var legacy struct {
+			AzureResourceTags map[string]string `json:"azure_resource_tags,omitempty"`
+		}
+		if err := json.Unmarshal(data, &legacy); err == nil && legacy.AzureResourceTags != nil {
+			state.ResourceTags = legacy.AzureResourceTags
+		}
 	}
 
 	return &state, nil

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2788,13 +2788,14 @@ func TagAWSCloudFormationStacks(t *testing.T, config *TestConfig, region string)
 }
 
 // TagAWSVPCs tags CAPA-created VPCs in the given region with ownership metadata.
-// Discovers VPCs by CAPA tag key pattern and applies capi-test-* tags.
+// Discovers VPCs by the exact CAPA ownership tag key for our cluster name.
 func TagAWSVPCs(t *testing.T, config *TestConfig, region string) error {
 	t.Helper()
 
+	capaTagKey := fmt.Sprintf("sigs.k8s.io/cluster-api-provider-aws/cluster/%s", config.WorkloadClusterName)
 	output, err := RunCommandQuiet(t, "aws", "ec2", "describe-vpcs",
 		"--region", region,
-		"--filters", "Name=tag-key,Values=sigs.k8s.io/cluster-api-provider-aws/cluster/*",
+		"--filters", fmt.Sprintf("Name=tag-key,Values=%s", capaTagKey),
 		"--query", "Vpcs[].VpcId",
 		"--output", "json")
 	if err != nil {

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2730,7 +2730,8 @@ func TagAzureResourceGroup(t *testing.T, config *TestConfig) error {
 }
 
 // TagAWSCloudFormationStacks tags CloudFormation stacks in the given region with ownership metadata.
-// Discovers stacks by name pattern (contains "capa-" or "rosa-") and applies capi-test-* tags.
+// Discovers stacks by name pattern (contains "capa-" or "rosa-") and applies capi-test-* tags
+// using the Resource Groups Tagging API (additive, does not replace existing stack tags).
 func TagAWSCloudFormationStacks(t *testing.T, config *TestConfig, region string) error {
 	t.Helper()
 
@@ -2750,31 +2751,38 @@ func TagAWSCloudFormationStacks(t *testing.T, config *TestConfig, region string)
 		return fmt.Errorf("failed to parse CloudFormation stacks: %w", err)
 	}
 
-	tagged := 0
+	var stackARNs []string
 	for _, stack := range stacks {
 		if !strings.Contains(stack.StackName, "capa-") && !strings.Contains(stack.StackName, "rosa-") {
 			continue
 		}
+		stackARNs = append(stackARNs, stack.StackID)
+	}
 
-		args := []string{"cloudformation", "update-stack",
-			"--stack-name", stack.StackName,
-			"--use-previous-template",
-			"--region", region,
-			"--tags"}
-		for _, pair := range sortedTagPairs(config.ResourceTags, "=") {
-			parts := strings.SplitN(pair, "=", 2)
-			args = append(args, fmt.Sprintf("Key=%s,Value=%s", parts[0], parts[1]))
-		}
+	if len(stackARNs) == 0 {
+		t.Log("No matching CloudFormation stacks found to tag")
+		return nil
+	}
 
-		if _, err := RunCommandQuiet(t, "aws", args...); err != nil {
-			t.Logf("Warning: could not tag CloudFormation stack %s: %v", stack.StackName, err)
-		} else {
-			tagged++
+	tagJSON, err := json.Marshal(config.ResourceTags)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tags: %w", err)
+	}
+
+	args := []string{"resourcegroupstaggingapi", "tag-resources",
+		"--region", region,
+		"--tags", string(tagJSON),
+		"--resource-arn-list"}
+	args = append(args, stackARNs...)
+
+	if _, err := RunCommandQuiet(t, "aws", args...); err != nil {
+		return fmt.Errorf("failed to tag CloudFormation stacks: %w", err)
+	}
+	t.Logf("Tagged %d CloudFormation stack(s)", len(stackARNs))
+	for _, stack := range stacks {
+		if strings.Contains(stack.StackName, "capa-") || strings.Contains(stack.StackName, "rosa-") {
 			PrintToTTY("  Tagged CloudFormation stack: %s\n", stack.StackName)
 		}
-	}
-	if tagged > 0 {
-		t.Logf("Tagged %d CloudFormation stack(s)", tagged)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Add AWS resource tagging, cleanup, and stale detection alongside existing Azure support. Also fixes a misleading comment in `commands.sh` about the `DEPLOY_CHARTS` default.

Ref: [ARO-27408](https://redhat.atlassian.net/browse/ARO-27408), [ARO-27386](https://redhat.atlassian.net/browse/ARO-27386)

## Changes Made

- Rename `AzureResourceTags` → `ResourceTags` (provider-agnostic) across config, helpers, and test files
- Add `TagAWSCloudFormationStacks()` and `TagAWSVPCs()` helper functions using additive tagging API (`resourcegroupstaggingapi tag-resources`)
- Add `TestDeployment_TagAWSResources` Phase 05 test function for ROSA provider
- Create `scripts/cleanup-aws-resources.sh` for AWS resource cleanup (CloudFormation stacks + VPCs)
- Add `clean-aws`, `_clean-aws-force`, `_clean-aws-conditional` Makefile targets with dedicated `AWS_REGION` variable
- Update `clean-all` and `clean-my-resources` to include AWS resources
- Update `check-stale-resources.sh` to filter AWS VPCs and CloudFormation stacks by `capi-test-created-at` ownership tag
- Add backward compatibility in `ReadDeploymentState` for old `azure_resource_tags` JSON field
- Fix `commands.sh` comment about `DEPLOY_CHARTS` default behavior
- Wait for NAT gateway deletion before VPC cleanup (async deletion handling)

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `AWS_REGION` | AWS region for cleanup targets (Makefile only) | `us-east-1` |

## Additional Notes

- CloudFormation stack tagging uses `resourcegroupstaggingapi tag-resources` (additive) instead of `cloudformation update-stack` (which replaces all tags and triggers a real stack update)
- VPC discovery uses the exact CAPA tag key `sigs.k8s.io/cluster-api-provider-aws/cluster/<name>` instead of wildcards (EC2 `describe-vpcs` `tag-key` filter doesn't support wildcards)
- Cleanup includes `ROLLBACK_COMPLETE` stacks (failed creations that consume quota)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-27408]: https://redhat.atlassian.net/browse/ARO-27408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARO-27386]: https://redhat.atlassian.net/browse/ARO-27386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ