### PR TITLE
fix: move Azure resource tagging earlier to prevent untagged orphans (ARO-27587)

### DIFF
--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -372,10 +372,12 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 	// The RG is created asynchronously after CRs are applied, typically within a few minutes.
 	rgTimeout, err := time.ParseDuration(GetEnvOrDefault("AZURE_RG_CREATION_TIMEOUT", "10m"))
 	if err != nil {
+		t.Logf("Warning: invalid AZURE_RG_CREATION_TIMEOUT format, using default 10m: %v", err)
 		rgTimeout = 10 * time.Minute
 	}
 	rgPollInterval, err := time.ParseDuration(GetEnvOrDefault("AZURE_RG_POLL_INTERVAL", "15s"))
 	if err != nil {
+		t.Logf("Warning: invalid AZURE_RG_POLL_INTERVAL format, using default 15s: %v", err)
 		rgPollInterval = 15 * time.Second
 	}
 	rgStart := time.Now()

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -356,18 +356,13 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 		return
 	}
 
-	if !CommandExists("az") {
-		t.Skipf("Azure CLI not available, skipping resource tagging")
-		return
-	}
-
 	if config.InfraProviderName != "aro" {
 		t.Skipf("Azure resource tagging only applies to ARO provider")
 		return
 	}
 
 	if err := EnsureAzureCliLogin(t); err != nil {
-		t.Skipf("Skipping Azure resource tagging: Azure CLI auth unavailable: %v", err)
+		t.Errorf("Azure CLI auth unavailable for resource tagging: %v — resources will be created without tags", err)
 		return
 	}
 

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -338,6 +338,75 @@ func TestDeployment_ProviderCredentialsConfigured(t *testing.T) {
 	}
 }
 
