### PR TITLE
fix: ignore ocp/builder in Dependabot Docker updates (ARO-28382)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,10 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    ignore:
+      # registry.ci.openshift.org requires Red Hat SSO auth — Dependabot cannot access it;
+      # ocp/builder images are managed by OpenShift CI and intentionally pinned.
+      - dependency-name: "ocp/builder"
 
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Description

Stops Dependabot from failing on every run with
`private_source_authentication_failure` when it tries to check
`ocp/builder` images from `registry.ci.openshift.org`.

Ref: ARO-28382

## Changes Made

- Added an `ignore` rule for `ocp/builder` in the Docker Dependabot
  block (`.github/dependabot.yml`)

## Configuration Changes

N/A

## Additional Notes

`registry.ci.openshift.org` requires Red Hat SSO authentication.
Dependabot has no credentials for this private registry. The
`ocp/builder` image used in `Dockerfile.prow` is managed by OpenShift
CI and is intentionally pinned — it is not meant to be updated via
Dependabot.

This is distinct from ARO-28172 (already closed), which addressed
workflow failures for Dependabot PRs due to missing secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)