### PR TITLE
feat: add CLUSTER_DEPLOYMENT_TIMEOUT and CLUSTER_DELETION_TIMEOUT with auto-computed step timeouts (ARO-27601)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,7 +405,9 @@ export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 This is validated during Check Dependencies (phase 1) to prevent late deployment failures.
 
 ### Test Behavior
-- `DEPLOYMENT_TIMEOUT` - Control plane deployment timeout (default: `60m`, format: Go duration like `1h`, `45m`)
+- `CLUSTER_DEPLOYMENT_TIMEOUT` - How long the in-code polling loop waits for the workload cluster to become ready (default: `60m`, format: minutes only like `60m`, `90m`, `120m`). The Makefile's `GO_STEP_DEPLOY_CRS_TIMEOUT` is auto-computed as this value + 15 minutes headroom.
+- `CLUSTER_DELETION_TIMEOUT` - How long the in-code polling loop waits for the workload cluster to be deleted (default: `60m`, format: minutes only like `60m`, `90m`). The Makefile's `GO_STEP_DELETION_TIMEOUT` is auto-computed as this value + 15 minutes headroom.
+- `DEPLOYMENT_TIMEOUT` - **Deprecated**: Legacy timeout variable. If `CLUSTER_DEPLOYMENT_TIMEOUT` / `CLUSTER_DELETION_TIMEOUT` are not set, the system falls back to `DEPLOYMENT_TIMEOUT` for backward compatibility.
 - `DEPLOYMENT_STALL_TIMEOUT` - Stall detection timeout: if no progress (control plane ready status, machine pool replicas, infrastructure resources) for this duration, the test fails early instead of waiting for the full deployment timeout (default: `30m`, set to `0` to disable)
 
 ### MCE Component Management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Never hardcode values - always use `GetEnvOrDefault()` for new configuration.
 **Validation:**
 - `ValidateDomainPrefix(user, env)` - Domain prefix length (max 15 chars)
 - `ValidateRFC1123Name(name, varName)` - RFC 1123 subdomain naming
-- `ValidateExternalAuthID` / `ValidateTimeout` / `ValidateDeploymentTimeout` / `ValidateASOControllerTimeout`
+- `ValidateExternalAuthID` / `ValidateTimeout` / `ValidateDeploymentTimeout` / `ValidateClusterDeploymentTimeout` / `ValidateClusterDeletionTimeout` / `ValidateASOControllerTimeout`
 - `ValidateAllConfigurations(t, config)` / `FormatValidationResults` - Bulk config validation
 - `ValidateAzureSubscriptionAccess` / `ValidateAzureRegion` - Azure resource validation
 - `ValidateYAMLFile` / `ValidateServicePrincipalCredentials`

--- a/Makefile
+++ b/Makefile
@@ -60,13 +60,27 @@ endif
 # Set to -v for verbose output (default), or empty string for quiet output
 TEST_VERBOSITY ?= -v
 
+# User-facing cluster operation timeouts (minutes-only format: "60m", "90m", "120m").
+# These control how long the in-code polling loops wait for cluster operations.
+# The Go step timeouts below are auto-computed as these values + 15m headroom.
+# NOTE: Only the Nm format is supported (e.g., 60m, 90m). Other Go duration
+# formats like "1h" or "2h30m" will break the shell arithmetic below.
+CLUSTER_DEPLOYMENT_TIMEOUT ?= 60m
+CLUSTER_DELETION_TIMEOUT ?= 60m
+
+# Validate that timeout values are in minutes-only format (Nm)
+$(if $(shell echo '$(CLUSTER_DEPLOYMENT_TIMEOUT)' | grep -qE '^[0-9]+m$$' || echo INVALID),$(if $(filter INVALID,$(shell echo '$(CLUSTER_DEPLOYMENT_TIMEOUT)' | grep -qE '^[0-9]+m$$' || echo INVALID)),$(error CLUSTER_DEPLOYMENT_TIMEOUT must be in minutes format like "60m", got "$(CLUSTER_DEPLOYMENT_TIMEOUT)")))
+$(if $(shell echo '$(CLUSTER_DELETION_TIMEOUT)' | grep -qE '^[0-9]+m$$' || echo INVALID),$(if $(filter INVALID,$(shell echo '$(CLUSTER_DELETION_TIMEOUT)' | grep -qE '^[0-9]+m$$' || echo INVALID)),$(error CLUSTER_DELETION_TIMEOUT must be in minutes format like "60m", got "$(CLUSTER_DELETION_TIMEOUT)")))
+
 # Test timeout configuration — Go's -timeout flag (process-level hard kill)
