### PR TITLE
fix: restore MCE component states after test failure (ARO-27424)

### DIFF
--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -526,6 +526,11 @@ jobs:
         fi
         exit $EXIT
 
+    - name: 'Restore MCE component states'
+      if: always()
+      run: make _mce-teardown || true
+      continue-on-error: true
+
     - name: 'Cleanup resources'
       if: always()
       run: |

--- a/.github/workflows/workload-cluster-rosa.yml
+++ b/.github/workflows/workload-cluster-rosa.yml
@@ -464,6 +464,11 @@ jobs:
         fi
         exit $EXIT
 
+    - name: 'Restore MCE component states'
+      if: always()
+      run: make _mce-teardown || true
+      continue-on-error: true
+
     - name: 'Cleanup resources'
       if: always()
       run: FORCE=1 make clean-all

--- a/Makefile
+++ b/Makefile
@@ -380,44 +380,60 @@ _test-all-impl:
 		echo ""; \
 		exit 1 \
 	)
-	@$(MAKE) --no-print-directory _management_cluster RESULTS_DIR=$(RESULTS_DIR) || ( \
+	@# Phases 03-08 are wrapped so MCE teardown always runs, even on failure.
+	@# MCE components must be restored to their pre-test state regardless of outcome.
+	@SUITE_EXIT=0; \
+	$(MAKE) --no-print-directory _management_cluster RESULTS_DIR=$(RESULTS_DIR) || { \
 		echo ""; \
 		echo "❌ ERROR: Cluster deployment phase failed. Cannot continue with test suite."; \
 		echo "   Previous stages (check dependencies, setup) completed successfully."; \
 		echo ""; \
-		exit 1 \
-	)
-	@$(MAKE) --no-print-directory _generate-yamls RESULTS_DIR=$(RESULTS_DIR) || ( \
+		SUITE_EXIT=1; \
+	}; \
+	if [ $$SUITE_EXIT -eq 0 ]; then \
+		$(MAKE) --no-print-directory _generate-yamls RESULTS_DIR=$(RESULTS_DIR) || { \
+			echo ""; \
+			echo "❌ ERROR: YAML generation phase failed. Cannot continue with test suite."; \
+			echo "   Previous stages (check dependencies, setup, cluster) completed successfully."; \
+			echo ""; \
+			SUITE_EXIT=1; \
+		}; \
+	fi; \
+	if [ $$SUITE_EXIT -eq 0 ]; then \
+		$(MAKE) --no-print-directory _deploy-crs RESULTS_DIR=$(RESULTS_DIR) || { \
+			echo ""; \
+			echo "❌ ERROR: CR deployment phase failed. Cannot continue with test suite."; \
+			echo "   Previous stages (check dependencies, setup, cluster, YAML generation) completed successfully."; \
+			echo ""; \
+			SUITE_EXIT=1; \
+		}; \
+	fi; \
+	if [ $$SUITE_EXIT -eq 0 ]; then \
+		$(MAKE) --no-print-directory _verify-workload-cluster RESULTS_DIR=$(RESULTS_DIR) || { \
+			echo ""; \
+			echo "❌ ERROR: Workload cluster verification phase failed."; \
+			echo "   Previous stages completed successfully but workload cluster verification encountered issues."; \
+			echo ""; \
+			SUITE_EXIT=1; \
+		}; \
+	fi; \
+	if [ $$SUITE_EXIT -eq 0 ]; then \
+		$(MAKE) --no-print-directory _delete-workload-cluster RESULTS_DIR=$(RESULTS_DIR) || { \
+			echo ""; \
+			echo "❌ ERROR: Workload cluster deletion phase failed."; \
+			echo "   Previous stages completed successfully but cluster deletion encountered issues."; \
+			echo ""; \
+			SUITE_EXIT=1; \
+		}; \
+	fi; \
+	echo ""; \
+	echo "=== MCE teardown (always runs) ==="; \
+	$(MAKE) --no-print-directory _mce-teardown RESULTS_DIR=$(RESULTS_DIR) || true; \
+	if [ $$SUITE_EXIT -ne 0 ]; then \
 		echo ""; \
-		echo "❌ ERROR: YAML generation phase failed. Cannot continue with test suite."; \
-		echo "   Previous stages (check dependencies, setup, cluster) completed successfully."; \
-		echo ""; \
-		exit 1 \
-	)
-	@$(MAKE) --no-print-directory _deploy-crs RESULTS_DIR=$(RESULTS_DIR) || ( \
-		echo ""; \
-		echo "❌ ERROR: CR deployment phase failed. Cannot continue with test suite."; \
-		echo "   Previous stages (check dependencies, setup, cluster, YAML generation) completed successfully."; \
-		echo ""; \
-		exit 1 \
-	)
-	@$(MAKE) --no-print-directory _verify-workload-cluster RESULTS_DIR=$(RESULTS_DIR) || ( \
-		echo ""; \
-		echo "❌ ERROR: Workload cluster verification phase failed."; \
-		echo "   Previous stages completed successfully but workload cluster verification encountered issues."; \
-		echo ""; \
-		exit 1 \
-	)
-	@$(MAKE) --no-print-directory _delete-workload-cluster RESULTS_DIR=$(RESULTS_DIR) || ( \
-		echo ""; \
-		echo "❌ ERROR: Workload cluster deletion phase failed."; \
-		echo "   Previous stages completed successfully but cluster deletion encountered issues."; \
-		echo ""; \
-		exit 1 \
-	)
-	@# MCE teardown: revert MCE components to original state (best-effort, non-blocking)
-	@# This is a safety net for local runs; Prow CI runs this via the post step.
-	@$(MAKE) --no-print-directory _mce-teardown RESULTS_DIR=$(RESULTS_DIR) || true
+		echo "❌ Test suite failed (see errors above)"; \
+		exit 1; \
+	fi
 	@echo ""
 	@echo "======================================="
 	@echo "=== All Test Phases Completed Successfully ==="

