### PR TITLE
feat: add deletion diagnostics with clusterctl output and controller logs (ARO-27588)

### DIFF
--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -246,13 +246,6 @@ func TestDeletion_WaitForClusterDeletion(t *testing.T) {
 			}
 		}
 
-		// Controller log summaries every 3rd iteration (starting from 1st) to limit noise
-		if iteration%3 == 1 {
-			summaries := GetAllControllerLogSummaries(t, context)
-			PrintToTTY("%s", FormatControllerLogSummaries(summaries))
-			t.Logf("Controller log check (iteration %d): completed", iteration)
-		}
-
 		time.Sleep(pollInterval)
 	}
 }

--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -128,6 +128,14 @@ func TestDeletion_WaitForClusterDeletion(t *testing.T) {
 	PrintToTTY("\n")
 	t.Logf("Waiting for cluster '%s' deletion (namespace: %s, timeout: %v)...", provisionedClusterName, config.WorkloadClusterNamespace, timeout)
 
+	// Resolve clusterctl for diagnostics during deletion monitoring
+	clusterctlPath, hasClusterctl := ResolveClusterctlPath()
+	if hasClusterctl {
+		PrintToTTY("📊 clusterctl available for deletion diagnostics: %s\n\n", clusterctlPath)
+	} else {
+		PrintToTTY("ℹ️  clusterctl not available — skipping clusterctl diagnostics\n\n")
+	}
+
 	iteration := 0
 	for {
 		elapsed := time.Since(startTime)
@@ -135,6 +143,43 @@ func TestDeletion_WaitForClusterDeletion(t *testing.T) {
 
 		if elapsed > timeout {
 			PrintToTTY("\n❌ Timeout waiting for cluster deletion after %v\n\n", elapsed.Round(time.Second))
+
+			// === Diagnostic dump on timeout ===
+			PrintToTTY("=== DELETION TIMEOUT DIAGNOSTICS ===\n\n")
+			t.Logf("=== Deletion timeout diagnostics ===")
+
+			// 1. clusterctl describe
+			if hasClusterctl {
+				PrintToTTY("--- clusterctl describe (timeout snapshot) ---\n")
+				clOutput, clErr := RunCommandQuiet(t, clusterctlPath, "describe", "cluster",
+					provisionedClusterName, "-n", config.WorkloadClusterNamespace, "--show-conditions=all")
+				if clErr == nil {
+					PrintToTTY("%s\n", clOutput)
+					t.Logf("clusterctl describe at timeout:\n%s", clOutput)
+				} else {
+					PrintToTTY("clusterctl describe failed: %v\n\n", clErr)
+					t.Logf("clusterctl describe at timeout failed: %v", clErr)
+				}
+			}
+
+			// 2. Controller log summaries + save to results dir
+			PrintToTTY("--- Controller logs (timeout snapshot) ---\n")
+			summaries := GetAllControllerLogSummaries(t, context)
+			resultsDir := GetResultsDir()
+			summaries = SaveAllControllerLogs(t, context, resultsDir, summaries)
+			PrintToTTY("%s", FormatControllerLogSummaries(summaries))
+			t.Logf("Controller logs saved to %s", resultsDir)
+
+			// 3. Finalizer details
+			finOutput, finErr := RunCommandQuiet(t, "kubectl", "--context", context,
+				"-n", config.WorkloadClusterNamespace, "get", "cluster", provisionedClusterName,
+				"-o", "jsonpath={.metadata.finalizers}")
+			if finErr == nil && strings.TrimSpace(finOutput) != "" {
+				PrintToTTY("--- Active finalizers ---\n%s\n\n", finOutput)
+				t.Logf("Active finalizers at timeout: %s", finOutput)
+			}
+
+			PrintToTTY("=== END DIAGNOSTICS ===\n\n")
 
 			// Build provider-agnostic troubleshooting message
 			controlPlaneResource := "controlplane"
@@ -190,6 +235,25 @@ func TestDeletion_WaitForClusterDeletion(t *testing.T) {
 
 		// Report detailed deletion progress
 		ReportDeletionProgress(t, iteration, elapsed, remaining, status)
+
+		// clusterctl describe on every iteration for live CAPI resource tree
+		if hasClusterctl {
+			clOutput, clErr := RunCommandQuiet(t, clusterctlPath, "describe", "cluster",
+				provisionedClusterName, "-n", config.WorkloadClusterNamespace, "--show-conditions=all")
+			if clErr == nil {
+				PrintToTTY("\n--- clusterctl describe ---\n%s\n", clOutput)
+				t.Logf("clusterctl describe:\n%s", clOutput)
+			} else {
+				t.Logf("clusterctl describe failed (may be expected during deletion): %v", clErr)
+			}
+		}
+
+		// Controller log summaries every 3rd iteration to limit noise
+		if iteration%3 == 0 {
+			summaries := GetAllControllerLogSummaries(t, context)
+			PrintToTTY("%s", FormatControllerLogSummaries(summaries))
+			t.Logf("Controller log check (iteration %d): completed", iteration)
+		}
 
 		time.Sleep(pollInterval)
 	}

--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -129,13 +129,14 @@ func TestDeletion_WaitForClusterDeletion(t *testing.T) {
 	t.Logf("Waiting for cluster '%s' deletion (namespace: %s, timeout: %v)...", provisionedClusterName, config.WorkloadClusterNamespace, timeout)
 
 	// Resolve clusterctl for diagnostics during deletion monitoring
-	clusterctlPath, hasClusterctl := ResolveClusterctlPath()
+	clusterctlPath, hasClusterctl := ResolveClusterctlPath(config)
 	if hasClusterctl {
 		PrintToTTY("📊 clusterctl available for deletion diagnostics: %s\n\n", clusterctlPath)
 	} else {
 		PrintToTTY("ℹ️  clusterctl not available — skipping clusterctl diagnostics\n\n")
 	}
 
+	var lastStatus DeletionResourceStatus
 	iteration := 0
 	for {
 		elapsed := time.Since(startTime)
@@ -170,13 +171,10 @@ func TestDeletion_WaitForClusterDeletion(t *testing.T) {
 			PrintToTTY("%s", FormatControllerLogSummaries(summaries))
 			t.Logf("Controller logs saved to %s", resultsDir)
 
-			// 3. Finalizer details
-			finOutput, finErr := RunCommandQuiet(t, "kubectl", "--context", context,
-				"-n", config.WorkloadClusterNamespace, "get", "cluster", provisionedClusterName,
-				"-o", "jsonpath={.metadata.finalizers}")
-			if finErr == nil && strings.TrimSpace(finOutput) != "" {
-				PrintToTTY("--- Active finalizers ---\n%s\n\n", finOutput)
-				t.Logf("Active finalizers at timeout: %s", finOutput)
+			// 3. Finalizer details (reuse from last GetDeletionResourceStatus call)
+			if len(lastStatus.ClusterFinalizers) > 0 {
+				PrintToTTY("--- Active finalizers ---\n%s\n\n", strings.Join(lastStatus.ClusterFinalizers, ", "))
+				t.Logf("Active finalizers at timeout: %s", strings.Join(lastStatus.ClusterFinalizers, ", "))
 			}
 
 			PrintToTTY("=== END DIAGNOSTICS ===\n\n")
@@ -221,20 +219,20 @@ func TestDeletion_WaitForClusterDeletion(t *testing.T) {
 		iteration++
 
 		// Get comprehensive deletion status
-		status := GetDeletionResourceStatus(t, context, config.WorkloadClusterNamespace, provisionedClusterName, resourceGroup)
+		lastStatus = GetDeletionResourceStatus(t, context, config.WorkloadClusterNamespace, provisionedClusterName, resourceGroup)
 
 		// Check if cluster is fully deleted
-		if !status.ClusterExists {
+		if !lastStatus.ClusterExists {
 			PrintToTTY("\n✅ Cluster '%s' has been deleted (took %v)\n\n", provisionedClusterName, elapsed.Round(time.Second))
 			t.Logf("Cluster '%s' deleted successfully (took %v)", provisionedClusterName, elapsed.Round(time.Second))
 
 			// Show final status
-			PrintToTTY("%s", FormatDeletionProgress(status))
+			PrintToTTY("%s", FormatDeletionProgress(lastStatus))
 			return
 		}
 
 		// Report detailed deletion progress
-		ReportDeletionProgress(t, iteration, elapsed, remaining, status)
+		ReportDeletionProgress(t, iteration, elapsed, remaining, lastStatus)
 
 		// clusterctl describe on every iteration for live CAPI resource tree
 		if hasClusterctl {
@@ -248,8 +246,8 @@ func TestDeletion_WaitForClusterDeletion(t *testing.T) {
 			}
 		}
 
-		// Controller log summaries every 3rd iteration to limit noise
-		if iteration%3 == 0 {
+		// Controller log summaries every 3rd iteration (starting from 1st) to limit noise
+		if iteration%3 == 1 {
 			summaries := GetAllControllerLogSummaries(t, context)
 			PrintToTTY("%s", FormatControllerLogSummaries(summaries))
 			t.Logf("Controller log check (iteration %d): completed", iteration)

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3062,8 +3062,7 @@ func CheckPodsForImagePullErrors(t *testing.T, kubeContext, namespace string) er
 
 // ResolveClusterctlPath finds the clusterctl binary, checking the repo binary first,
 // then the system PATH. Returns the resolved path and whether it was found.
-func ResolveClusterctlPath() (string, bool) {
-	config := NewTestConfig()
+func ResolveClusterctlPath(config *TestConfig) (string, bool) {
 	repoPath := filepath.Join(config.RepoDir, config.ClusterctlBinPath)
 	if FileExists(repoPath) {
 		return repoPath, true

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3060,6 +3060,20 @@ func CheckPodsForImagePullErrors(t *testing.T, kubeContext, namespace string) er
 		namespace, strings.Join(affectedPods, ", "))
 }
 
+// ResolveClusterctlPath finds the clusterctl binary, checking the repo binary first,
+// then the system PATH. Returns the resolved path and whether it was found.
+func ResolveClusterctlPath() (string, bool) {
+	config := NewTestConfig()
+	repoPath := filepath.Join(config.RepoDir, config.ClusterctlBinPath)
+	if FileExists(repoPath) {
+		return repoPath, true
+	}
+	if CommandExists("clusterctl") {
+		return "clusterctl", true
+	}
+	return "", false
+}
+
 // GetControllerLogs retrieves logs from a controller deployment.
 // Returns the log output or an error if the logs cannot be retrieved.
 func GetControllerLogs(t *testing.T, kubeContext, namespace, deploymentName string, tailLines int) (string, error) {
@@ -3545,9 +3559,23 @@ func GetDeletionResourceStatus(t *testing.T, kubeContext, namespace, clusterName
 		status.ClusterExists = true
 		status.ClusterPhase = data.Summary.Phase
 
-		// Extract finalizers from cluster conditions (if available in future)
-		// For now, keep empty as the monitoring script doesn't expose finalizers
-		status.ClusterFinalizers = []string{}
+		// Query finalizers directly from the cluster resource
+		finalizerOutput, finErr := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
+			"-n", namespace, "get", "cluster", clusterName,
+			"-o", "jsonpath={.metadata.finalizers}")
+		if finErr == nil && strings.TrimSpace(finalizerOutput) != "" {
+			raw := strings.TrimSpace(finalizerOutput)
+			raw = strings.Trim(raw, "[]")
+			if raw != "" {
+				for _, f := range strings.Split(raw, ",") {
+					f = strings.TrimSpace(f)
+					f = strings.Trim(f, "\"")
+					if f != "" {
+						status.ClusterFinalizers = append(status.ClusterFinalizers, f)
+					}
+				}
+			}
+		}
 
 		// Get control plane kind and count from monitoring data
 		if data.ControlPlane.Name != "" {

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3561,7 +3561,8 @@ func GetDeletionResourceStatus(t *testing.T, kubeContext, namespace, clusterName
 		// Query finalizers directly from the cluster resource
 		finalizerOutput, finErr := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
 			"-n", namespace, "get", "cluster", clusterName,
-			"-o", "jsonpath={.metadata.finalizers}")
+			"-o", "jsonpath={.metadata.finalizers}",
+			"--request-timeout=10s")
 		if finErr == nil && strings.TrimSpace(finalizerOutput) != "" {
 			raw := strings.TrimSpace(finalizerOutput)
 			raw = strings.Trim(raw, "[]")


### PR DESCRIPTION
## Description

Add comprehensive diagnostics during workload cluster deletion to help identify what blocks k8s resource cleanup, particularly in the ocp-ci (MCE) environment where ARO cloud resources delete successfully but CAPI CRs can hang in the management cluster.

JIRA: https://redhat.atlassian.net/browse/ARO-27588

## Changes Made

- Add `clusterctl describe` output on every poll iteration during deletion monitoring — shows the live CAPI resource tree with conditions
- Add controller log summaries (CAPI, CAPZ, ASO) every 3rd iteration (~90s) during deletion monitoring
- Add full diagnostic dump on deletion timeout: clusterctl snapshot, controller logs saved to results dir, and active finalizer details
- Populate `ClusterFinalizers` field in `DeletionResourceStatus` (was always empty) by querying the cluster resource metadata
- Extract `ResolveClusterctlPath()` helper to avoid duplicating clusterctl path resolution logic across phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cluster deletion test diagnostics: periodic controller log summaries during polling, conditional live cluster description output, and a dedicated diagnostics dump on timeout that includes recent finalizer information.
  * Added a helper to locate the external cluster CLI and enhanced deletion status tracking to capture active cluster finalizers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->