### PR TITLE
fix: correct generate-yamls comments referencing non-existent deploy-crs step (ARO-27409)

### DIFF
--- a/openshift-ci/step-registry/capz-test-generate-yamls-commands.sh
+++ b/openshift-ci/step-registry/capz-test-generate-yamls-commands.sh
@@ -22,8 +22,9 @@ echo "=== ARO_REPO_DIR contents ==="
 ls -la "${ARO_REPO_DIR}/" | head -20 || true
 echo "============================================="
 
-# Copy generated YAMLs to SHARED_DIR so they persist for the deploy-crs step.
-# Each Prow step runs in a separate container; /tmp is not shared between them.
+# Copy generated YAMLs to SHARED_DIR for artifact preservation and potential
+# use by downstream steps. Each Prow step runs in a separate container;
+# /tmp is not shared between them.
 OUTPUT_DIR="${ARO_REPO_DIR}/${WORKLOAD_CLUSTER_NAME:-capz-tests}-${DEPLOYMENT_ENV}"
 if [[ ! -d "${OUTPUT_DIR}" ]]; then
   echo "Expected generated manifests in ${OUTPUT_DIR}, but the directory was not created" >&2
@@ -39,7 +40,7 @@ fi
 
 for f in "${generated_files[@]}"; do
     basename_f="$(basename "${f}")"
-    # Always copy to SHARED_DIR (raw, needed for deploy-crs step)
+    # Always copy to SHARED_DIR (raw, for downstream steps)
     cp "${f}" "${SHARED_DIR}/generated-${basename_f}"
     # Skip credential files from public artifacts
     case "${basename_f}" in


### PR DESCRIPTION
## Description

Update comments in the generate-yamls Prow step to remove references to the
"deploy-crs step". This is a shared step definition used by both the workload
and management-cluster-only pipelines — the deploy-crs step only exists in the
workload pipeline.

JIRA: https://redhat.atlassian.net/browse/ARO-27409

## Changes Made

- Line 25-26: Replaced "persist for the deploy-crs step" with generic "artifact preservation and potential use by downstream steps"
- Line 42: Replaced "needed for deploy-crs step" with "for downstream steps"

## Configuration Changes

N/A — comment-only change, no functional impact.

## Additional Notes

Found during PR review of [openshift/release#76592](https://github.com/openshift/release/pull/76592).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced script documentation to clarify artifact preservation and downstream step behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->