--- a/test/09_teardown_test.go
+++ b/test/09_teardown_test.go
@@ -1,10 +1,7 @@
 package test
 
 import (
-	"fmt"
-	"strings"
 	"testing"
-	"time"
 )
 
 // TestTeardown_RevertMCEComponents reverts MCE components to their original states.
@@ -34,106 +31,5 @@ func TestTeardown_RevertMCEComponents(t *testing.T) {
 	PrintTestHeader(t, "TestTeardown_RevertMCEComponents",
 		"Revert MCE components to their original pre-test states")
 
-	state, err := ReadDeploymentState()
-	if err != nil {
-		t.Fatalf("Failed to read deployment state: %v", err)
-	}
-
-	if state == nil || len(state.MCEOriginalStates) == 0 {
-		PrintToTTY("No MCE original states saved — nothing to revert\n\n")
-		t.Skip("No MCE original states found in deployment state file")
-	}
-
-	// Show what will be reverted
-	PrintToTTY("\n=== MCE component teardown plan ===\n")
-	PrintToTTY("%-40s %-12s %s\n", "COMPONENT", "ORIGINAL", "CURRENT")
-	PrintToTTY("%s\n", strings.Repeat("-", 65))
-
-	type revertAction struct {
-		name            string
-		originalEnabled bool
-	}
-	var actions []revertAction
-	var queryErrors []string
-
-	for component, originalEnabled := range state.MCEOriginalStates {
-		current, err := GetMCEComponentStatus(t, context, component)
-		if err != nil {
-			queryErrors = append(queryErrors, fmt.Sprintf("%s: %v", component, err))
-			PrintToTTY("%-40s %-12s ⚠️  error: %v\n", component, fmtEnabled(originalEnabled), err)
-			continue
-		}
-
-		currentStr := fmtEnabled(current.Enabled)
-		originalStr := fmtEnabled(originalEnabled)
-
-		if current.Enabled == originalEnabled {
-			PrintToTTY("%-40s %-12s %-12s (no change needed)\n", component, originalStr, currentStr)
-		} else {
-			PrintToTTY("%-40s %-12s %-12s ← will revert\n", component, originalStr, currentStr)
-			actions = append(actions, revertAction{name: component, originalEnabled: originalEnabled})
-		}
-	}
-
-	PrintToTTY("%s\n", strings.Repeat("-", 65))
-
-	if len(queryErrors) > 0 {
-		PrintToTTY("\n⚠️  Failed to query %d component(s):\n", len(queryErrors))
-		for _, e := range queryErrors {
-			PrintToTTY("   - %s\n", e)
-		}
-	}
-
-	if len(actions) == 0 {
-		PrintToTTY("\n✅ All MCE components are already in their original state — no revert needed\n\n")
-		t.Log("All MCE components already in original state")
-		return
-	}
-
-	// Revert components
-	PrintToTTY("\n=== Reverting %d MCE component(s) ===\n\n", len(actions))
-
-	var revertErrors []string
-	var reverted []string
-
-	for _, action := range actions {
-		if err := SetMCEComponentState(t, context, action.name, action.originalEnabled); err != nil {
-			revertErrors = append(revertErrors, fmt.Sprintf("%s: %v", action.name, err))
-			PrintToTTY("❌ Failed to revert %s: %v\n", action.name, err)
-		} else {
-			reverted = append(reverted, fmt.Sprintf("%s → %s", action.name, fmtEnabled(action.originalEnabled)))
-		}
-	}
-
-	if len(revertErrors) > 0 {
-		PrintToTTY("\n❌ Failed to revert %d component(s):\n", len(revertErrors))
-		for _, e := range revertErrors {
-			PrintToTTY("   - %s\n", e)
-		}
-		t.Errorf("Failed to revert MCE components: %v", revertErrors)
-	}
-
-	if len(reverted) > 0 {
-		PrintToTTY("\n✅ Successfully reverted %d component(s):\n", len(reverted))
-		for _, r := range reverted {
-			PrintToTTY("   - %s\n", r)
-		}
-		t.Logf("Reverted MCE components: %v", reverted)
-
-		// Wait for MCE to reconcile
-		PrintToTTY("\n=== Waiting for MCE to reconcile ===\n")
-		PrintToTTY("Waiting 30 seconds for MCE to start reconciling...\n")
-		time.Sleep(30 * time.Second)
-		PrintToTTY("✅ MCE reconciliation wait complete\n\n")
-	}
-
-	PrintToTTY("✅ MCE teardown complete\n\n")
-	t.Log("MCE component teardown completed")
-}
-
-func fmtEnabled(enabled bool) string {
-	if enabled {
-		return "enabled"
-	}
-	return "disabled"
+	RestoreMCEOriginalStates(t, context)
 }

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2995,7 +2995,7 @@ func RestoreMCEOriginalStates(t *testing.T, kubeContext string) {
 	if len(reverted) > 0 {
 		PrintToTTY("✅ Restored %d MCE component(s): %v\n", len(reverted), reverted)
 		t.Logf("MCE restore: reverted %d component(s): %v", len(reverted), reverted)
-	} else {
+	} else if len(failed) == 0 {
 		PrintToTTY("✅ All MCE components already in original state\n")
 	}
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2949,6 +2949,64 @@ func SaveMCEOriginalStates(states map[string]bool) error {
 	return nil
 }
 
+// RestoreMCEOriginalStates reads saved MCE component states from the deployment state file
+// and reverts any components that have been changed back to their original state.
+// Designed for use in t.Cleanup — logs warnings on failure but never calls t.Fatal.
+func RestoreMCEOriginalStates(t *testing.T, kubeContext string) {
+	t.Helper()
+
+	state, err := ReadDeploymentState()
+	if err != nil {
+		t.Logf("MCE restore: failed to read deployment state: %v", err)
+		return
+	}
+
+	if state == nil || len(state.MCEOriginalStates) == 0 {
+		t.Log("MCE restore: no original states saved, nothing to revert")
+		return
+	}
+
+	PrintToTTY("\n=== MCE component restore (cleanup) ===\n")
+
+	var reverted, failed []string
+
+	for component, originalEnabled := range state.MCEOriginalStates {
+		current, err := GetMCEComponentStatus(t, kubeContext, component)
+		if err != nil {
+			failed = append(failed, fmt.Sprintf("%s: query failed: %v", component, err))
+			continue
+		}
+
+		if current.Enabled == originalEnabled {
+			continue
+		}
+
+		if err := SetMCEComponentState(t, kubeContext, component, originalEnabled); err != nil {
+			failed = append(failed, fmt.Sprintf("%s: revert failed: %v", component, err))
+		} else {
+			stateStr := "disabled"
+			if originalEnabled {
+				stateStr = "enabled"
+			}
+			reverted = append(reverted, fmt.Sprintf("%s → %s", component, stateStr))
+		}
+	}
+
+	if len(reverted) > 0 {
+		PrintToTTY("✅ Restored %d MCE component(s): %v\n", len(reverted), reverted)
+		t.Logf("MCE restore: reverted %d component(s): %v", len(reverted), reverted)
+	} else {
+		PrintToTTY("✅ All MCE components already in original state\n")
+	}
+
+	if len(failed) > 0 {
+		PrintToTTY("⚠️  Failed to restore %d MCE component(s): %v\n", len(failed), failed)
+		t.Logf("MCE restore WARNING: failed to revert %d component(s): %v", len(failed), failed)
+	}
+
+	PrintToTTY("\n")
+}
+
 // ControllerLogSummary holds summarized log information for a controller.
 type ControllerLogSummary struct {
 	Name       string   // Controller name (e.g., "CAPZ", "ASO", "CAPI")

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2951,7 +2951,7 @@ func SaveMCEOriginalStates(states map[string]bool) error {
 
 // RestoreMCEOriginalStates reads saved MCE component states from the deployment state file
 // and reverts any components that have been changed back to their original state.
-// Designed for use in t.Cleanup — logs warnings on failure but never calls t.Fatal.
+// Safe for cleanup paths — uses t.Errorf (non-fatal) on revert failures so subsequent steps still run.
 func RestoreMCEOriginalStates(t *testing.T, kubeContext string) {
 	t.Helper()
 
@@ -3001,7 +3001,7 @@ func RestoreMCEOriginalStates(t *testing.T, kubeContext string) {
 
 	if len(failed) > 0 {
 		PrintToTTY("⚠️  Failed to restore %d MCE component(s): %v\n", len(failed), failed)
-		t.Logf("MCE restore WARNING: failed to revert %d component(s): %v", len(failed), failed)
+		t.Errorf("MCE restore: failed to revert %d component(s): %v", len(failed), failed)
 	}
 
 	PrintToTTY("\n")


### PR DESCRIPTION
## Description

Restore MCE component states after test run completes or fails, ensuring the cluster is returned to its pre-test state regardless of outcome.

JIRA: https://redhat.atlassian.net/browse/ARO-27424

## Changes Made

- Add `RestoreMCEOriginalStates` helper function in `test/helpers.go` — reads saved states from deployment state file, compares with current, reverts changed components. Designed for cleanup: logs warnings on failure but never calls `t.Fatal`
- Restructure `_test-all-impl` in `Makefile` so `_mce-teardown` always runs even when earlier phases fail (phases 03-08 wrapped in a single shell block that tracks exit code)
- Add "Restore MCE component states" step to ARO and ROSA GHA workflow cleanup sections (`if: always()`) as a safety net before Azure/AWS resource cleanup
- Simplify `TestTeardown_RevertMCEComponents` (Phase 09) to delegate to the new helper, eliminating ~100 lines of duplicated logic

## Configuration Changes

No new environment variables.

## Additional Notes

Previously, `_mce-teardown` only ran on the success path in the Makefile — each phase used `|| (echo "error"; exit 1)` which terminated the entire recipe. Now phases 03-08 are wrapped in a single shell block that records failures but continues to MCE teardown before exiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored teardown to use a reusable helper that restores multi-cluster component states, simplifies reporting, and reduces test cruft.

* **Chores**
  * CI workflows updated to always-attempt MCE state restoration during finalization, treating failures as non-fatal.
  * Test orchestration changed so teardown runs unconditionally and per-phase failures are recorded without aborting final cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->