### PR TITLE
CAPZ: Extract MSI_RESOURCEGROUPNAME from Boskos-leased MSI containers

### DIFF
--- a/openshift-ci/capz-test-env.sh
+++ b/openshift-ci/capz-test-env.sh
@@ -58,6 +58,16 @@ export INFRA_PROVIDER CAPI_USER DEPLOYMENT_ENV
 export REGION
 : "${OPERATORS_UAMIS_SUFFIX_FILE:=/tmp/operators-uamis-suffix.txt}"
 export OPERATORS_UAMIS_SUFFIX_FILE
+
+# Use pre-existing MSI identities from a Boskos-leased container resource group.
+# LEASED_MSI_CONTAINERS is set by Prow from the aro-hcp-test-msi-containers-stg pool;
+# each value is an Azure RG pre-provisioned with bare-named managed identities.
+# CAPZ leases one container per job — take the first (and only) entry.
+if [[ -n "${LEASED_MSI_CONTAINERS:-}" ]]; then
+  read -r MSI_RESOURCEGROUPNAME _ <<< "${LEASED_MSI_CONTAINERS}"
+  export MSI_RESOURCEGROUPNAME
+  echo "[capz-test-env] Using pre-existing MSI from Boskos pool: ${MSI_RESOURCEGROUPNAME}"
+fi
 : "${ARO_REPO_URL:=https://github.com/stolostron/cluster-api-installer.git}"
 : "${ARO_REPO_BRANCH:=main}"
 : "${ARO_REPO_DIR:=/tmp/cluster-api-installer-aro}"


### PR DESCRIPTION
## Summary
- When `LEASED_MSI_CONTAINERS` is set by Prow (from `aro-hcp-test-msi-containers-stg` pool), extract the first resource group name and export it as `MSI_RESOURCEGROUPNAME`
- This triggers `gen.sh` to use pre-existing bare-named identities from the Boskos pool and skip dynamic `UserAssignedIdentity` + `RoleAssignment` creation via ASO
- Fixes the CI hang where the SP lacks `Microsoft.Authorization/roleAssignments/delete` permission, causing ASO to loop forever on cleanup

## Related
- Jira: ARO-27593
- cluster-api-installer fork: https://github.com/marek-veber/cluster-api-installer/tree/ARO-27593-use-msi-ci-resources
- openshift/release PR: https://github.com/openshift/release/pull/80110

## Test plan
- [ ] Verify `MSI_RESOURCEGROUPNAME` is correctly extracted from `LEASED_MSI_CONTAINERS` in CI logs
- [ ] Verify generated `aro.yaml` contains no `UserAssignedIdentity` or `RoleAssignment` resources
- [ ] Verify workload cluster deletion completes without 403 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI test environment configuration to support pre-existing managed identity resources for enhanced testing flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->