### PR TITLE
fix: retroactively tag untagged RGs and run tagging earlier in Phase 05 (ARO-28424)

### DIFF
--- a/scripts/check-stale-resources.sh
+++ b/scripts/check-stale-resources.sh
@@ -194,6 +194,10 @@ check_azure_resource_groups_by_convention() {
     local tagged_rg_names
     tagged_rg_names=$(echo "$AZURE_RGS_JSON" | jq -r '.[].name' 2>/dev/null || echo "")
 
+    # Cache subscription ID for retroactive tagging (computed once, used per RG)
+    local subscription_id
+    subscription_id=$(az account show --query id -o tsv 2>/dev/null || echo "")
+
     local all_rgs_json
     all_rgs_json=$(az group list \
         --query "[].{name: name, location: location, tags: tags}" \
@@ -292,6 +296,22 @@ check_azure_resource_groups_by_convention() {
                 --argjson resourceCount "$resource_count" \
                 '{name: $name, location: $location, createdAt: $createdAt, user: $user, env: $env, detection: $detection, resourceCount: $resourceCount}')
             stale_convention_rgs=$(echo "$stale_convention_rgs" | jq --argjson rg "$enriched" '. + [$rg]')
+
+            # Retroactively tag the RG so future scans can find it via capi-test-created-at.
+            # Phase 04 defers tagging when ASO hasn't created the RG yet; if the run is killed
+            # before Phase 05 retries, the RG ends up permanently untagged.
+            # az tag update --operation Merge adds tags without removing existing ones.
+            if [[ -n "$subscription_id" ]]; then
+                local resource_id="/subscriptions/${subscription_id}/resourceGroups/${rg_name}"
+                local tag_json
+                tag_json=$(jq -n --arg ts "$created_at" '{"capi-test-created-at": $ts, "capi-test-detection": "convention-retroactive"}')
+                if az tag update --resource-id "$resource_id" --operation Merge --tags "$tag_json" \
+                        >/dev/null 2>&1; then
+                    print_info "Retroactively tagged ${rg_name} with capi-test-created-at=${created_at}"
+                else
+                    print_warning "Could not retroactively tag ${rg_name} (non-fatal)"
+                fi
+            fi
         fi
     done < <(echo "$convention_rgs" | jq -c '.[]')
 

--- a/scripts/check-stale-resources.sh
+++ b/scripts/check-stale-resources.sh
@@ -303,9 +303,8 @@ check_azure_resource_groups_by_convention() {
             # az tag update --operation Merge adds tags without removing existing ones.
             if [[ -n "$subscription_id" ]]; then
                 local resource_id="/subscriptions/${subscription_id}/resourceGroups/${rg_name}"
-                local tag_json
-                tag_json=$(jq -n --arg ts "$created_at" '{"capi-test-created-at": $ts, "capi-test-detection": "convention-retroactive"}')
-                if az tag update --resource-id "$resource_id" --operation Merge --tags "$tag_json" \
+                if az tag update --resource-id "$resource_id" --operation Merge \
+                        --tags "capi-test-created-at=$created_at" "capi-test-detection=convention-retroactive" \
                         >/dev/null 2>&1; then
                     print_info "Retroactively tagged ${rg_name} with capi-test-created-at=${created_at}"
                 else

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -247,6 +247,74 @@ func TestDeployment_ApplyClusterYAMLs(t *testing.T) {
 	t.Logf("All %d YAML files applied successfully", len(expectedFiles))
 }
 
+// TestDeployment_TagAzureResources tags all Azure resources created by the deployment
+// with ownership metadata for parallel run cleanup. Tags the resource group (ARM tags)
+// and Azure AD Applications/Service Principals (Microsoft Graph tags).
+//
+// Runs immediately after CR apply (before credential validation and monitoring) so that
+// even killed or interrupted test runs leave tagged resources traceable to their owner.
+// Phase 04 defers tagging when ASO has not created the RG yet; this test polls for the
+// RG to appear so the tag is applied as soon as possible after CRs land.
+//
+// Non-fatal: failures are logged as warnings since tagging is for cleanup convenience only.
+func TestDeployment_TagAzureResources(t *testing.T) {
+	config := NewTestConfig()
+
+	if config.InfraProviderName != "aro" {
+		t.Skipf("Azure resource tagging only applies to ARO provider")
+		return
+	}
+
+	if err := EnsureAzureCliLogin(t); err != nil {
+		t.Logf("Warning: Azure CLI auth unavailable for resource tagging: %v — resources will be created without tags", err)
+		return
+	}
+
+	PrintToTTY("\n=== Tagging Azure Resources ===\n")
+
+	// Wait for the resource group to be created by ASO (triggered by CAPZ reconciliation).
+	// The RG is created asynchronously after CRs are applied, typically within a few minutes.
+	rgTimeout, err := time.ParseDuration(GetEnvOrDefault("AZURE_RG_CREATION_TIMEOUT", "10m"))
+	if err != nil {
+		t.Logf("Warning: invalid AZURE_RG_CREATION_TIMEOUT format, using default 10m: %v", err)
+		rgTimeout = 10 * time.Minute
+	}
+	rgPollInterval, err := time.ParseDuration(GetEnvOrDefault("AZURE_RG_POLL_INTERVAL", "15s"))
+	if err != nil {
+		t.Logf("Warning: invalid AZURE_RG_POLL_INTERVAL format, using default 15s: %v", err)
+		rgPollInterval = 15 * time.Second
+	}
+	rgStart := time.Now()
+	rgExists := false
+
+	PrintToTTY("Waiting for resource group %s to be created by ASO...\n", config.ResourceGroupName)
+	for time.Since(rgStart) < rgTimeout {
+		_, err := RunCommandQuiet(t, "az", "group", "show", "--name", config.ResourceGroupName)
+		if err == nil {
+			rgExists = true
+			PrintToTTY("✅ Resource group %s exists (waited %v)\n", config.ResourceGroupName, time.Since(rgStart).Round(time.Second))
+			break
+		}
+		PrintToTTY("⏳ Resource group not yet created (elapsed %v)\n", time.Since(rgStart).Round(time.Second))
+		time.Sleep(rgPollInterval)
+	}
+
+	if !rgExists {
+		t.Logf("Warning: resource group %s not created within %v, skipping tagging", config.ResourceGroupName, rgTimeout)
+		PrintToTTY("⚠️  Resource group not created within %v, skipping tagging\n\n", rgTimeout)
+		return
+	}
+
+	PrintToTTY("Tagging resource group %s...\n", config.ResourceGroupName)
+	if err := TagAzureResourceGroup(t, config); err != nil {
+		t.Logf("Warning: failed to tag resource group: %v", err)
+	}
+	tagAzureADApplications(t, config)
+	tagAzureServicePrincipals(t, config)
+
+	PrintToTTY("✅ Azure resource tagging completed\n\n")
+}
+
 // TestDeployment_ProviderCredentialsConfigured validates that provider credential secrets
 // are properly configured after applying YAML files.
 // Both ARO and ROSA use namespace-scoped credentials, so no controller restart is needed.
@@ -336,74 +404,6 @@ func TestDeployment_ProviderCredentialsConfigured(t *testing.T) {
 			t.Logf("%s credentials are properly configured", provider.Name)
 		})
 	}
-}
-
-// TestDeployment_TagAzureResources tags all Azure resources created by the deployment
-// with ownership metadata for parallel run cleanup. Tags the resource group (ARM tags)
-// and Azure AD Applications/Service Principals (Microsoft Graph tags).
-//
-// Runs early in the deployment sequence (before monitoring) so that even failed or
-// interrupted test runs leave tagged resources that can be traced back to their owner.
-// The resource group is created asynchronously by ASO (triggered by CAPZ reconciliation),
-// so this test polls for it to appear before tagging.
-//
-// Non-fatal: failures are logged as warnings since tagging is for cleanup convenience only.
-func TestDeployment_TagAzureResources(t *testing.T) {
-	config := NewTestConfig()
-
-	if config.InfraProviderName != "aro" {
-		t.Skipf("Azure resource tagging only applies to ARO provider")
-		return
-	}
-
-	if err := EnsureAzureCliLogin(t); err != nil {
-		t.Logf("Warning: Azure CLI auth unavailable for resource tagging: %v — resources will be created without tags", err)
-		return
-	}
-
-	PrintToTTY("\n=== Tagging Azure Resources ===\n")
-
-	// Wait for the resource group to be created by ASO (triggered by CAPZ reconciliation).
-	// The RG is created asynchronously after CRs are applied, typically within a few minutes.
-	rgTimeout, err := time.ParseDuration(GetEnvOrDefault("AZURE_RG_CREATION_TIMEOUT", "10m"))
-	if err != nil {
-		t.Logf("Warning: invalid AZURE_RG_CREATION_TIMEOUT format, using default 10m: %v", err)
-		rgTimeout = 10 * time.Minute
-	}
-	rgPollInterval, err := time.ParseDuration(GetEnvOrDefault("AZURE_RG_POLL_INTERVAL", "15s"))
-	if err != nil {
-		t.Logf("Warning: invalid AZURE_RG_POLL_INTERVAL format, using default 15s: %v", err)
-		rgPollInterval = 15 * time.Second
-	}
-	rgStart := time.Now()
-	rgExists := false
-
-	PrintToTTY("Waiting for resource group %s to be created by ASO...\n", config.ResourceGroupName)
-	for time.Since(rgStart) < rgTimeout {
-		_, err := RunCommandQuiet(t, "az", "group", "show", "--name", config.ResourceGroupName)
-		if err == nil {
-			rgExists = true
-			PrintToTTY("✅ Resource group %s exists (waited %v)\n", config.ResourceGroupName, time.Since(rgStart).Round(time.Second))
-			break
-		}
-		PrintToTTY("⏳ Resource group not yet created (elapsed %v)\n", time.Since(rgStart).Round(time.Second))
-		time.Sleep(rgPollInterval)
-	}
-
-	if !rgExists {
-		t.Logf("Warning: resource group %s not created within %v, skipping tagging", config.ResourceGroupName, rgTimeout)
-		PrintToTTY("⚠️  Resource group not created within %v, skipping tagging\n\n", rgTimeout)
-		return
-	}
-
-	PrintToTTY("Tagging resource group %s...\n", config.ResourceGroupName)
-	if err := TagAzureResourceGroup(t, config); err != nil {
-		t.Logf("Warning: failed to tag resource group: %v", err)
-	}
-	tagAzureADApplications(t, config)
-	tagAzureServicePrincipals(t, config)
-
-	PrintToTTY("✅ Azure resource tagging completed\n\n")
 }
 
 // TestDeployment_MonitorCluster tests monitoring the ARO cluster deployment


