### PR TITLE
fix: check GOCACHE dir itself for writability, not just parent (ARO-27593)

### DIFF
--- a/openshift-ci/capz-test-env.sh
+++ b/openshift-ci/capz-test-env.sh
@@ -63,9 +63,11 @@ fi
 
 set -o xtrace
 : "${GOCACHE:=/tmp/go-cache}"
-if [[ ! -w "$(dirname "$GOCACHE")" ]]; then
-  echo "[capz-test-env] GOCACHE parent directory not writable, falling back to /tmp/go-cache" >&2
+if [[ ! -d "${GOCACHE}" ]] || [[ ! -w "${GOCACHE}" ]]; then
+  echo "[capz-test-env] GOCACHE=${GOCACHE} is not writable, falling back to /tmp/go-cache" >&2
   GOCACHE=/tmp/go-cache
+else
+  echo "[capz-test-env] GOCACHE=${GOCACHE}"
 fi
 export GOCACHE
 


### PR DESCRIPTION
## Description

Fix GOCACHE writability detection in Prow CI containers where `/go/.cache` exists but is read-only, while its parent `/go` is writable.

Related: https://github.com/openshift/release/pull/80110

## Changes Made

- Check if GOCACHE directory exists and is writable, instead of only checking the parent directory
- Log the GOCACHE value on both fallback and success paths

## Configuration Changes

No new variables — fixes behavior of the existing `GOCACHE` fallback from #764.

## Additional Notes

Previous check (`! -w "$(dirname "$GOCACHE")"`) missed the case where `/go` is group-writable (`drwxrwsr-x`) but `/go/.cache` is not (`drwxr-sr-x`). The new check tests GOCACHE itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build cache directory validation in the test environment configuration. The system now properly verifies that the cache directory exists and is writable, with automatic fallback to a temporary alternative when the primary location is unavailable or inaccessible, enhancing build environment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->