+// TestDeployment_TagAzureResources tags all Azure resources created by the deployment
+// with ownership metadata for parallel run cleanup. Tags the resource group (ARM tags)
+// and Azure AD Applications/Service Principals (Microsoft Graph tags).
+//
+// Runs early in the deployment sequence (before monitoring) so that even failed or
+// interrupted test runs leave tagged resources that can be traced back to their owner.
+// The resource group is created asynchronously by CAPI controllers after CRs are applied,
+// so this test polls for it to appear before tagging.
+//
+// Non-fatal: failures are logged as warnings since tagging is for cleanup convenience only.
+func TestDeployment_TagAzureResources(t *testing.T) {
+	config := NewTestConfig()
+
+	if len(config.ResourceTags) == 0 {
+		t.Skipf("No Azure resource tags configured")
+		return
+	}
+
+	if !CommandExists("az") {
+		t.Skipf("Azure CLI not available, skipping resource tagging")
+		return
+	}
+
+	if config.InfraProviderName != "aro" {
+		t.Skipf("Azure resource tagging only applies to ARO provider")
+		return
+	}
+
+	if err := EnsureAzureCliLogin(t); err != nil {
+		t.Skipf("Skipping Azure resource tagging: Azure CLI auth unavailable: %v", err)
+	}
+
+	PrintToTTY("\n=== Tagging Azure Resources ===\n")
+
+	// Wait for the resource group to be created by CAPI controllers.
+	// The RG is created asynchronously after CRs are applied, typically within a few minutes.
+	rgTimeout := 10 * time.Minute
+	rgPollInterval := 15 * time.Second
+	rgStart := time.Now()
+	rgExists := false
+
+	PrintToTTY("Waiting for resource group %s to be created by controllers...\n", config.ResourceGroupName)
+	for time.Since(rgStart) < rgTimeout {
+		_, err := RunCommandQuiet(t, "az", "group", "show", "--name", config.ResourceGroupName)
+		if err == nil {
+			rgExists = true
+			PrintToTTY("✅ Resource group %s exists (waited %v)\n", config.ResourceGroupName, time.Since(rgStart).Round(time.Second))
+			break
+		}
+		PrintToTTY("⏳ Resource group not yet created (elapsed %v)\n", time.Since(rgStart).Round(time.Second))
+		time.Sleep(rgPollInterval)
+	}
+
+	if !rgExists {
+		t.Logf("Warning: resource group %s not created within %v, skipping tagging", config.ResourceGroupName, rgTimeout)
+		PrintToTTY("⚠️  Resource group not created within %v, skipping tagging\n\n", rgTimeout)
+		return
+	}
+
+	PrintToTTY("Tagging resource group %s...\n", config.ResourceGroupName)
+	if err := TagAzureResourceGroup(t, config); err != nil {
+		t.Logf("Warning: failed to tag resource group: %v", err)
+	}
+	tagAzureADApplications(t, config)
+	tagAzureServicePrincipals(t, config)
+
+	PrintToTTY("✅ Azure resource tagging completed\n\n")
+}
+
 // TestDeployment_MonitorCluster tests monitoring the ARO cluster deployment
 func TestDeployment_MonitorCluster(t *testing.T) {
 
@@ -1215,44 +1284,6 @@ func TestDeployment_VerifyClusterInfrastructureReady(t *testing.T) {
 		PrintToTTY("⏳ Cluster.InfrastructureReady: %s (elapsed %v)\n", status, elapsed.Round(time.Second))
 		time.Sleep(pollInterval)
 	}
-}
-
-// TestDeployment_TagAzureResources tags all Azure resources created by the deployment
-// with ownership metadata for parallel run cleanup. Tags the resource group (ARM tags)
-// and Azure AD Applications/Service Principals (Microsoft Graph tags).
-// Non-fatal: failures are logged as warnings since tagging is for cleanup convenience only.
-func TestDeployment_TagAzureResources(t *testing.T) {
-	config := NewTestConfig()
-
-	if len(config.ResourceTags) == 0 {
-		t.Skipf("No Azure resource tags configured")
-		return
-	}
-
-	if !CommandExists("az") {
-		t.Skipf("Azure CLI not available, skipping resource tagging")
-		return
-	}
-
-	if config.InfraProviderName != "aro" {
-		t.Skipf("Azure resource tagging only applies to ARO provider")
-		return
-	}
-
-	if err := EnsureAzureCliLogin(t); err != nil {
-		t.Skipf("Skipping Azure resource tagging: Azure CLI auth unavailable: %v", err)
-	}
-
-	PrintToTTY("\n=== Tagging Azure Resources ===\n")
-
-	PrintToTTY("Tagging resource group %s...\n", config.ResourceGroupName)
-	if err := TagAzureResourceGroup(t, config); err != nil {
-		t.Logf("Warning: failed to tag resource group: %v", err)
-	}
-	tagAzureADApplications(t, config)
-	tagAzureServicePrincipals(t, config)
-
-	PrintToTTY("✅ Azure resource tagging completed\n\n")
 }
 
 // TestDeployment_TagAWSResources tags AWS resources (CloudFormation stacks and VPCs) created

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -357,7 +357,7 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 	}
 
 	if err := EnsureAzureCliLogin(t); err != nil {
-		t.Errorf("Azure CLI auth unavailable for resource tagging: %v — resources will be created without tags", err)
+		t.Logf("Warning: Azure CLI auth unavailable for resource tagging: %v — resources will be created without tags", err)
 		return
 	}
 

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -368,6 +368,7 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 
 	if err := EnsureAzureCliLogin(t); err != nil {
 		t.Skipf("Skipping Azure resource tagging: Azure CLI auth unavailable: %v", err)
+		return
 	}
 
 	PrintToTTY("\n=== Tagging Azure Resources ===\n")

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -370,8 +370,14 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 
 	// Wait for the resource group to be created by CAPI controllers.
 	// The RG is created asynchronously after CRs are applied, typically within a few minutes.