-# Individual phase timeouts (format: Go duration like 30m, 1h, etc.)
+# GO_STEP_DEPLOY_CRS_TIMEOUT and GO_STEP_DELETION_TIMEOUT are auto-computed
+# from the user-facing values above + 15 minutes headroom, ensuring the Go process
+# has time to save logs and diagnostics before being killed.
 GO_STEP_CLUSTER_TIMEOUT ?= 30m
 GO_STEP_GENERATE_YAMLS_TIMEOUT ?= 20m
-GO_STEP_DEPLOY_CRS_TIMEOUT ?= 105m
+GO_STEP_DEPLOY_CRS_TIMEOUT ?= $(shell echo $$(( $$(echo '$(CLUSTER_DEPLOYMENT_TIMEOUT)' | sed 's/m$$//') + 15 ))m)
 GO_STEP_VERIFY_TIMEOUT ?= 20m
-GO_STEP_DELETION_TIMEOUT ?= 60m
+GO_STEP_DELETION_TIMEOUT ?= $(shell echo $$(( $$(echo '$(CLUSTER_DELETION_TIMEOUT)' | sed 's/m$$//') + 15 ))m)
 
 # Results directory configuration
 # Create unique results directory for each test run using timestamp
@@ -231,11 +245,11 @@ _deploy-crs: check-gotestsum
 	@echo ""
 	@EXIT_CODE=0; \
 	echo "--- Phase 1: Apply resources (fail-fast) ---"; \
-	TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-apply.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestDeployment_0|TestDeployment_Apply|TestDeployment_Provider" -timeout $(GO_STEP_DEPLOY_CRS_TIMEOUT) -failfast || EXIT_CODE=$$?; \
+	CLUSTER_DEPLOYMENT_TIMEOUT=$(CLUSTER_DEPLOYMENT_TIMEOUT) TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-apply.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestDeployment_0|TestDeployment_Apply|TestDeployment_Provider" -timeout $(GO_STEP_DEPLOY_CRS_TIMEOUT) -failfast || EXIT_CODE=$$?; \
 	if [ $$EXIT_CODE -eq 0 ]; then \
 		echo ""; \
 		echo "--- Phase 2: Monitor deployment ---"; \
-		TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-monitor.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestDeployment_Monitor|TestDeployment_Wait|TestDeployment_Verify|TestDeployment_Tag" -timeout $(GO_STEP_DEPLOY_CRS_TIMEOUT) || EXIT_CODE=$$?; \
+		CLUSTER_DEPLOYMENT_TIMEOUT=$(CLUSTER_DEPLOYMENT_TIMEOUT) TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-monitor.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestDeployment_Monitor|TestDeployment_Wait|TestDeployment_Verify|TestDeployment_Tag" -timeout $(GO_STEP_DEPLOY_CRS_TIMEOUT) || EXIT_CODE=$$?; \
 	fi; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
@@ -278,7 +292,7 @@ _delete-workload-cluster: check-gotestsum
 	@echo "Results will be saved to: $(RESULTS_DIR)"
 	@echo ""
 	@EXIT_CODE=0; \
