### PR TITLE
fix: skip management-cluster workflow for Dependabot PRs (ARO-28172)

### DIFF
--- a/.github/workflows/management-cluster-aro.yml
+++ b/.github/workflows/management-cluster-aro.yml
@@ -9,6 +9,9 @@ name: Management Cluster (ARO)
 #   - Push to main (post-merge validation)
 #   - Manual dispatch
 #
+# Skips:
+#   - Dependabot PRs (GitHub does not expose secrets to Dependabot workflows)
+#
 # Requires:
 #   - Repository secret: QUAY_AUTH
 #
@@ -47,7 +50,7 @@ env:
 jobs:
   management-cluster:
     name: Management Cluster (ARO/CAPZ)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 60
 


### PR DESCRIPTION
## Description

Skip the Management Cluster (ARO) workflow for Dependabot PRs. GitHub does not expose repository secrets to Dependabot-triggered workflows, causing the job to fail at credential validation (QUAY_AUTH is empty).

JIRA: https://redhat.atlassian.net/browse/ARO-28172

## Changes Made

- Added `github.actor != 'dependabot[bot]'` condition to the management-cluster job in `management-cluster-aro.yml`
- Added "Skips" section to workflow header comment documenting the Dependabot exclusion

## Configuration Changes

No new environment variables.

## Additional Notes

- Only `management-cluster-aro.yml` is affected — it's the only PR-triggered workflow using `QUAY_AUTH`
- Security workflows (gosec, govulncheck, nancy, trivy) only use `GITHUB_TOKEN`, which is always available to Dependabot
- The ROSA management cluster workflow is already disabled (`if: false`)
- Dependabot PRs are dependency version bumps (action pins, go modules) — the management cluster deployment adds no validation value for these changes

Generated with [Claude Code](https://claude.com/claude-code)