### PR TITLE
fix: show actionable error instead of unknown for Azure RG deletion status (ARO-27859)

### DIFF
--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3657,8 +3657,8 @@ func GetDeletionResourceStatus(t *testing.T, kubeContext, namespace, clusterName
 					} else {
 						t.Logf("Warning: Could not determine Azure RG status: %v", err)
 						errMsg := err.Error()
-						if len(errMsg) > 80 {
-							errMsg = errMsg[:80]
+						if len([]rune(errMsg)) > 80 {
+							errMsg = string([]rune(errMsg)[:80])
 						}
 						aroStatus.RGError = errMsg
 					}

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3509,6 +3509,7 @@ type ARODeletionStatus struct {
 	RGExists         bool
 	RGChecked        bool
 	RGProvisionState string
+	RGError          string // Non-empty when the az CLI check failed (auth, network, etc.)
 }
 
 // DeletionResourceStatus represents the status of resources being deleted.
@@ -3638,17 +3639,32 @@ func GetDeletionResourceStatus(t *testing.T, kubeContext, namespace, clusterName
 					aroStatus.RGExists = true
 					aroStatus.RGChecked = true
 					aroStatus.RGProvisionState = strings.TrimSpace(output)
-				} else if err != nil {
+				} else if err == nil {
+					aroStatus.RGExists = true
+					aroStatus.RGChecked = true
+					aroStatus.RGProvisionState = "exists"
+				} else {
 					errOutput := strings.ToLower(output + " " + err.Error())
 					if strings.Contains(errOutput, "resourcegroupnotfound") ||
 						strings.Contains(errOutput, "could not be found") ||
 						(strings.Contains(errOutput, "resource group") && strings.Contains(errOutput, "not found")) {
 						aroStatus.RGExists = false
 						aroStatus.RGChecked = true
+					} else if strings.Contains(errOutput, "deleting") || strings.Contains(errOutput, "deprovisioning") {
+						aroStatus.RGExists = true
+						aroStatus.RGChecked = true
+						aroStatus.RGProvisionState = "Deleting"
 					} else {
 						t.Logf("Warning: Could not determine Azure RG status: %v", err)
+						errMsg := err.Error()
+						if len(errMsg) > 80 {
+							errMsg = errMsg[:80]
+						}
+						aroStatus.RGError = errMsg
 					}
 				}
+			} else {
+				aroStatus.RGError = "az CLI not available"
 			}
 
 			status.AROProviderSpecific = aroStatus
@@ -3731,7 +3747,11 @@ func FormatDeletionProgress(status DeletionResourceStatus) string {
 		aroStatus := status.AROProviderSpecific
 		if aroStatus.ResourceGroup != "" {
 			if !aroStatus.RGChecked {
-				sb.WriteString(formatRow("❓", "Azure RG", fmt.Sprintf("%s (unknown)", aroStatus.ResourceGroup)))
+				if aroStatus.RGError != "" {
+					sb.WriteString(formatRow("⚠️", "Azure RG", fmt.Sprintf("%s (%s)", aroStatus.ResourceGroup, aroStatus.RGError)))
+				} else {
+					sb.WriteString(formatRow("❓", "Azure RG", fmt.Sprintf("%s (unchecked)", aroStatus.ResourceGroup)))
+				}
 			} else if aroStatus.RGExists {
 				stateInfo := aroStatus.RGProvisionState
 				if stateInfo == "" {
@@ -3766,7 +3786,11 @@ func ReportDeletionProgress(t *testing.T, iteration int, elapsed, remaining time
 	azureRGStatus := "n/a"
 	if status.AROProviderSpecific != nil {
 		if !status.AROProviderSpecific.RGChecked {
-			azureRGStatus = "unknown"
+			if status.AROProviderSpecific.RGError != "" {
+				azureRGStatus = "error: " + status.AROProviderSpecific.RGError
+			} else {
+				azureRGStatus = "unchecked"
+			}
 		} else if status.AROProviderSpecific.RGExists {
 			azureRGStatus = "exists"
 		} else {


### PR DESCRIPTION
## Description

Replace the uninformative "unknown" Azure Resource Group deletion status with actionable error messages. When `az group show` fails during deletion monitoring, the test output now shows the actual error (auth expiry, throttling, etc.) instead of a generic `❓ ... (unknown)`.

Ref: [ARO-27859](https://redhat.atlassian.net/browse/ARO-27859)

## Changes Made

- Add `RGError` field to `ARODeletionStatus` struct to capture why the `az` CLI check failed
- Handle `az group show` edge case where command succeeds but returns empty output
- Detect "deleting" / "deprovisioning" states in `az` error output and report them as `Deleting` instead of `unknown`
- Show warning icon with error message when the RG check fails, instead of `❓ (unknown)`
- Include error details in `ReportDeletionProgress` log output
- Handle defensive case where `az` CLI is unavailable

## Configuration Changes

No new environment variables.

## Additional Notes

**Before**: `❓ Azure RG: capz-tests-bd2ec6-resgroup (unknown)`

**After** (depending on failure cause):
- `⚠️ Azure RG: capz-tests-bd2ec6-resgroup (exit status 1: AuthenticationFailed...)`
- `🔄 Azure RG: capz-tests-bd2ec6-resgroup (Deleting)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-27859]: https://redhat.atlassian.net/browse/ARO-27859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Azure resource-group error reporting during cluster deletion to surface explicit error details when checks fail (instead of generic or unknown messaging).
  * Improved deletion status visibility by clearly distinguishing unchecked Azure RG status from real failure states, including cases where the resource group is still deleting/deprovisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->