### PR TITLE
fix: use stolostron module path in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rcap/capi-tests
+module github.com/stolostron/capi-tests
 
 go 1.24
 


### PR DESCRIPTION
## Description

Fix the Go module path from `github.com/rcap/capi-tests` (personal fork) to `github.com/stolostron/capi-tests` (org repo).

## Changes Made

- Updated `go.mod` module declaration to `github.com/stolostron/capi-tests`

## Additional Notes

The incorrect module path caused the JUnit XML `<testsuite name="...">` to be `github.com/rcap/capi-tests/test` instead of `github.com/stolostron/capi-tests/test`. This prevented Sippy from importing our test results, since the suite name must match an entry in Sippy's allowlist.

Companion PR: https://github.com/openshift/sippy/pull/3697 (adds our suite to Sippy's allowlist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project module path to the new repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->