### PR TITLE
fix: switch installer repo to upstream stolostron and update clusterctl

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -3,9 +3,9 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20
 # Tool versions - pin all versions for reproducible builds
 ARG KUBECTL_VERSION=v1.35.2
 ARG HELM_VERSION=v3.16.0
-ARG CLUSTERCTL_VERSION=v1.12.3
+ARG CLUSTERCTL_VERSION=v1.12.8
 # Update CLUSTERCTL_SHA256 when changing CLUSTERCTL_VERSION (no checksum file published by upstream)
-ARG CLUSTERCTL_SHA256=9b75287b15656a62ece65c8ad7491412cebfd30c78e085a9d61396a50df17349
+ARG CLUSTERCTL_SHA256=19679fd674731c7f48276b633874834958a62b0e93cb870b87a2df240d6a7ce0
 ARG GOTESTSUM_VERSION=v1.13.0
 
 # Install OpenShift CLI
@@ -48,15 +48,6 @@ RUN curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o 
 
 # Install gotestsum for JUnit XML output
 RUN GOFLAGS='' GOBIN=/usr/local/bin go install gotest.tools/gotestsum@${GOTESTSUM_VERSION}
-
-# Pre-clone cluster-api-installer so it's available in all Prow steps
-# (each step runs in a separate container from this image, so /tmp is not shared)
-ARG INSTALLER_REPO=https://github.com/marek-veber/cluster-api-installer
-ARG INSTALLER_BRANCH=capi-tests
-RUN git clone -b "${INSTALLER_BRANCH}" "${INSTALLER_REPO}" /tmp/cluster-api-installer-aro
-
-# Ensure Go and installer directories are writable for arbitrary UIDs (OpenShift CI runs as random non-root user)
-RUN chmod -R 777 /go /tmp/cluster-api-installer-aro
 
 # Install clusterctl (with checksum verification via hardcoded digest)
 RUN curl -Lo /usr/local/bin/clusterctl "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterctl-linux-amd64" && \

--- a/openshift-ci/capz-test-env.sh
+++ b/openshift-ci/capz-test-env.sh
@@ -58,8 +58,8 @@ export INFRA_PROVIDER CAPI_USER DEPLOYMENT_ENV
 export REGION
 : "${OPERATORS_UAMIS_SUFFIX_FILE:=/tmp/operators-uamis-suffix.txt}"
 export OPERATORS_UAMIS_SUFFIX_FILE
-: "${ARO_REPO_URL:=https://github.com/marek-veber/cluster-api-installer.git}"
-: "${ARO_REPO_BRANCH:=capi-tests}"
+: "${ARO_REPO_URL:=https://github.com/stolostron/cluster-api-installer.git}"
+: "${ARO_REPO_BRANCH:=main}"
 : "${ARO_REPO_DIR:=/tmp/cluster-api-installer-aro}"
 export ARO_REPO_URL ARO_REPO_BRANCH ARO_REPO_DIR
 


### PR DESCRIPTION
## Summary
- Switch cluster-api-installer from personal fork (`marek-veber/cluster-api-installer`, branch `capi-tests`) to upstream (`stolostron/cluster-api-installer`, branch `main`)
- Update clusterctl from v1.12.3 to v1.12.8 with updated SHA256 checksum
- Remove pre-clone of installer from Prow Dockerfile (repo is cloned at test runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated clusterctl version and corresponding security checksum in container build configuration.
  * Streamlined Docker image build process by removing intermediate repository initialization steps.
  * Updated default cluster installer repository source and branch for test environment deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->