### PR TITLE
fix: rename Makefile timeout vars with GO_STEP_ prefix (ARO-27600)

### DIFF
--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -143,7 +143,7 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 280  # DEPLOY_CRS_TIMEOUT (130m) + DELETION_TIMEOUT (120m) + overhead (30m)
+    timeout-minutes: 280  # GO_STEP_DEPLOY_CRS_TIMEOUT (130m) + GO_STEP_DELETION_TIMEOUT (120m) + overhead (30m)
     environment: ${{ inputs.environment || 'aro-stage' }}
     env:
       # Cluster mode selection
@@ -302,12 +302,12 @@ jobs:
 
     - name: 'Run test-all'
       # Azure credentials and config are set at job level (see env: above)
-      # DEPLOY_CRS_TIMEOUT has a 10m buffer over DEPLOYMENT_TIMEOUT so the deployment
+      # GO_STEP_DEPLOY_CRS_TIMEOUT has a 10m buffer over DEPLOYMENT_TIMEOUT so the deployment
       # loop can produce a graceful t.Fatalf before Go's test timer panics.
       run: |
         export DEPLOYMENT_TIMEOUT="${TEST_TIMEOUT_MINUTES}m"
-        export DEPLOY_CRS_TIMEOUT="$((TEST_TIMEOUT_MINUTES + 10))m"
-        export DELETION_TIMEOUT="${TEST_TIMEOUT_MINUTES}m"
+        export GO_STEP_DEPLOY_CRS_TIMEOUT="$((TEST_TIMEOUT_MINUTES + 10))m"
+        export GO_STEP_DELETION_TIMEOUT="${TEST_TIMEOUT_MINUTES}m"
         make test-all
       continue-on-error: true
       id: phase3

--- a/.github/workflows/workload-cluster-rosa.yml
+++ b/.github/workflows/workload-cluster-rosa.yml
@@ -94,7 +94,7 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 280  # DEPLOY_CRS_TIMEOUT (130m) + DELETION_TIMEOUT (120m) + overhead (30m)
+    timeout-minutes: 280  # GO_STEP_DEPLOY_CRS_TIMEOUT (130m) + GO_STEP_DELETION_TIMEOUT (120m) + overhead (30m)
     environment: ${{ inputs.environment || 'rosa-stage' }}
     env:
       # Cluster mode selection
@@ -255,12 +255,12 @@ jobs:
 
     - name: 'Run test-all'
       # AWS credentials and config are set at job level (see env: above)
-      # DEPLOY_CRS_TIMEOUT has a 10m buffer over DEPLOYMENT_TIMEOUT so the deployment
+      # GO_STEP_DEPLOY_CRS_TIMEOUT has a 10m buffer over DEPLOYMENT_TIMEOUT so the deployment
       # loop can produce a graceful t.Fatalf before Go's test timer panics.
       run: |
         export DEPLOYMENT_TIMEOUT="${TEST_TIMEOUT_MINUTES}m"
-        export DEPLOY_CRS_TIMEOUT="$((TEST_TIMEOUT_MINUTES + 10))m"
-        export DELETION_TIMEOUT="${TEST_TIMEOUT_MINUTES}m"
+        export GO_STEP_DEPLOY_CRS_TIMEOUT="$((TEST_TIMEOUT_MINUTES + 10))m"
+        export GO_STEP_DELETION_TIMEOUT="${TEST_TIMEOUT_MINUTES}m"
         make test-all
       continue-on-error: true
       id: phase3

--- a/Makefile
+++ b/Makefile
@@ -60,13 +60,13 @@ endif
 # Set to -v for verbose output (default), or empty string for quiet output
 TEST_VERBOSITY ?= -v
 
-# Test timeout configuration
+# Test timeout configuration — Go's -timeout flag (process-level hard kill)
 # Individual phase timeouts (format: Go duration like 30m, 1h, etc.)
