### PR TITLE
feat: centralize vault credential loading in capz-test-env.sh (ARO-27593)

### DIFF
--- a/openshift-ci/capz-test-env.sh
+++ b/openshift-ci/capz-test-env.sh
@@ -18,8 +18,7 @@ if [[ -n "${CLUSTER_PROFILE_DIR:-}" && -f "${CLUSTER_PROFILE_DIR}/osServicePrinc
     fi
   done
   export AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
-  echo "[capz-test-env] Azure credentials loaded from cluster profile"
-  set -o xtrace
+  echo "[capz-test-env] Azure credentials loaded from cluster profile from: ${CLUSTER_PROFILE_DIR}/osServicePrincipal.json"
 fi
 
 # Override with CAPZ-specific Azure credentials from Vault (when available).
@@ -42,9 +41,25 @@ if [[ -d "${CAPZ_CREDS_DIR}" && -f "${CAPZ_CREDS_DIR}/AZURE_CLIENT_ID" ]]; then
     fi
   done
   export AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
-  echo "[capz-test-env] Azure credentials overridden with CAPZ vault credentials"
-  set -o xtrace
+  echo "[capz-test-env] Azure credentials overridden with CAPZ vault credentials from $CAPZ_CREDS_DIR"
 fi
+
+
+if [[ -n "${VAULT_SECRET_PROFILE:-}" && -d "/var/run/aro-hcp-${VAULT_SECRET_PROFILE:-}" ]] ; then
+    export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+    { set +o xtrace; } 2>/dev/null
+    AZURE_CLIENT_ID="$(cat "${CLUSTER_PROFILE_DIR}/client-id")"
+    AZURE_CLIENT_SECRET="$(cat "${CLUSTER_PROFILE_DIR}/client-secret")"
+    AZURE_TENANT_ID="$(cat "${CLUSTER_PROFILE_DIR}/tenant")"
+    AZURE_SUBSCRIPTION_ID="$(cat "${CLUSTER_PROFILE_DIR}/subscription-id")"
+    export AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
+    echo "[capz-test-env] Azure credentials overridden with CAPZ vault credentials from ${CLUSTER_PROFILE_DIR}"
+fi
+
+
+set -o xtrace
+: "${GOCACHE:=/tmp/go-cache}"
+export GOCACHE
 
 : "${INFRA_PROVIDER:=aro}"
 : "${CAPI_USER:=prow}"
@@ -105,6 +120,17 @@ else
   echo "$RESOURCEGROUPNAME" > "$RESOURCEGROUPNAME_FILE"
 fi
 
+# Extract MSI resource group from Boskos lease (when available).
+# LEASED_MSI_CONTAINERS is set by Prow when the aro-hcp-test-msi-containers-*
+# lease is acquired; the first word is the resource group name.
+if [[ -n "${LEASED_MSI_CONTAINERS:-}" && -z "${MSI_RESOURCEGROUPNAME:-}" ]]; then
+  read -r MSI_RESOURCEGROUPNAME _ <<< "${LEASED_MSI_CONTAINERS}"
+  export MSI_RESOURCEGROUPNAME
+  echo "[capz-test-env] Using pre-existing MSI from Boskos pool: ${MSI_RESOURCEGROUPNAME}"
+fi
+
 # WORKLOAD_CLUSTER_NAMESPACE is set at the steps.env level in the ci-operator
 # config, so all steps share the same fixed namespace without needing to pass
 # it through SHARED_DIR files.
+
+{ set +o xtrace; } 2>/dev/null

--- a/openshift-ci/capz-test-env.sh
+++ b/openshift-ci/capz-test-env.sh
@@ -44,18 +44,22 @@ if [[ -d "${CAPZ_CREDS_DIR}" && -f "${CAPZ_CREDS_DIR}/AZURE_CLIENT_ID" ]]; then
   echo "[capz-test-env] Azure credentials overridden with CAPZ vault credentials from $CAPZ_CREDS_DIR"
 fi
 
-
-if [[ -n "${VAULT_SECRET_PROFILE:-}" && -d "/var/run/aro-hcp-${VAULT_SECRET_PROFILE:-}" ]] ; then
-    export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
-    { set +o xtrace; } 2>/dev/null
-    AZURE_CLIENT_ID="$(cat "${CLUSTER_PROFILE_DIR}/client-id")"
-    AZURE_CLIENT_SECRET="$(cat "${CLUSTER_PROFILE_DIR}/client-secret")"
-    AZURE_TENANT_ID="$(cat "${CLUSTER_PROFILE_DIR}/tenant")"
-    AZURE_SUBSCRIPTION_ID="$(cat "${CLUSTER_PROFILE_DIR}/subscription-id")"
-    export AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
-    echo "[capz-test-env] Azure credentials overridden with CAPZ vault credentials from ${CLUSTER_PROFILE_DIR}"
+if [[ -n "${VAULT_SECRET_PROFILE:-}" && -d "/var/run/aro-hcp-${VAULT_SECRET_PROFILE}" ]]; then
+  export CLUSTER_PROFILE_DIR="/var/run/aro-hcp-${VAULT_SECRET_PROFILE}"
+  { set +o xtrace; } 2>/dev/null
+  AZURE_CLIENT_ID="$(cat "${CLUSTER_PROFILE_DIR}/client-id")"
+  AZURE_CLIENT_SECRET="$(cat "${CLUSTER_PROFILE_DIR}/client-secret")"
+  AZURE_TENANT_ID="$(cat "${CLUSTER_PROFILE_DIR}/tenant")"
+  AZURE_SUBSCRIPTION_ID="$(cat "${CLUSTER_PROFILE_DIR}/subscription-id")"
+  for var in AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID; do
+    if [[ -z "${!var}" || "${!var}" == "null" ]]; then
+      echo "[capz-test-env] ERROR: ${var} is missing or null in ${CLUSTER_PROFILE_DIR}" >&2
+      exit 1
+    fi
+  done
+  export AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
+  echo "[capz-test-env] Azure credentials overridden with CAPZ vault credentials from ${CLUSTER_PROFILE_DIR}"
 fi
-
 
 set -o xtrace
 : "${GOCACHE:=/tmp/go-cache}"


### PR DESCRIPTION
## Description

Centralize vault credential loading and shared env setup in capz-test-env.sh so step scripts
don't need to duplicate the credential block before every `source openshift-ci/capz-test-env.sh`.

Related: https://github.com/openshift/release/pull/80110

## Changes Made

- Add VAULT_SECRET_PROFILE (aro-hcp-*) credential loading to capz-test-env.sh with nounset-safe checks
- Move `set -o xtrace` control to the calling script — capz-test-env.sh no longer re-enables it
- Add `GOCACHE=/tmp/go-cache` default export
- Add `MSI_RESOURCEGROUPNAME` extraction from Boskos lease (`LEASED_MSI_CONTAINERS`)

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| VAULT_SECRET_PROFILE | Selects aro-hcp-{int,stg,prod} credential mount | (unset) |
| GOCACHE | Go build cache directory | /tmp/go-cache |
| MSI_RESOURCEGROUPNAME | Resource group from Boskos MSI lease | (auto from LEASED_MSI_CONTAINERS) |

## Additional Notes

This eliminates the credential-loading preamble duplicated across ~10 step scripts in openshift/release#80110.
Step scripts now only need `source openshift-ci/capz-test-env.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Azure credential sourcing and validation in CI infrastructure
  * Improved environment variable management and initialization during test setup
  * Refined script execution control and logging for better diagnostics
  * Optimized credential override behavior for vault-mounted configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->