-	TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-delete.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestDeletion -timeout $(GO_STEP_DELETION_TIMEOUT) || EXIT_CODE=$$?; \
+	CLUSTER_DELETION_TIMEOUT=$(CLUSTER_DELETION_TIMEOUT) TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-delete.xml -- $(TEST_VERBOSITY) ./test -count=1 -run TestDeletion -timeout $(GO_STEP_DELETION_TIMEOUT) || EXIT_CODE=$$?; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \
 	cp -f $(RESULTS_DIR)/*.log $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \

--- a/README.md
+++ b/README.md
@@ -171,23 +171,25 @@ The test suite validates naming compliance during the Check Dependencies phase (
 
 ### Test Behavior
 
-- `DEPLOYMENT_TIMEOUT` - Control plane deployment timeout (default: `60m`). Use Go duration format: `1h`, `45m`, `90m`, etc.
+- `CLUSTER_DEPLOYMENT_TIMEOUT` - How long the in-code polling loop waits for the workload cluster to become ready (default: `60m`). Use minutes format: `60m`, `90m`, `120m` (required by Makefile auto-computation).
+- `CLUSTER_DELETION_TIMEOUT` - How long the in-code polling loop waits for the workload cluster to be deleted (default: `60m`). Use minutes format: `60m`, `90m`, `120m`.
+- `DEPLOYMENT_TIMEOUT` - **Deprecated**: Legacy timeout variable. Falls back to this if `CLUSTER_DEPLOYMENT_TIMEOUT` / `CLUSTER_DELETION_TIMEOUT` are not set.
 - `DEPLOYMENT_STALL_TIMEOUT` - Stall detection timeout (default: `30m`). If the deployment makes no progress for this duration, the test fails early instead of waiting for the full timeout. Set to `0` to disable.
 - `TEST_VERBOSITY` - Test output verbosity (default: `-v` for verbose). Set to empty string for quiet output: `TEST_VERBOSITY= make test`
 
 #### Makefile Timeout Variables
 
-Individual test phase timeouts control Go's `-timeout` flag (process-level hard kill) and can be overridden via Makefile variables:
+Individual test phase timeouts control Go's `-timeout` flag (process-level hard kill). `GO_STEP_DEPLOY_CRS_TIMEOUT` and `GO_STEP_DELETION_TIMEOUT` are **auto-computed** from the user-facing values above + 15 minutes headroom, ensuring the Go process has time to save logs and diagnostics before being killed. Other step timeouts can be overridden via Makefile variables:
 
 | Variable | Default | Phase |
 |----------|---------|-------|
 | `GO_STEP_CLUSTER_TIMEOUT` | `30m` | Management cluster deployment |
 | `GO_STEP_GENERATE_YAMLS_TIMEOUT` | `20m` | YAML generation |
-| `GO_STEP_DEPLOY_CRS_TIMEOUT` | `105m` | CR deployment and monitoring |
+| `GO_STEP_DEPLOY_CRS_TIMEOUT` | auto (`CLUSTER_DEPLOYMENT_TIMEOUT` + 15m) | CR deployment and monitoring |
 | `GO_STEP_VERIFY_TIMEOUT` | `20m` | Workload cluster verification |
-| `GO_STEP_DELETION_TIMEOUT` | `60m` | Workload cluster deletion |
+| `GO_STEP_DELETION_TIMEOUT` | auto (`CLUSTER_DELETION_TIMEOUT` + 15m) | Workload cluster deletion |
 
-Example: `GO_STEP_DEPLOY_CRS_TIMEOUT=90m make _deploy-crs`
+Example: `CLUSTER_DEPLOYMENT_TIMEOUT=90m make _deploy-crs` (sets Go step timeout to 105m automatically)
 
 ## Getting Started
 

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -939,13 +939,21 @@ func TestCheckDependencies_AzureSubscriptionAccess(t *testing.T) {
 func TestCheckDependencies_TimeoutConfiguration(t *testing.T) {
 	config := NewTestConfig()
 
-	t.Run("DeploymentTimeout", func(t *testing.T) {
-		if err := ValidateDeploymentTimeout(config.DeploymentTimeout); err != nil {
-			// Non-fatal warning - deployment will just timeout if too short
+	t.Run("ClusterDeploymentTimeout", func(t *testing.T) {
+		if err := ValidateClusterDeploymentTimeout(config.ClusterDeploymentTimeout); err != nil {
 			t.Logf("Warning: %v", err)
 		} else {
-			t.Logf("DEPLOYMENT_TIMEOUT '%v' is within acceptable range (%v - %v)",
-				config.DeploymentTimeout, MinDeploymentTimeout, MaxDeploymentTimeout)
+			t.Logf("CLUSTER_DEPLOYMENT_TIMEOUT '%v' is within acceptable range (%v - %v)",
+				config.ClusterDeploymentTimeout, MinDeploymentTimeout, MaxDeploymentTimeout)
+		}
+	})
+
+	t.Run("ClusterDeletionTimeout", func(t *testing.T) {
+		if err := ValidateClusterDeletionTimeout(config.ClusterDeletionTimeout); err != nil {
+			t.Logf("Warning: %v", err)
+		} else {
+			t.Logf("CLUSTER_DELETION_TIMEOUT '%v' is within acceptable range (%v - %v)",
+				config.ClusterDeletionTimeout, MinDeploymentTimeout, MaxDeploymentTimeout)
 		}
 	})
 

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -508,7 +508,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 	machinePoolName := config.GetProvisionedMachinePoolName()
 
 	// Wait for both to be ready (with configurable timeout)
-	timeout := config.DeploymentTimeout
+	timeout := config.ClusterDeploymentTimeout
 	pollInterval := 30 * time.Second
 	startTime := time.Now()
 
@@ -955,7 +955,7 @@ func TestDeployment_VerifyInfrastructureResources(t *testing.T) {
 
 	RequireClusterResource(t, context, config.WorkloadClusterNamespace, provisionedClusterName)
 
-	timeout := config.DeploymentTimeout
+	timeout := config.ClusterDeploymentTimeout
 	pollInterval := 30 * time.Second
 	startTime := time.Now()
 

--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -115,8 +115,7 @@ func TestDeletion_WaitForClusterDeletion(t *testing.T) {
 	PrintTestHeader(t, "TestDeletion_WaitForClusterDeletion",
 		"Wait for cluster resource to be fully deleted")
 
-	// Use the deployment timeout for deletion as well (deletion can take significant time)
-	timeout := config.DeploymentTimeout
+	timeout := config.ClusterDeletionTimeout
 	pollInterval := 30 * time.Second
 	startTime := time.Now()
 

--- a/test/config.go
+++ b/test/config.go
@@ -19,7 +19,16 @@ var (
 )
 
 const (
-	// DefaultDeploymentTimeout is the default timeout for control plane deployment
+	// DefaultClusterDeploymentTimeout is the default timeout for the in-code polling loop
+	// that waits for the workload cluster to become ready during deployment (Phase 05).
+	DefaultClusterDeploymentTimeout = 60 * time.Minute
+
+	// DefaultClusterDeletionTimeout is the default timeout for the in-code polling loop
+	// that waits for the workload cluster to be fully deleted (Phase 07).
+	DefaultClusterDeletionTimeout = 60 * time.Minute
+
+	// DefaultDeploymentTimeout is the legacy default timeout for control plane deployment.
+	// Deprecated: Use DefaultClusterDeploymentTimeout instead.
 	DefaultDeploymentTimeout = 60 * time.Minute
 
 	// DefaultASOControllerTimeout is the default timeout for ASO controller manager to become ready.
@@ -505,10 +514,12 @@ type TestConfig struct {
 	GenScriptPath     string
 
 	// Timeouts
-	DeploymentTimeout      time.Duration
-	DeploymentStallTimeout time.Duration // 0 disables stall detection
-	ASOControllerTimeout   time.Duration
-	HelmInstallTimeout     time.Duration
+	ClusterDeploymentTimeout time.Duration // CLUSTER_DEPLOYMENT_TIMEOUT: how long the deploy polling loop waits
+	ClusterDeletionTimeout   time.Duration // CLUSTER_DELETION_TIMEOUT: how long the deletion polling loop waits
+	DeploymentTimeout        time.Duration // Deprecated: alias for ClusterDeploymentTimeout (backward compat)
+	DeploymentStallTimeout   time.Duration // 0 disables stall detection
+	ASOControllerTimeout     time.Duration
+	HelmInstallTimeout       time.Duration
 
 	// Infrastructure providers
 	// InfraProviderName is the selected infrastructure provider ("aro" or "rosa").
@@ -744,10 +755,12 @@ func NewTestConfig() *TestConfig {
 		GenScriptPath:     GetEnvOrDefault("GEN_SCRIPT_PATH", defaultGenScriptPath),
 
 		// Timeouts
-		DeploymentTimeout:      parseDeploymentTimeout(),
-		DeploymentStallTimeout: parseDeploymentStallTimeout(),
-		ASOControllerTimeout:   asoTimeout,
-		HelmInstallTimeout:     parseHelmInstallTimeout(),
+		ClusterDeploymentTimeout: parseClusterDeploymentTimeout(),
+		ClusterDeletionTimeout:   parseClusterDeletionTimeout(),
+		DeploymentTimeout:        parseClusterDeploymentTimeout(), // backward compat alias
+		DeploymentStallTimeout:   parseDeploymentStallTimeout(),
+		ASOControllerTimeout:     asoTimeout,
+		HelmInstallTimeout:       parseHelmInstallTimeout(),
 
 		// Infrastructure providers
 		InfraProviderName: infraProviderName,
@@ -781,9 +794,68 @@ func getControllerNamespace(envVar, defaultNS string) string {
 	return defaultNS
 }
 
+// parseClusterDeploymentTimeout parses the CLUSTER_DEPLOYMENT_TIMEOUT environment variable.
+// Controls how long the deployment polling loop waits for the cluster to become ready.
+//
+// Resolution order:
+//  1. CLUSTER_DEPLOYMENT_TIMEOUT (new, preferred)
+//  2. DEPLOYMENT_TIMEOUT (legacy, backward compat)
+//  3. DefaultClusterDeploymentTimeout (60m)
+func parseClusterDeploymentTimeout() time.Duration {
+	if timeoutStr := os.Getenv("CLUSTER_DEPLOYMENT_TIMEOUT"); timeoutStr != "" {
+		timeout, err := time.ParseDuration(timeoutStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: invalid CLUSTER_DEPLOYMENT_TIMEOUT '%s', using default %v\n", timeoutStr, DefaultClusterDeploymentTimeout)
+			return DefaultClusterDeploymentTimeout
+		}
+		return timeout
+	}
+
+	// Fall back to legacy DEPLOYMENT_TIMEOUT
+	if timeoutStr := os.Getenv("DEPLOYMENT_TIMEOUT"); timeoutStr != "" {
+		timeout, err := time.ParseDuration(timeoutStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: invalid DEPLOYMENT_TIMEOUT '%s', using default %v\n", timeoutStr, DefaultClusterDeploymentTimeout)
+			return DefaultClusterDeploymentTimeout
+		}
+		return timeout
+	}
+
+	return DefaultClusterDeploymentTimeout
+}
+
+// parseClusterDeletionTimeout parses the CLUSTER_DELETION_TIMEOUT environment variable.
+// Controls how long the deletion polling loop waits for the cluster to be deleted.
+//
+// Resolution order:
+//  1. CLUSTER_DELETION_TIMEOUT (new, preferred)
+//  2. DEPLOYMENT_TIMEOUT (legacy, backward compat)
+//  3. DefaultClusterDeletionTimeout (60m)
+func parseClusterDeletionTimeout() time.Duration {
+	if timeoutStr := os.Getenv("CLUSTER_DELETION_TIMEOUT"); timeoutStr != "" {
+		timeout, err := time.ParseDuration(timeoutStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: invalid CLUSTER_DELETION_TIMEOUT '%s', using default %v\n", timeoutStr, DefaultClusterDeletionTimeout)
+			return DefaultClusterDeletionTimeout
+		}
+		return timeout
+	}
+
+	// Fall back to legacy DEPLOYMENT_TIMEOUT
+	if timeoutStr := os.Getenv("DEPLOYMENT_TIMEOUT"); timeoutStr != "" {
+		timeout, err := time.ParseDuration(timeoutStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: invalid DEPLOYMENT_TIMEOUT '%s', using default %v\n", timeoutStr, DefaultClusterDeletionTimeout)
+			return DefaultClusterDeletionTimeout
+		}
+		return timeout
+	}
+
+	return DefaultClusterDeletionTimeout
+}
+
 // parseDeploymentTimeout parses the DEPLOYMENT_TIMEOUT environment variable.
-// Returns the parsed duration or defaults to DefaultDeploymentTimeout.
-// Logs a warning if the provided value is invalid.
+// Deprecated: Use parseClusterDeploymentTimeout instead.
 func parseDeploymentTimeout() time.Duration {
 	timeoutStr := os.Getenv("DEPLOYMENT_TIMEOUT")
 	if timeoutStr == "" {

--- a/test/config.go
+++ b/test/config.go
@@ -715,6 +715,8 @@ func NewTestConfig() *TestConfig {
 		}
 	}
 
+	clusterDeployTimeout := parseClusterDeploymentTimeout()
+
 	return &TestConfig{
 		// Repository defaults
 		RepoURL:    GetEnvOrDefault("ARO_REPO_URL", "https://github.com/stolostron/cluster-api-installer"),
@@ -755,9 +757,9 @@ func NewTestConfig() *TestConfig {
 		GenScriptPath:     GetEnvOrDefault("GEN_SCRIPT_PATH", defaultGenScriptPath),
 
 		// Timeouts
-		ClusterDeploymentTimeout: parseClusterDeploymentTimeout(),
+		ClusterDeploymentTimeout: clusterDeployTimeout,
 		ClusterDeletionTimeout:   parseClusterDeletionTimeout(),
-		DeploymentTimeout:        parseClusterDeploymentTimeout(), // backward compat alias
+		DeploymentTimeout:        clusterDeployTimeout, // backward compat alias
 		DeploymentStallTimeout:   parseDeploymentStallTimeout(),
 		ASOControllerTimeout:     asoTimeout,
 		HelmInstallTimeout:       parseHelmInstallTimeout(),

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -238,6 +238,147 @@ func TestParseDeploymentStallTimeout_NegativeDuration(t *testing.T) {
 	}
 }
 
+// --- CLUSTER_DEPLOYMENT_TIMEOUT tests ---
+
+func TestParseClusterDeploymentTimeout_Default(t *testing.T) {
+	for _, key := range []string{"CLUSTER_DEPLOYMENT_TIMEOUT", "DEPLOYMENT_TIMEOUT"} {
+		t.Setenv(key, "")
+		_ = os.Unsetenv(key)
+	}
+
+	timeout := parseClusterDeploymentTimeout()
+	if timeout != DefaultClusterDeploymentTimeout {
+		t.Errorf("Expected default timeout %v, got %v", DefaultClusterDeploymentTimeout, timeout)
+	}
+}
+
+func TestParseClusterDeploymentTimeout_ValidDuration(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected time.Duration
+	}{
+		{"30m", 30 * time.Minute},
+		{"1h", 1 * time.Hour},
+		{"90m", 90 * time.Minute},
+		{"2h30m", 2*time.Hour + 30*time.Minute},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Setenv("CLUSTER_DEPLOYMENT_TIMEOUT", tc.input)
+			_ = os.Unsetenv("DEPLOYMENT_TIMEOUT")
+			timeout := parseClusterDeploymentTimeout()
+			if timeout != tc.expected {
+				t.Errorf("For input '%s', expected %v, got %v", tc.input, tc.expected, timeout)
+			}
+		})
+	}
+}
+
+func TestParseClusterDeploymentTimeout_InvalidDuration(t *testing.T) {
+	invalidValues := []string{"invalid", "abc", "45", "1x"}
+	for _, val := range invalidValues {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv("CLUSTER_DEPLOYMENT_TIMEOUT", val)
+			_ = os.Unsetenv("DEPLOYMENT_TIMEOUT")
+			timeout := parseClusterDeploymentTimeout()
+			if timeout != DefaultClusterDeploymentTimeout {
+				t.Errorf("For invalid input '%s', expected default %v, got %v", val, DefaultClusterDeploymentTimeout, timeout)
+			}
+		})
+	}
+}
+
+func TestParseClusterDeploymentTimeout_FallbackToDeploymentTimeout(t *testing.T) {
+	_ = os.Unsetenv("CLUSTER_DEPLOYMENT_TIMEOUT")
+	t.Setenv("DEPLOYMENT_TIMEOUT", "45m")
+
+	timeout := parseClusterDeploymentTimeout()
+	if timeout != 45*time.Minute {
+		t.Errorf("Expected fallback to DEPLOYMENT_TIMEOUT (45m), got %v", timeout)
+	}
+}
+
+func TestParseClusterDeploymentTimeout_PrecedenceOverDeploymentTimeout(t *testing.T) {
+	t.Setenv("CLUSTER_DEPLOYMENT_TIMEOUT", "90m")
+	t.Setenv("DEPLOYMENT_TIMEOUT", "45m")
+
+	timeout := parseClusterDeploymentTimeout()
+	if timeout != 90*time.Minute {
+		t.Errorf("CLUSTER_DEPLOYMENT_TIMEOUT should take precedence, expected 90m, got %v", timeout)
+	}
+}
+
+// --- CLUSTER_DELETION_TIMEOUT tests ---
+
+func TestParseClusterDeletionTimeout_Default(t *testing.T) {
+	for _, key := range []string{"CLUSTER_DELETION_TIMEOUT", "DEPLOYMENT_TIMEOUT"} {
+		t.Setenv(key, "")
+		_ = os.Unsetenv(key)
+	}
+
+	timeout := parseClusterDeletionTimeout()
+	if timeout != DefaultClusterDeletionTimeout {
+		t.Errorf("Expected default timeout %v, got %v", DefaultClusterDeletionTimeout, timeout)
+	}
+}
+
+func TestParseClusterDeletionTimeout_ValidDuration(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected time.Duration
+	}{
+		{"30m", 30 * time.Minute},
+		{"1h", 1 * time.Hour},
+		{"90m", 90 * time.Minute},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Setenv("CLUSTER_DELETION_TIMEOUT", tc.input)
+			_ = os.Unsetenv("DEPLOYMENT_TIMEOUT")
+			timeout := parseClusterDeletionTimeout()
+			if timeout != tc.expected {
+				t.Errorf("For input '%s', expected %v, got %v", tc.input, tc.expected, timeout)
+			}
+		})
+	}
+}
+
+func TestParseClusterDeletionTimeout_InvalidDuration(t *testing.T) {
+	invalidValues := []string{"invalid", "abc", "45", "1x"}
+	for _, val := range invalidValues {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv("CLUSTER_DELETION_TIMEOUT", val)
+			_ = os.Unsetenv("DEPLOYMENT_TIMEOUT")
+			timeout := parseClusterDeletionTimeout()
+			if timeout != DefaultClusterDeletionTimeout {
+				t.Errorf("For invalid input '%s', expected default %v, got %v", val, DefaultClusterDeletionTimeout, timeout)
+			}
+		})
+	}
+}
+
+func TestParseClusterDeletionTimeout_FallbackToDeploymentTimeout(t *testing.T) {
+	_ = os.Unsetenv("CLUSTER_DELETION_TIMEOUT")
+	t.Setenv("DEPLOYMENT_TIMEOUT", "45m")
+
+	timeout := parseClusterDeletionTimeout()
+	if timeout != 45*time.Minute {
+		t.Errorf("Expected fallback to DEPLOYMENT_TIMEOUT (45m), got %v", timeout)
+	}
+}
+
+func TestParseClusterDeletionTimeout_PrecedenceOverDeploymentTimeout(t *testing.T) {
+	t.Setenv("CLUSTER_DELETION_TIMEOUT", "30m")
+	t.Setenv("DEPLOYMENT_TIMEOUT", "45m")
+
+	timeout := parseClusterDeletionTimeout()
+	if timeout != 30*time.Minute {
+		t.Errorf("CLUSTER_DELETION_TIMEOUT should take precedence, expected 30m, got %v", timeout)
+	}
+}
+
 func TestIsKindMode(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -4073,8 +4073,18 @@ func ValidateTimeout(name string, timeout, min, max time.Duration) error {
 	return nil
 }
 
+// ValidateClusterDeploymentTimeout validates the CLUSTER_DEPLOYMENT_TIMEOUT configuration.
+func ValidateClusterDeploymentTimeout(timeout time.Duration) error {
+	return ValidateTimeout("CLUSTER_DEPLOYMENT_TIMEOUT", timeout, MinDeploymentTimeout, MaxDeploymentTimeout)
+}
+
+// ValidateClusterDeletionTimeout validates the CLUSTER_DELETION_TIMEOUT configuration.
+func ValidateClusterDeletionTimeout(timeout time.Duration) error {
+	return ValidateTimeout("CLUSTER_DELETION_TIMEOUT", timeout, MinDeploymentTimeout, MaxDeploymentTimeout)
+}
+
 // ValidateDeploymentTimeout validates the DEPLOYMENT_TIMEOUT configuration.
-// Returns nil if the timeout is within acceptable bounds, or an error with remediation guidance.
+// Deprecated: Use ValidateClusterDeploymentTimeout instead.
 func ValidateDeploymentTimeout(timeout time.Duration) error {
 	return ValidateTimeout("DEPLOYMENT_TIMEOUT", timeout, MinDeploymentTimeout, MaxDeploymentTimeout)
 }
@@ -4201,18 +4211,31 @@ func ValidateAllConfigurations(t *testing.T, config *TestConfig) []ConfigValidat
 	})
 
 	// Validate timeout values
-	timeoutResult := ConfigValidationResult{
-		Variable:   "DEPLOYMENT_TIMEOUT",
-		Value:      config.DeploymentTimeout.String(),
-		IsCritical: false, // Not critical, deployment will just timeout
+	deployTimeoutResult := ConfigValidationResult{
+		Variable:   "CLUSTER_DEPLOYMENT_TIMEOUT",
+		Value:      config.ClusterDeploymentTimeout.String(),
+		IsCritical: false,
 	}
-	if err := ValidateDeploymentTimeout(config.DeploymentTimeout); err != nil {
-		timeoutResult.IsValid = false
-		timeoutResult.Error = err
+	if err := ValidateClusterDeploymentTimeout(config.ClusterDeploymentTimeout); err != nil {
+		deployTimeoutResult.IsValid = false
+		deployTimeoutResult.Error = err
 	} else {
-		timeoutResult.IsValid = true
+		deployTimeoutResult.IsValid = true
 	}
-	results = append(results, timeoutResult)
+	results = append(results, deployTimeoutResult)
+
+	deletionTimeoutResult := ConfigValidationResult{
+		Variable:   "CLUSTER_DELETION_TIMEOUT",
+		Value:      config.ClusterDeletionTimeout.String(),
+		IsCritical: false,
+	}
+	if err := ValidateClusterDeletionTimeout(config.ClusterDeletionTimeout); err != nil {
+		deletionTimeoutResult.IsValid = false
+		deletionTimeoutResult.Error = err
+	} else {
+		deletionTimeoutResult.IsValid = true
+	}
+	results = append(results, deletionTimeoutResult)
 
 	asoResult := ConfigValidationResult{
 		Variable:   "ASO_CONTROLLER_TIMEOUT",


### PR DESCRIPTION
## Description

Introduce user-facing `CLUSTER_DEPLOYMENT_TIMEOUT` and `CLUSTER_DELETION_TIMEOUT` environment variables that control how long the in-code polling loops wait for cluster deployment and deletion. The Makefile `GO_STEP_DEPLOY_CRS_TIMEOUT` and `GO_STEP_DELETION_TIMEOUT` are now auto-computed as the user value + 15 minutes headroom, ensuring the Go process always has time to save logs and diagnostics before being killed.

`DEPLOYMENT_TIMEOUT` is preserved as a deprecated fallback for backward compatibility.

JIRA: https://redhat.atlassian.net/browse/ARO-27601

Recreates #761 (accidentally closed when fork was deleted).

## Changes Made

- Add `CLUSTER_DEPLOYMENT_TIMEOUT` (default: 60m) to control the deploy polling loop
- Add `CLUSTER_DELETION_TIMEOUT` (default: 60m) to control the deletion polling loop
- Auto-compute `GO_STEP_DEPLOY_CRS_TIMEOUT` and `GO_STEP_DELETION_TIMEOUT` in Makefile (user value + 15m)
- Add Makefile validation enforcing minutes-only format (`^[0-9]+m$`) with clear error on invalid input
- Update `05_deploy_crs_test.go` and `07_deletion_test.go` to use the new config fields
- Add validation and unit tests (12 new tests, all passing)
- Deprecate `DEPLOYMENT_TIMEOUT` with backward-compatible fallback

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `CLUSTER_DEPLOYMENT_TIMEOUT` | In-code polling timeout for cluster deployment | `60m` |
| `CLUSTER_DELETION_TIMEOUT` | In-code polling timeout for cluster deletion | `60m` |
| `DEPLOYMENT_TIMEOUT` | **Deprecated** — fallback for backward compat | `60m` |

## Additional Notes

The `GO_STEP_*` Makefile variables are now computed automatically. Users only need to set the `CLUSTER_*` variables — the step timeouts derive from them with 15m headroom for diagnostics. Only minutes format is supported (e.g., `60m`, `90m`, `120m`) — other Go duration formats like `1h` are rejected by Makefile validation because the auto-computation uses shell arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced separate, user-configurable timeouts for cluster deployment and cluster deletion: `CLUSTER_DEPLOYMENT_TIMEOUT` and `CLUSTER_DELETION_TIMEOUT` (default 60 minutes).
  * These timeouts are validated to use a minutes-only format (e.g., `60m`) and are applied to the relevant deployment and deletion phases.
  * Added support for legacy `DEPLOYMENT_TIMEOUT` as a fallback when cluster-specific variables are not set, with warnings on invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->