-CLUSTER_TIMEOUT ?= 30m
-GENERATE_YAMLS_TIMEOUT ?= 20m
-DEPLOY_CRS_TIMEOUT ?= 105m
-VERIFY_TIMEOUT ?= 20m
-DELETION_TIMEOUT ?= 60m
+GO_STEP_CLUSTER_TIMEOUT ?= 30m
+GO_STEP_GENERATE_YAMLS_TIMEOUT ?= 20m
+GO_STEP_DEPLOY_CRS_TIMEOUT ?= 105m
+GO_STEP_VERIFY_TIMEOUT ?= 20m
+GO_STEP_DELETION_TIMEOUT ?= 60m
 
 # Results directory configuration
 # Create unique results directory for each test run using timestamp
@@ -188,7 +188,7 @@ _management_cluster: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-cluster.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestExternalCluster|TestKindCluster" -timeout $(CLUSTER_TIMEOUT) -failfast || EXIT_CODE=$$?; \
+	TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-cluster.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestExternalCluster|TestKindCluster" -timeout $(GO_STEP_CLUSTER_TIMEOUT) -failfast || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	cp -f $(RESULTS_DIR)/*.log $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
@@ -209,7 +209,7 @@ _generate-yamls: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-generate-yamls.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestInfrastructure -timeout $(GENERATE_YAMLS_TIMEOUT) || EXIT_CODE=$$?; \
+	TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-generate-yamls.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestInfrastructure -timeout $(GO_STEP_GENERATE_YAMLS_TIMEOUT) || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	cp -f $(RESULTS_DIR)/*.log $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
@@ -231,11 +231,11 @@ _deploy-crs: check-gotestsum
 	@echo ""
 	@EXIT_CODE=0; \
 	echo "--- Phase 1: Apply resources (fail-fast) ---"; \
-	TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-apply.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestDeployment_0|TestDeployment_Apply|TestDeployment_Provider" -timeout $(DEPLOY_CRS_TIMEOUT) -failfast || EXIT_CODE=$$?; \
+	TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-apply.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestDeployment_0|TestDeployment_Apply|TestDeployment_Provider" -timeout $(GO_STEP_DEPLOY_CRS_TIMEOUT) -failfast || EXIT_CODE=$$?; \
 	if [ $$EXIT_CODE -eq 0 ]; then \
 		echo ""; \
 		echo "--- Phase 2: Monitor deployment ---"; \
-		TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-monitor.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestDeployment_Monitor|TestDeployment_Wait|TestDeployment_Verify|TestDeployment_Tag" -timeout $(DEPLOY_CRS_TIMEOUT) || EXIT_CODE=$$?; \
+		TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-monitor.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestDeployment_Monitor|TestDeployment_Wait|TestDeployment_Verify|TestDeployment_Tag" -timeout $(GO_STEP_DEPLOY_CRS_TIMEOUT) || EXIT_CODE=$$?; \
 	fi; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
@@ -257,7 +257,7 @@ _verify-workload-cluster: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-verify.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestVerification -timeout $(VERIFY_TIMEOUT) || EXIT_CODE=$$?; \
+	TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-verify.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestVerification -timeout $(GO_STEP_VERIFY_TIMEOUT) || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	cp -f $(RESULTS_DIR)/*.log $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
@@ -278,7 +278,7 @@ _delete-workload-cluster: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-delete.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestDeletion -timeout $(DELETION_TIMEOUT) || EXIT_CODE=$$?; \
+	TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-delete.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestDeletion -timeout $(GO_STEP_DELETION_TIMEOUT) || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	cp -f $(RESULTS_DIR)/*.log $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \

--- a/README.md
+++ b/README.md
@@ -177,17 +177,17 @@ The test suite validates naming compliance during the Check Dependencies phase (
 
 #### Makefile Timeout Variables
 
-Individual test phase timeouts can be overridden via Makefile variables:
+Individual test phase timeouts control Go's `-timeout` flag (process-level hard kill) and can be overridden via Makefile variables:
 
 | Variable | Default | Phase |
 |----------|---------|-------|
-| `CLUSTER_TIMEOUT` | `30m` | Management cluster deployment |
-| `GENERATE_YAMLS_TIMEOUT` | `20m` | YAML generation |
-| `DEPLOY_CRS_TIMEOUT` | `60m` | CR deployment and monitoring |
-| `VERIFY_TIMEOUT` | `20m` | Workload cluster verification |
-| `DELETION_TIMEOUT` | `60m` | Workload cluster deletion |
+| `GO_STEP_CLUSTER_TIMEOUT` | `30m` | Management cluster deployment |
+| `GO_STEP_GENERATE_YAMLS_TIMEOUT` | `20m` | YAML generation |
+| `GO_STEP_DEPLOY_CRS_TIMEOUT` | `60m` | CR deployment and monitoring |
+| `GO_STEP_VERIFY_TIMEOUT` | `20m` | Workload cluster verification |
+| `GO_STEP_DELETION_TIMEOUT` | `60m` | Workload cluster deletion |
 
-Example: `DEPLOY_CRS_TIMEOUT=90m make _deploy-crs`
+Example: `GO_STEP_DEPLOY_CRS_TIMEOUT=90m make _deploy-crs`
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Individual test phase timeouts control Go's `-timeout` flag (process-level hard 
 |----------|---------|-------|
 | `GO_STEP_CLUSTER_TIMEOUT` | `30m` | Management cluster deployment |
 | `GO_STEP_GENERATE_YAMLS_TIMEOUT` | `20m` | YAML generation |
-| `GO_STEP_DEPLOY_CRS_TIMEOUT` | `60m` | CR deployment and monitoring |
+| `GO_STEP_DEPLOY_CRS_TIMEOUT` | `105m` | CR deployment and monitoring |
 | `GO_STEP_VERIFY_TIMEOUT` | `20m` | Workload cluster verification |
 | `GO_STEP_DELETION_TIMEOUT` | `60m` | Workload cluster deletion |
 


### PR DESCRIPTION
## Description

Clarify the purpose of Makefile timeout variables by renaming them with a `GO_STEP_` prefix. These variables control Go's `-timeout` flag (process-level hard kill), not the in-code polling timeouts like `DEPLOYMENT_TIMEOUT`.

JIRA: https://redhat.atlassian.net/browse/ARO-27600

## Changes Made

- Rename `CLUSTER_TIMEOUT` → `GO_STEP_CLUSTER_TIMEOUT`
- Rename `GENERATE_YAMLS_TIMEOUT` → `GO_STEP_GENERATE_YAMLS_TIMEOUT`
- Rename `DEPLOY_CRS_TIMEOUT` → `GO_STEP_DEPLOY_CRS_TIMEOUT`
- Rename `VERIFY_TIMEOUT` → `GO_STEP_VERIFY_TIMEOUT`
- Rename `DELETION_TIMEOUT` → `GO_STEP_DELETION_TIMEOUT`
- Update GHA workflow files (ARO + ROSA) with new variable names
- Update README.md documentation table and example

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `GO_STEP_CLUSTER_TIMEOUT` | Go -timeout for management cluster phase (was `CLUSTER_TIMEOUT`) | `30m` |
| `GO_STEP_GENERATE_YAMLS_TIMEOUT` | Go -timeout for YAML generation phase (was `GENERATE_YAMLS_TIMEOUT`) | `20m` |
| `GO_STEP_DEPLOY_CRS_TIMEOUT` | Go -timeout for CR deployment phase (was `DEPLOY_CRS_TIMEOUT`) | `105m` |
| `GO_STEP_VERIFY_TIMEOUT` | Go -timeout for verification phase (was `VERIFY_TIMEOUT`) | `20m` |
| `GO_STEP_DELETION_TIMEOUT` | Go -timeout for deletion phase (was `DELETION_TIMEOUT`) | `60m` |

## Additional Notes

Rename only — no logic changes. All defaults remain the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved test timeout configuration in CI/CD workflows to clarify phase-specific timeout handling and buffer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->