### PR TITLE
fix: align .config.prowgen slack channel with openshift/release

### DIFF
--- a/openshift-ci/.config.prowgen
+++ b/openshift-ci/.config.prowgen
@@ -1,12 +1,12 @@
 slack_reporter:
-- channel: "#aro-hcp-capz-health"
+- channel: "#hcm-aro-team-capz"
   job_states_to_report:
   - failure
   - error
   report_template: ':failed: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>'
   job_names:
   - capz-e2e
-- channel: "#aro-hcp-capz-health"
+- channel: "#hcm-aro-team-capz"
   job_states_to_report:
   - success
   report_template: ':done-circle-check: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>'


### PR DESCRIPTION
## Description

Align local `.config.prowgen` Slack channel with the deployed version in openshift/release.

The local copy targeted `#aro-hcp-capz-health` while the deployed version in
openshift/release already targets `#hcm-aro-team-capz`. This aligns them.

## Changes Made

- Updated both slack_reporter channel entries from `#aro-hcp-capz-health` to `#hcm-aro-team-capz`

## Configuration Changes

No new environment variables.

## Additional Notes

This is Step 1 of the Slack reporter fix. Step 2 (regenerating ProwJob YAML with `make jobs`
in openshift/release to add `reporter_config`) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Slack notification channel configuration for job reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->