### PR TITLE
fix: add --request-timeout to all kubectl get commands (ARO-24300)

### DIFF
--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -195,7 +195,7 @@ func TestCheckDependencies_ExternalKubeconfig(t *testing.T) {
 
 	// Validate kubectl can connect to the cluster
 	SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	output, err := RunCommand(t, "kubectl", "--context", context, "get", "nodes", "--no-headers")
+	output, err := RunCommand(t, "kubectl", "--context", context, "get", "nodes", "--no-headers", KubectlRequestTimeout)
 	if err != nil {
 		t.Fatalf("Cannot connect to external cluster with context '%s': %v\n\nEnsure the cluster is accessible and credentials are valid.", context, err)
 	}

--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -706,15 +706,15 @@ func TestKindCluster_CAPIControllerReady(t *testing.T) {
 
 			// Dump diagnostic info to help identify the root cause
 			PrintToTTY("=== Diagnostic: pod status in %s ===\n", config.CAPINamespace)
-			if podOutput, podErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, KubectlRequestTimeout, "get", "pods", "-o", "wide"); podErr == nil {
+			if podOutput, podErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, KubectlDiagnosticTimeout, "get", "pods", "-o", "wide"); podErr == nil {
 				PrintToTTY("%s\n", podOutput)
 			}
 			PrintToTTY("=== Diagnostic: pod descriptions in %s ===\n", config.CAPINamespace)
-			if descOutput, descErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, KubectlRequestTimeout, "describe", "pods"); descErr == nil {
+			if descOutput, descErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, KubectlDiagnosticTimeout, "describe", "pods"); descErr == nil {
 				PrintToTTY("%s\n", descOutput)
 			}
 			PrintToTTY("=== Diagnostic: events in %s ===\n", config.CAPINamespace)
-			if evtOutput, evtErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, KubectlRequestTimeout, "get", "events", "--sort-by=.lastTimestamp"); evtErr == nil {
+			if evtOutput, evtErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, KubectlDiagnosticTimeout, "get", "events", "--sort-by=.lastTimestamp"); evtErr == nil {
 				PrintToTTY("%s\n", evtOutput)
 			}
 
@@ -814,15 +814,15 @@ func TestKindCluster_InfraControllersReady(t *testing.T) {
 
 						// Dump diagnostic info to help identify the root cause
 						PrintToTTY("=== Diagnostic: pod status in %s ===\n", ctrl.Namespace)
-						if podOutput, podErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, KubectlRequestTimeout, "get", "pods", "-o", "wide"); podErr == nil {
+						if podOutput, podErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, KubectlDiagnosticTimeout, "get", "pods", "-o", "wide"); podErr == nil {
 							PrintToTTY("%s\n", podOutput)
 						}
 						PrintToTTY("=== Diagnostic: pod descriptions in %s ===\n", ctrl.Namespace)
-						if descOutput, descErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, KubectlRequestTimeout, "describe", "pods"); descErr == nil {
+						if descOutput, descErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, KubectlDiagnosticTimeout, "describe", "pods"); descErr == nil {
 							PrintToTTY("%s\n", descOutput)
 						}
 						PrintToTTY("=== Diagnostic: events in %s ===\n", ctrl.Namespace)
-						if evtOutput, evtErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, KubectlRequestTimeout, "get", "events", "--sort-by=.lastTimestamp"); evtErr == nil {
+						if evtOutput, evtErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, KubectlDiagnosticTimeout, "get", "events", "--sort-by=.lastTimestamp"); evtErr == nil {
 							PrintToTTY("%s\n", evtOutput)
 						}
 