### PR DESCRIPTION
## Description

Fix resource group tagging when ASO creates the RG after Phase 04 defers and the run is killed before Phase 05 can retry.

Phase 04 defers RG tagging when ASO hasn't yet created the resource group. If the test run is killed between Phase 04 completing and Phase 05's tagging step executing, the RG created asynchronously by ASO ends up permanently untagged — invisible to tag-based cleanup queries.

JIRA: https://redhat.atlassian.net/browse/ARO-28424

## Changes Made

- `scripts/check-stale-resources.sh`: when `check_azure_resource_groups_by_convention` finds a stale untagged RG with a known creation timestamp, applies `capi-test-created-at` and `capi-test-detection=convention-retroactive` tags via `az tag update --operation Merge` (merges without removing existing tags). Self-heals existing untagged RGs on the next stale scan.
- `test/05_deploy_crs_test.go`: moved `TestDeployment_TagAzureResources` to run immediately after `TestDeployment_ApplyClusterYAMLs` (before credential validation), reducing the window in which a killed process leaves an ASO-created RG permanently untagged.

## Configuration Changes

No new environment variables.

| Variable | Purpose | Default |
|----------|---------|---------|
|          |         |         |

## Additional Notes

The retroactive tagging in the stale scanner is the primary fix — it handles all existing and future cases of untagged RGs regardless of how they were created. The test reorder is a secondary improvement that minimises the race window on future runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)