-	rgTimeout := 10 * time.Minute
-	rgPollInterval := 15 * time.Second
+	rgTimeout, err := time.ParseDuration(GetEnvOrDefault("AZURE_RG_CREATION_TIMEOUT", "10m"))
+	if err != nil {
+		rgTimeout = 10 * time.Minute
+	}
+	rgPollInterval, err := time.ParseDuration(GetEnvOrDefault("AZURE_RG_POLL_INTERVAL", "15s"))
+	if err != nil {
+		rgPollInterval = 15 * time.Second
+	}
 	rgStart := time.Now()
 	rgExists := false
 

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -344,7 +344,7 @@ func TestDeployment_ProviderCredentialsConfigured(t *testing.T) {
 //
 // Runs early in the deployment sequence (before monitoring) so that even failed or
 // interrupted test runs leave tagged resources that can be traced back to their owner.
-// The resource group is created asynchronously by CAPI controllers after CRs are applied,
+// The resource group is created asynchronously by ASO (triggered by CAPZ reconciliation),
 // so this test polls for it to appear before tagging.
 //
 // Non-fatal: failures are logged as warnings since tagging is for cleanup convenience only.
@@ -368,7 +368,7 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 
 	PrintToTTY("\n=== Tagging Azure Resources ===\n")
 
-	// Wait for the resource group to be created by CAPI controllers.
+	// Wait for the resource group to be created by ASO (triggered by CAPZ reconciliation).
 	// The RG is created asynchronously after CRs are applied, typically within a few minutes.
 	rgTimeout, err := time.ParseDuration(GetEnvOrDefault("AZURE_RG_CREATION_TIMEOUT", "10m"))
 	if err != nil {
@@ -383,7 +383,7 @@ func TestDeployment_TagAzureResources(t *testing.T) {
 	rgStart := time.Now()
 	rgExists := false
 
-	PrintToTTY("Waiting for resource group %s to be created by controllers...\n", config.ResourceGroupName)
+	PrintToTTY("Waiting for resource group %s to be created by ASO...\n", config.ResourceGroupName)
 	for time.Since(rgStart) < rgTimeout {
 		_, err := RunCommandQuiet(t, "az", "group", "show", "--name", config.ResourceGroupName)
 		if err == nil {

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -351,11 +351,6 @@ func TestDeployment_ProviderCredentialsConfigured(t *testing.T) {
 func TestDeployment_TagAzureResources(t *testing.T) {
 	config := NewTestConfig()
 
-	if len(config.ResourceTags) == 0 {
-		t.Skipf("No Azure resource tags configured")
-		return
-	}
-
 	if config.InfraProviderName != "aro" {
 		t.Skipf("Azure resource tagging only applies to ARO provider")
 		return


### PR DESCRIPTION
## Description

Move Azure resource tagging earlier in the test sequence to prevent untagged orphan resources.

JIRA: https://redhat.atlassian.net/browse/ARO-27587

## Changes Made

- Move `TestDeployment_TagAzureResources` from the end of phase 05 (after all verification) to right after `TestDeployment_ProviderCredentialsConfigured` (before the monitoring loop)
- Add polling wait for the resource group to be created by CAPI controllers (configurable timeout, default 10m), since RG creation is asynchronous
- Make RG polling timeout and interval configurable via `AZURE_RG_CREATION_TIMEOUT` and `AZURE_RG_POLL_INTERVAL` env vars
- Keep tagging non-fatal: if the RG doesn't appear within the timeout, skip with a warning
- Add defensive `return` after `t.Skipf` in Azure CLI auth guard for consistency

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `AZURE_RG_CREATION_TIMEOUT` | Timeout for waiting for resource group creation by CAPI controllers | `10m` |
| `AZURE_RG_POLL_INTERVAL` | Poll interval when checking for resource group existence | `15s` |

## Additional Notes

Previously, tagging was the last test in phase 05. If a test run failed or was interrupted at any point during the 60-minute deployment monitoring, the resource group existed but was never tagged. Every stale resource detected by ARO-27417 had missing tags, confirming this gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)