### PR TITLE
fix: fall back GOCACHE to /tmp/go-cache when parent dir is not writable (ARO-27593)

### DIFF
--- a/openshift-ci/capz-test-env.sh
+++ b/openshift-ci/capz-test-env.sh
@@ -63,7 +63,7 @@ fi
 
 set -o xtrace
 : "${GOCACHE:=/tmp/go-cache}"
-if [[ ! -w "${GOCACHE%/*}" ]]; then
+if [[ ! -w "$(dirname "$GOCACHE")" ]]; then
   GOCACHE=/tmp/go-cache
 fi
 export GOCACHE

--- a/openshift-ci/capz-test-env.sh
+++ b/openshift-ci/capz-test-env.sh
@@ -64,6 +64,7 @@ fi
 set -o xtrace
 : "${GOCACHE:=/tmp/go-cache}"
 if [[ ! -w "$(dirname "$GOCACHE")" ]]; then
+  echo "[capz-test-env] GOCACHE parent directory not writable, falling back to /tmp/go-cache" >&2
   GOCACHE=/tmp/go-cache
 fi
 export GOCACHE

--- a/openshift-ci/capz-test-env.sh
+++ b/openshift-ci/capz-test-env.sh
@@ -63,6 +63,9 @@ fi
 
 set -o xtrace
 : "${GOCACHE:=/tmp/go-cache}"
+if [[ ! -w "${GOCACHE%/*}" ]]; then
+  GOCACHE=/tmp/go-cache
+fi
 export GOCACHE
 
 : "${INFRA_PROVIDER:=aro}"


### PR DESCRIPTION
## Description

Fall back GOCACHE to `/tmp/go-cache` when the parent directory of the current value is not writable.

Related: https://github.com/openshift/release/pull/80110

## Changes Made

- Add writability check for GOCACHE parent directory in capz-test-env.sh
- If the parent dir (e.g. `~/.cache`) is not writable (read-only home in CI containers), override to `/tmp/go-cache`

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| GOCACHE | Go build cache directory | /tmp/go-cache (fallback when parent not writable) |

## Additional Notes

In Prow CI containers the home directory may be read-only, causing Go's default `~/.cache/go-build` to fail. This ensures builds work regardless of home dir permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI environment validation to ensure the Go cache location is set to a writable directory.

* **Bug Fixes**
  * Prevented cache-related failures in CI by forcing a writable Go cache path when the computed location is not writable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->