### PR TITLE
fix: remove redundant diagnostic comments in generate-yamls step (ARO-27410)

### DIFF
--- a/openshift-ci/step-registry/capz-test-generate-yamls-commands.sh
+++ b/openshift-ci/step-registry/capz-test-generate-yamls-commands.sh
@@ -6,7 +6,6 @@ set -o xtrace
 
 source openshift-ci/capz-test-env.sh
 
-# Diagnostic: print the capi-tests commit so we can verify which version CI used
 echo "=== capi-tests source commit ==="
 git log --oneline -1 || echo "(not a git repo)"
 echo "================================"
@@ -17,7 +16,6 @@ echo "================================"
 export TEST_RESULTS_DIR="${ARTIFACT_DIR}"
 script -e -q -c "make _generate-yamls RESULTS_DIR=\"${ARTIFACT_DIR}\"" /dev/null
 
-# Diagnostic: show ARO_REPO_DIR contents after generation
 echo "=== ARO_REPO_DIR contents ==="
 ls -la "${ARO_REPO_DIR}/" | head -20 || true
 echo "============================================="


### PR DESCRIPTION
## Description

Remove two redundant `# Diagnostic:` comments in `capz-test-generate-yamls-commands.sh`. The echo banners already serve as documentation in the build log.

Ref: ARO-27410

## Changes Made

- Removed `# Diagnostic: print the capi-tests commit so we can verify which version CI used` (line 9)
- Removed `# Diagnostic: show ARO_REPO_DIR contents after generation` (line 20)

## Configuration Changes

N/A

## Additional Notes

The echo statements and commands are self-explanatory — the comments were restating what the code does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI testing diagnostics by enhancing runtime visibility with labeled output sections. The test script now displays git commit information and generated manifest directory contents, replacing placeholder diagnostic comments with concrete output to facilitate better debugging and troubleshooting during continuous integration test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->