--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -34,7 +34,7 @@ func TestExternalCluster_01_Connectivity(t *testing.T) {
 	PrintToTTY("Kubeconfig: %s\n", config.UseKubeconfig)
 	PrintToTTY("Context: %s\n\n", context)
 
-	output, err := RunCommand(t, "kubectl", "--context", context, "get", "nodes")
+	output, err := RunCommand(t, "kubectl", "--context", context, "get", "nodes", KubectlRequestTimeout)
 	if err != nil {
 		PrintToTTY("❌ Failed to connect to external cluster: %v\n", err)
 		t.Fatalf("Cannot connect to external cluster: %v", err)
@@ -526,7 +526,7 @@ func TestKindCluster_01_ClusterReady(t *testing.T) {
 		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
 	}
 
-	output, err = RunCommand(t, "kubectl", "--context", config.GetKubeContext(), "get", "nodes")
+	output, err = RunCommand(t, "kubectl", "--context", config.GetKubeContext(), "get", "nodes", KubectlRequestTimeout)
 	if err != nil {
 		PrintToTTY("❌ Failed to access management cluster nodes: %v\nOutput: %s\n\n", err, output)
 		t.Errorf("Failed to access management cluster nodes: %v\nOutput: %s", err, output)
@@ -579,7 +579,7 @@ func TestKindCluster_02_ControllersInstalled(t *testing.T) {
 	for _, ctrl := range config.AllControllers() {
 		PrintToTTY("Checking %s controller manager...\n", ctrl.DisplayName)
 		_, err := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace,
-			"get", "deployment", ctrl.DeploymentName)
+			"get", "deployment", ctrl.DeploymentName, KubectlRequestTimeout)
 		if err != nil {
 			PrintToTTY("❌ %s controller not found in %s namespace\n", ctrl.DisplayName, ctrl.Namespace)
 			allFound = false
@@ -645,7 +645,7 @@ func TestKindCluster_CAPINamespacesExists(t *testing.T) {
 	for _, ns := range config.AllNamespaces() {
 		PrintToTTY("Checking namespace: %s...\n", ns)
 
-		_, err := RunCommand(t, "kubectl", "--context", context, "get", "namespace", ns)
+		_, err := RunCommand(t, "kubectl", "--context", context, "get", "namespace", ns, KubectlRequestTimeout)
 		if err != nil {
 			PrintToTTY("⚠️  Namespace '%s' may not exist yet (this might be expected): %v\n", ns, err)
 			t.Logf("Namespace '%s' may not exist yet (this might be expected): %v", ns, err)
@@ -663,7 +663,7 @@ func TestKindCluster_CAPINamespacesExists(t *testing.T) {
 	PrintToTTY("\n=== Checking for CAPI pods ===\n")
 	PrintToTTY("Running: kubectl get pods -A --selector=cluster.x-k8s.io/provider\n")
 
-	output, err := RunCommand(t, "kubectl", "--context", context, "get", "pods", "-A", "--selector=cluster.x-k8s.io/provider")
+	output, err := RunCommand(t, "kubectl", "--context", context, "get", "pods", "-A", "--selector=cluster.x-k8s.io/provider", KubectlRequestTimeout)
 	if err != nil {
 		PrintToTTY("⚠️  CAPI pods check failed: %v\nOutput: %s\n\n", err, output)
 		t.Logf("CAPI pods check: %v\nOutput: %s", err, output)
@@ -706,15 +706,15 @@ func TestKindCluster_CAPIControllerReady(t *testing.T) {
 
 			// Dump diagnostic info to help identify the root cause
 			PrintToTTY("=== Diagnostic: pod status in %s ===\n", config.CAPINamespace)
-			if podOutput, podErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, "--request-timeout=30s", "get", "pods", "-o", "wide"); podErr == nil {
+			if podOutput, podErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, KubectlRequestTimeout, "get", "pods", "-o", "wide"); podErr == nil {
 				PrintToTTY("%s\n", podOutput)
 			}
 			PrintToTTY("=== Diagnostic: pod descriptions in %s ===\n", config.CAPINamespace)
-			if descOutput, descErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, "--request-timeout=30s", "describe", "pods"); descErr == nil {
+			if descOutput, descErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, KubectlRequestTimeout, "describe", "pods"); descErr == nil {
 				PrintToTTY("%s\n", descOutput)
 			}
 			PrintToTTY("=== Diagnostic: events in %s ===\n", config.CAPINamespace)
-			if evtOutput, evtErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, "--request-timeout=30s", "get", "events", "--sort-by=.lastTimestamp"); evtErr == nil {
+			if evtOutput, evtErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace, KubectlRequestTimeout, "get", "events", "--sort-by=.lastTimestamp"); evtErr == nil {
 				PrintToTTY("%s\n", evtOutput)
 			}
 
@@ -733,7 +733,8 @@ func TestKindCluster_CAPIControllerReady(t *testing.T) {
 
 		output, err := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace,
 			"get", "deployment", CAPIControllerDeployment,
-			"-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}")
+			"-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}",
+			KubectlRequestTimeout)
 
 		if err != nil {
 			PrintToTTY("[%d] ⚠️  Status check failed: %v\n", iteration, err)
@@ -750,7 +751,8 @@ func TestKindCluster_CAPIControllerReady(t *testing.T) {
 					PrintToTTY("Checking mce-capi-webhook-config deployment...\n")
 					mceOutput, mceErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace,
 						"get", "deployment", "mce-capi-webhook-config",
-						"-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}")
+						"-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}",
+						KubectlRequestTimeout)
 					if mceErr != nil {
 						PrintToTTY("⚠️  MCE webhook config check failed: %v\n", mceErr)
 					} else if strings.TrimSpace(mceOutput) == "True" {
@@ -812,15 +814,15 @@ func TestKindCluster_InfraControllersReady(t *testing.T) {
 
 						// Dump diagnostic info to help identify the root cause
 						PrintToTTY("=== Diagnostic: pod status in %s ===\n", ctrl.Namespace)
-						if podOutput, podErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, "--request-timeout=30s", "get", "pods", "-o", "wide"); podErr == nil {
+						if podOutput, podErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, KubectlRequestTimeout, "get", "pods", "-o", "wide"); podErr == nil {
 							PrintToTTY("%s\n", podOutput)
 						}
 						PrintToTTY("=== Diagnostic: pod descriptions in %s ===\n", ctrl.Namespace)
-						if descOutput, descErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, "--request-timeout=30s", "describe", "pods"); descErr == nil {
+						if descOutput, descErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, KubectlRequestTimeout, "describe", "pods"); descErr == nil {
 							PrintToTTY("%s\n", descOutput)
 						}
 						PrintToTTY("=== Diagnostic: events in %s ===\n", ctrl.Namespace)
-						if evtOutput, evtErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, "--request-timeout=30s", "get", "events", "--sort-by=.lastTimestamp"); evtErr == nil {
+						if evtOutput, evtErr := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace, KubectlRequestTimeout, "get", "events", "--sort-by=.lastTimestamp"); evtErr == nil {
 							PrintToTTY("%s\n", evtOutput)
 						}
 
@@ -839,7 +841,8 @@ func TestKindCluster_InfraControllersReady(t *testing.T) {
 
 					output, err := RunCommand(t, "kubectl", "--context", context, "-n", ctrl.Namespace,
 						"get", "deployment", ctrl.DeploymentName,
-						"-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}")
+						"-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}",
+						KubectlRequestTimeout)
 
 					if err != nil {
 						PrintToTTY("[%d] ⚠️  Status check failed: %v\n", iteration, err)
@@ -944,7 +947,8 @@ func TestKindCluster_WebhooksReady(t *testing.T) {
 			// First check if endpoint exists and has addresses
 			endpointOutput, err := RunCommandQuiet(t, "kubectl", "--context", context,
 				"get", "endpoints", wh.ServiceName, "-n", wh.Namespace,
-				"-o", "jsonpath={.subsets[0].addresses[0].ip}")
+				"-o", "jsonpath={.subsets[0].addresses[0].ip}",
+				KubectlRequestTimeout)
 
 			if err != nil || strings.TrimSpace(endpointOutput) == "" {
 				PrintToTTY("[%d] ⏳ Waiting for %s endpoint to have addresses...\n", iteration, wh.DisplayName)

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -36,7 +36,7 @@ func TestDeployment_00_CreateNamespace(t *testing.T) {
 	PrintToTTY("Context: %s\n\n", context)
 
 	// Check if namespace already exists
-	_, err := RunCommandQuiet(t, "kubectl", "--context", context, "get", "namespace", config.WorkloadClusterNamespace)
+	_, err := RunCommandQuiet(t, "kubectl", "--context", context, "get", "namespace", config.WorkloadClusterNamespace, KubectlRequestTimeout)
 	if err == nil {
 		PrintToTTY("✅ Namespace '%s' already exists\n\n", config.WorkloadClusterNamespace)
 		t.Logf("Namespace '%s' already exists", config.WorkloadClusterNamespace)
@@ -301,7 +301,7 @@ func TestDeployment_ProviderCredentialsConfigured(t *testing.T) {
 			// Check if secret exists
 			PrintToTTY("Checking if %s secret exists...\n", secretName)
 			_, err := RunCommandQuiet(t, "kubectl", "--context", context, "-n", secretNamespace,
-				"get", "secret", secretName)
+				"get", "secret", secretName, KubectlRequestTimeout)
 			if err != nil {
 				PrintToTTY("❌ Secret '%s' not found in %s namespace\n", secretName, secretNamespace)
 				PrintToTTY("\nThe YAML generation did not create the credentials secret.\n")
@@ -316,7 +316,8 @@ func TestDeployment_ProviderCredentialsConfigured(t *testing.T) {
 			for _, field := range cred.RequiredFields {
 				output, err := RunCommandQuiet(t, "kubectl", "--context", context, "-n", secretNamespace,
 					"get", "secret", secretName,
-					"-o", fmt.Sprintf("jsonpath={.data.%s}", field))
+					"-o", fmt.Sprintf("jsonpath={.data.%s}", field),
+					KubectlRequestTimeout)
 
 				if err != nil || strings.TrimSpace(output) == "" {
 					missingFields = append(missingFields, field)
@@ -455,7 +456,7 @@ func TestDeployment_MonitorCluster(t *testing.T) {
 	PrintToTTY("\nChecking if cluster resource exists...\n")
 	t.Logf("Checking for cluster resource: %s (namespace: %s)", provisionedClusterName, config.WorkloadClusterNamespace)
 
-	output, err := RunCommand(t, "kubectl", "--context", context, "-n", config.WorkloadClusterNamespace, "get", "cluster", provisionedClusterName)
+	output, err := RunCommand(t, "kubectl", "--context", context, "-n", config.WorkloadClusterNamespace, "get", "cluster", provisionedClusterName, KubectlRequestTimeout)
 	if err != nil {
 		PrintToTTY("⚠️  Cluster resource not found (may not be deployed yet)\n\n")
 		t.Skipf("Cluster resource not found (may not be deployed yet): %v", err)

--- a/test/06_verification_test.go
+++ b/test/06_verification_test.go
@@ -72,7 +72,7 @@ func TestVerification_RetrieveKubeconfig(t *testing.T) {
 			attempt, maxRetries, context, config.WorkloadClusterNamespace, secretName)
 
 		output, secretErr = RunCommandQuiet(t, "kubectl", "--context", context, "-n", config.WorkloadClusterNamespace, "get", "secret",
-			secretName, "-o", "jsonpath={.data.value}")
+			secretName, "-o", "jsonpath={.data.value}", KubectlRequestTimeout)
 
 		if secretErr == nil && strings.TrimSpace(output) != "" {
 			t.Logf("Kubeconfig secret found on attempt %d", attempt)
@@ -232,7 +232,7 @@ func TestVerification_ClusterNodes(t *testing.T) {
 					os.Setenv("KUBECONFIG", oldKubeconfig)
 				}
 			}()
-			output, err := RunCommand(t, "kubectl", "get", "nodes")
+			output, err := RunCommand(t, "kubectl", "get", "nodes", KubectlRequestTimeout)
 
 			if err == nil {
 				PrintToTTY("%s\n\n", output)
@@ -313,7 +313,7 @@ func TestVerification_ClusterHealth(t *testing.T) {
 	// Check pods in kube-system namespace
 	t.Log("Checking system pods...")
 
-	output, err := RunCommand(t, "kubectl", "get", "pods", "-n", "kube-system")
+	output, err := RunCommand(t, "kubectl", "get", "pods", "-n", "kube-system", KubectlRequestTimeout)
 	if err != nil {
 		t.Logf("Failed to get system pods: %v\nOutput: %s", err, output)
 	} else {
@@ -321,7 +321,7 @@ func TestVerification_ClusterHealth(t *testing.T) {
 	}
 
 	// Check for any failing pods
-	output, err = RunCommand(t, "kubectl", "get", "pods", "-A", "--field-selector=status.phase!=Running,status.phase!=Succeeded")
+	output, err = RunCommand(t, "kubectl", "get", "pods", "-A", "--field-selector=status.phase!=Running,status.phase!=Succeeded", KubectlRequestTimeout)
 	if err == nil && strings.TrimSpace(output) != "" {
 		lines := strings.Split(output, "\n")
 		if len(lines) > 1 { // More than just header

--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -33,7 +33,7 @@ func TestDeletion_DeleteCluster(t *testing.T) {
 
 	// Check if cluster exists before attempting deletion
 	_, err := RunCommand(t, "kubectl", "--context", context, "-n", config.WorkloadClusterNamespace,
-		"get", "cluster", provisionedClusterName)
+		"get", "cluster", provisionedClusterName, KubectlRequestTimeout)
 	if err != nil {
 		PrintToTTY("⚠️  Cluster '%s' not found in namespace '%s'\n", provisionedClusterName, config.WorkloadClusterNamespace)
 		t.Skipf("Cluster '%s' not found (may not have been deployed or already deleted)", provisionedClusterName)
@@ -51,7 +51,8 @@ func TestDeletion_DeleteCluster(t *testing.T) {
 
 		// Check if ROSAControlPlane exists and whether it's already being deleted
 		output, cpErr := RunCommandQuiet(t, "kubectl", "--context", context, "-n", config.WorkloadClusterNamespace,
-			"get", "rosacontrolplane", controlPlaneName, "-o", "jsonpath={.metadata.deletionTimestamp}")
+			"get", "rosacontrolplane", controlPlaneName, "-o", "jsonpath={.metadata.deletionTimestamp}",
+			KubectlRequestTimeout)
 		if cpErr == nil {
 			if strings.TrimSpace(output) != "" {
 				PrintToTTY("⏳ ROSAControlPlane '%s' already being deleted (deletionTimestamp set)\n", controlPlaneName)
@@ -421,7 +422,7 @@ func TestDeletion_DeleteManagementClusterK8sTestNamespace(t *testing.T) {
 
 	// Check if namespace exists
 	output, err := RunCommandQuiet(t, "kubectl", "--context", context,
-		"get", "namespace", config.WorkloadClusterNamespace)
+		"get", "namespace", config.WorkloadClusterNamespace, KubectlRequestTimeout)
 	if err != nil {
 		errMsg := strings.ToLower(output + " " + err.Error())
 		if strings.Contains(errMsg, "not found") || strings.Contains(errMsg, "notfound") {
@@ -518,7 +519,7 @@ func TestDeletion_Summary(t *testing.T) {
 
 	// Check namespace status
 	nsOutput, nsErr := RunCommandQuiet(t, "kubectl", "--context", context,
-		"get", "namespace", config.WorkloadClusterNamespace)
+		"get", "namespace", config.WorkloadClusterNamespace, KubectlRequestTimeout)
 	if nsErr != nil {
 		errMsg := strings.ToLower(nsOutput + " " + nsErr.Error())
 		if strings.Contains(errMsg, "not found") || strings.Contains(errMsg, "notfound") {

--- a/test/08_cleanup_test.go
+++ b/test/08_cleanup_test.go
@@ -217,7 +217,7 @@ func TestCleanup_VerifyManagementClusterK8sTestNamespaceRemoval(t *testing.T) {
 	context := config.GetKubeContext()
 
 	output, err := RunCommandQuiet(t, "kubectl", "--context", context,
-		"get", "namespace", config.WorkloadClusterNamespace)
+		"get", "namespace", config.WorkloadClusterNamespace, KubectlRequestTimeout)
 	if err != nil {
 		errMsg := strings.ToLower(output + " " + err.Error())
 		if strings.Contains(errMsg, "not found") || strings.Contains(errMsg, "notfound") {

--- a/test/config.go
+++ b/test/config.go
@@ -61,6 +61,10 @@ const (
 	// DefaultControllerTimeout is the default timeout for waiting for a controller to become ready.
 	DefaultControllerTimeout = 10 * time.Minute
 
+	// KubectlRequestTimeout is the kubectl --request-timeout flag value for all kubectl get commands.
+	// Prevents individual API calls from hanging indefinitely when the API server is slow or unreachable.
+	KubectlRequestTimeout = "--request-timeout=120s"
+
 	// CAPI core constants (provider-independent)
 
 	// CAPIControllerDeployment is the CAPI core controller deployment name.

--- a/test/config.go
+++ b/test/config.go
@@ -61,9 +61,14 @@ const (
 	// DefaultControllerTimeout is the default timeout for waiting for a controller to become ready.
 	DefaultControllerTimeout = 10 * time.Minute
 
-	// KubectlRequestTimeout is the kubectl --request-timeout flag value for all kubectl get commands.
-	// Prevents individual API calls from hanging indefinitely when the API server is slow or unreachable.
+	// KubectlRequestTimeout is the kubectl --request-timeout flag value for kubectl read commands
+	// (get, describe). Prevents API calls from hanging when the API server is slow or unreachable.
 	KubectlRequestTimeout = "--request-timeout=120s"
+
+	// KubectlDiagnosticTimeout is a shorter kubectl --request-timeout for diagnostic dumps,
+	// health-check polling loops, and other contexts where a fast timeout is preferable to
+	// avoid extending failure paths or blocking retry loops.
+	KubectlDiagnosticTimeout = "--request-timeout=15s"
 
 	// CAPI core constants (provider-independent)
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1240,7 +1240,7 @@ func GetInfrastructureResourceStatus(t *testing.T, kubeContext, namespace, clust
 	var result InfrastructureResourceStatus
 
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext, "-n", namespace,
-		"get", "arocluster", clusterName, "-o", "jsonpath={.status}")
+		"get", "arocluster", clusterName, "-o", "jsonpath={.status}", KubectlRequestTimeout)
 	if err != nil || strings.TrimSpace(output) == "" {
 		return result
 	}
@@ -1423,7 +1423,7 @@ func DumpNotReadyResourceDiagnostics(t *testing.T, context, namespace string, no
 		condOutput, err := RunCommandQuiet(t, "kubectl", "--context", context, "-n", namespace,
 			"get", resourceType, r.Resource.Name,
 			"-o", "jsonpath={range .status.conditions[*]}{.type}: {.status} ({.reason}) {.message}{\"\\n\"}{end}",
-			"--request-timeout=10s")
+			KubectlRequestTimeout)
 		if err == nil && strings.TrimSpace(condOutput) != "" {
 			PrintToTTY("Conditions:\n%s\n", condOutput)
 			t.Logf("%s/%s conditions:\n%s", r.Resource.Kind, r.Resource.Name, condOutput)
@@ -1439,7 +1439,7 @@ func DumpNotReadyResourceDiagnostics(t *testing.T, context, namespace string, no
 			"get", "events",
 			"--field-selector", fmt.Sprintf("involvedObject.name=%s", r.Resource.Name),
 			"--sort-by=.lastTimestamp",
-			"--request-timeout=10s")
+			KubectlRequestTimeout)
 		if err == nil && strings.TrimSpace(evtOutput) != "" {
 			PrintToTTY("Events:\n%s\n", evtOutput)
 			t.Logf("%s/%s events:\n%s", r.Resource.Kind, r.Resource.Name, evtOutput)
@@ -1456,7 +1456,7 @@ func DumpNotReadyResourceDiagnostics(t *testing.T, context, namespace string, no
 	PrintToTTY("%s\n", nsHeader)
 	diagLog.WriteString(nsHeader + "\n")
 	evtOutput, err := RunCommandQuiet(t, "kubectl", "--context", context, "-n", namespace,
-		"get", "events", "--sort-by=.lastTimestamp", "--request-timeout=10s")
+		"get", "events", "--sort-by=.lastTimestamp", KubectlRequestTimeout)
 	if err == nil && strings.TrimSpace(evtOutput) != "" {
 		// Show last 30 lines to avoid flooding
 		lines := strings.Split(evtOutput, "\n")
@@ -2014,7 +2014,7 @@ func WaitForClusterHealthy(t *testing.T, kubeContext string, timeout time.Durati
 		// Try a simple kubectl command to check API server responsiveness
 		PrintToTTY("[%d] Checking API server responsiveness...\n", attempt)
 
-		_, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext, "get", "nodes", "--request-timeout=10s")
+		_, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext, "get", "nodes", KubectlRequestTimeout)
 		if err == nil {
 			PrintToTTY("✅ Cluster is healthy and responding\n\n")
 			t.Log("Cluster is healthy and responding")
@@ -2337,7 +2337,7 @@ func FormatAzureError(info *AzureErrorInfo) string {
 func RequireClusterResource(t *testing.T, kubeContext, namespace, clusterName string) {
 	t.Helper()
 
-	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext, "-n", namespace, "get", "cluster", clusterName)
+	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext, "-n", namespace, "get", "cluster", clusterName, KubectlRequestTimeout)
 	if err != nil {
 		errText := strings.ToLower(output + " " + err.Error())
 		if strings.Contains(errText, "not found") || strings.Contains(errText, "no resources found") {
@@ -2489,7 +2489,8 @@ func GetDeploymentImage(t *testing.T, kubeContext, namespace, deploymentName str
 
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
 		"-n", namespace, "get", "deployment", deploymentName,
-		"-o", "jsonpath={.spec.template.spec.containers[0].image}")
+		"-o", "jsonpath={.spec.template.spec.containers[0].image}",
+		KubectlRequestTimeout)
 	if err != nil {
 		return "", fmt.Errorf("failed to get deployment image: %w", err)
 	}
@@ -3028,7 +3029,7 @@ func CheckPodsForImagePullErrors(t *testing.T, kubeContext, namespace string) er
 	t.Helper()
 
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
-		"-n", namespace, "--request-timeout=10s",
+		"-n", namespace, KubectlRequestTimeout,
 		"get", "pods",
 		"-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\t\"}{range .status.containerStatuses[*]}{.state.waiting.reason}{\" \"}{end}{range .status.initContainerStatuses[*]}{.state.waiting.reason}{\" \"}{end}{\"\\n\"}{end}")
 	if err != nil {
@@ -3562,7 +3563,7 @@ func GetDeletionResourceStatus(t *testing.T, kubeContext, namespace, clusterName
 		finalizerOutput, finErr := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
 			"-n", namespace, "get", "cluster", clusterName,
 			"-o", "jsonpath={.metadata.finalizers}",
-			"--request-timeout=10s")
+			KubectlRequestTimeout)
 		if finErr == nil && strings.TrimSpace(finalizerOutput) != "" {
 			raw := strings.TrimSpace(finalizerOutput)
 			raw = strings.Trim(raw, "[]")
@@ -3792,7 +3793,7 @@ func GetManagementClusterK8sTestNamespaces(t *testing.T, kubeContext string) ([]
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
 		"get", "namespaces", "-l", labelSelector,
 		"-o", "jsonpath={.items[*].metadata.name}",
-		"--request-timeout=10s")
+		KubectlRequestTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list test namespaces with label %s: %w", labelSelector, err)
 	}
@@ -3814,7 +3815,7 @@ func GetManagementClusterK8sTestNamespaceResources(t *testing.T, kubeContext, na
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
 		"-n", namespace, "get",
 		"clusters.cluster.x-k8s.io,machinepools.cluster.x-k8s.io,secrets,configmaps,all",
-		"--no-headers", "--ignore-not-found", "--request-timeout=10s")
+		"--no-headers", "--ignore-not-found", KubectlRequestTimeout)
 	if err != nil {
 		return "", fmt.Errorf("failed to list resources in namespace %s: %w", namespace, err)
 	}
@@ -4293,7 +4294,8 @@ func GetExistingClusterNames(t *testing.T, kubeContext, namespace string) ([]str
 
 	// Get all Cluster resources in the namespace
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
-		"-n", namespace, "get", "cluster", "-o", "jsonpath={.items[*].metadata.name}")
+		"-n", namespace, "get", "cluster", "-o", "jsonpath={.items[*].metadata.name}",
+		KubectlRequestTimeout)
 
 	if err != nil {
 		// Check if the error is because CRD doesn't exist (expected on fresh clusters)
@@ -4402,7 +4404,7 @@ func FormatMismatchedClustersError(mismatched []string, expectedClusterName, nam
 func IsMCECluster(t *testing.T, kubeContext string) bool {
 	t.Helper()
 	_, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
-		"get", "mce", "multiclusterengine", "-o", "name")
+		"get", "mce", "multiclusterengine", "-o", "name", KubectlRequestTimeout)
 	return err == nil
 }
 
@@ -4421,7 +4423,8 @@ func GetMCEComponentStatus(t *testing.T, kubeContext, componentName string) (*MC
 	// Query component enabled status using jsonpath
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
 		"get", "mce", "multiclusterengine", "-o",
-		fmt.Sprintf("jsonpath={.spec.overrides.components[?(@.name=='%s')].enabled}", componentName))
+		fmt.Sprintf("jsonpath={.spec.overrides.components[?(@.name=='%s')].enabled}", componentName),
+		KubectlRequestTimeout)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to query MCE component status: %w", err)
@@ -4454,7 +4457,7 @@ func SetMCEComponentState(t *testing.T, kubeContext, componentName string, enabl
 
 	// Get current MCE resource as JSON
 	currentOutput, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
-		"get", "mce", "multiclusterengine", "-o", "json")
+		"get", "mce", "multiclusterengine", "-o", "json", KubectlRequestTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to get MCE resource: %w", err)
 	}
@@ -4503,7 +4506,7 @@ func EnableMCEComponent(t *testing.T, kubeContext, componentName string) error {
 
 	// Get current MCE resource as JSON
 	currentOutput, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
-		"get", "mce", "multiclusterengine", "-o", "json")
+		"get", "mce", "multiclusterengine", "-o", "json", KubectlRequestTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to get MCE resource: %w", err)
 	}
@@ -4566,7 +4569,8 @@ func WaitForMCEController(t *testing.T, kubeContext, namespace, deploymentName s
 		// Check if deployment exists and is available
 		output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
 			"-n", namespace, "get", "deployment", deploymentName,
-			"-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}")
+			"-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}",
+			KubectlRequestTimeout)
 
 		if err != nil {
 			PrintToTTY("[%d] Deployment %s not found yet, waiting...\n", iteration, deploymentName)

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1423,7 +1423,7 @@ func DumpNotReadyResourceDiagnostics(t *testing.T, context, namespace string, no
 		condOutput, err := RunCommandQuiet(t, "kubectl", "--context", context, "-n", namespace,
 			"get", resourceType, r.Resource.Name,
 			"-o", "jsonpath={range .status.conditions[*]}{.type}: {.status} ({.reason}) {.message}{\"\\n\"}{end}",
-			KubectlRequestTimeout)
+			KubectlDiagnosticTimeout)
 		if err == nil && strings.TrimSpace(condOutput) != "" {
 			PrintToTTY("Conditions:\n%s\n", condOutput)
 			t.Logf("%s/%s conditions:\n%s", r.Resource.Kind, r.Resource.Name, condOutput)
@@ -1439,7 +1439,7 @@ func DumpNotReadyResourceDiagnostics(t *testing.T, context, namespace string, no
 			"get", "events",
 			"--field-selector", fmt.Sprintf("involvedObject.name=%s", r.Resource.Name),
 			"--sort-by=.lastTimestamp",
-			KubectlRequestTimeout)
+			KubectlDiagnosticTimeout)
 		if err == nil && strings.TrimSpace(evtOutput) != "" {
 			PrintToTTY("Events:\n%s\n", evtOutput)
 			t.Logf("%s/%s events:\n%s", r.Resource.Kind, r.Resource.Name, evtOutput)
@@ -1456,7 +1456,7 @@ func DumpNotReadyResourceDiagnostics(t *testing.T, context, namespace string, no
 	PrintToTTY("%s\n", nsHeader)
 	diagLog.WriteString(nsHeader + "\n")
 	evtOutput, err := RunCommandQuiet(t, "kubectl", "--context", context, "-n", namespace,
-		"get", "events", "--sort-by=.lastTimestamp", KubectlRequestTimeout)
+		"get", "events", "--sort-by=.lastTimestamp", KubectlDiagnosticTimeout)
 	if err == nil && strings.TrimSpace(evtOutput) != "" {
 		// Show last 30 lines to avoid flooding
 		lines := strings.Split(evtOutput, "\n")
@@ -2014,7 +2014,7 @@ func WaitForClusterHealthy(t *testing.T, kubeContext string, timeout time.Durati
 		// Try a simple kubectl command to check API server responsiveness
 		PrintToTTY("[%d] Checking API server responsiveness...\n", attempt)
 
-		_, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext, "get", "nodes", KubectlRequestTimeout)
+		_, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext, "get", "nodes", KubectlDiagnosticTimeout)
 		if err == nil {
 			PrintToTTY("✅ Cluster is healthy and responding\n\n")
 			t.Log("Cluster is healthy and responding")
@@ -3029,7 +3029,7 @@ func CheckPodsForImagePullErrors(t *testing.T, kubeContext, namespace string) er
 	t.Helper()
 
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
-		"-n", namespace, KubectlRequestTimeout,
+		"-n", namespace, KubectlDiagnosticTimeout,
 		"get", "pods",
 		"-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\t\"}{range .status.containerStatuses[*]}{.state.waiting.reason}{\" \"}{end}{range .status.initContainerStatuses[*]}{.state.waiting.reason}{\" \"}{end}{\"\\n\"}{end}")
 	if err != nil {
@@ -3563,7 +3563,7 @@ func GetDeletionResourceStatus(t *testing.T, kubeContext, namespace, clusterName
 		finalizerOutput, finErr := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
 			"-n", namespace, "get", "cluster", clusterName,
 			"-o", "jsonpath={.metadata.finalizers}",
-			KubectlRequestTimeout)
+			KubectlDiagnosticTimeout)
 		if finErr == nil && strings.TrimSpace(finalizerOutput) != "" {
 			raw := strings.TrimSpace(finalizerOutput)
 			raw = strings.Trim(raw, "[]")
@@ -3793,7 +3793,7 @@ func GetManagementClusterK8sTestNamespaces(t *testing.T, kubeContext string) ([]
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
 		"get", "namespaces", "-l", labelSelector,
 		"-o", "jsonpath={.items[*].metadata.name}",
-		KubectlRequestTimeout)
+		KubectlDiagnosticTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list test namespaces with label %s: %w", labelSelector, err)
 	}
@@ -3815,7 +3815,7 @@ func GetManagementClusterK8sTestNamespaceResources(t *testing.T, kubeContext, na
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
 		"-n", namespace, "get",
 		"clusters.cluster.x-k8s.io,machinepools.cluster.x-k8s.io,secrets,configmaps,all",
-		"--no-headers", "--ignore-not-found", KubectlRequestTimeout)
+		"--no-headers", "--ignore-not-found", KubectlDiagnosticTimeout)
 	if err != nil {
 		return "", fmt.Errorf("failed to list resources in namespace %s: %w", namespace, err)
 	}


### PR DESCRIPTION
## Description

Add `--request-timeout` to all kubectl `get` commands that were missing it, and centralize the timeout value in a `KubectlRequestTimeout` constant (120s). Without a request timeout, individual kubectl calls can hang indefinitely when the API server is slow or unreachable — blocking polling loops, test phases, or the entire suite.

Ref: [ARO-24300](https://redhat.atlassian.net/browse/ARO-24300)

## Changes Made

- Define `KubectlRequestTimeout` constant (`--request-timeout=120s`) in `test/config.go`
- Add `--request-timeout` to ~25 kubectl `get` commands across 7 test files that were missing it
- Refactor all existing inline timeout strings (`10s`, `30s`) to use the centralized constant
- Coverage: helpers.go, 01_check_dependencies, 03_cluster, 05_deploy_crs, 06_verification, 07_deletion, 08_cleanup

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| N/A — uses constant `KubectlRequestTimeout` | Prevent kubectl API calls from hanging indefinitely | `--request-timeout=120s` |

## Additional Notes

- Write operations (`delete`, `apply`, `patch`) are excluded — different timeout semantics
- `kubectl logs` is excluded — uses streaming, not request timeout
- The 120s value is generous enough to avoid false timeouts on slow clusters while still preventing indefinite hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-24300]: https://redhat.atlassian.net/browse/ARO-24300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized kubectl timeouts across the test suite: a general 120s timeout for regular API queries and a shorter 15s diagnostic timeout for polling/health checks.
  * Applied consistent timeouts to connectivity, node/readiness checks, deployment/resource availability polling, namespace/resource verifications, and diagnostic commands to improve test reliability and predictability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->