### PR TITLE
Use certificate-authority bundle for MCE cluster login

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,6 +414,8 @@ This is validated during Check Dependencies (phase 1) to prevent late deployment
 ### MCE Component Management
 - `MCE_AUTO_ENABLE` - Auto-enable MCE CAPI/CAPZ components if not found on external cluster (default: `true` when `USE_KUBECONFIG` is set)
 - `MCE_ENABLEMENT_TIMEOUT` - Timeout for waiting after MCE component enablement (default: `15m`, format: Go duration)
+- `MCE_API_CA_BUNDLE` - Path to CA bundle file for TLS verification of the MCE API server (recommended for production use)
+- `MCE_INSECURE_TLS` - Set to `true` to skip TLS certificate verification for MCE cluster login (local dev only; never set in CI)
 
 When using an external MCE cluster (`USE_KUBECONFIG`), the test suite will:
 1. Detect if the cluster is an MCE installation

--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@ The test suite integrates with GitHub Actions:
 | Variable | `MCE_API_URL` | MCE cluster API endpoint (optional, for MCE mode) |
 | Variable | `MCE_API_USER` | MCE cluster username (optional, default: `kubeadmin`) |
 | Secret | `MCE_API_PASSWORD` | MCE cluster password (optional, for MCE mode) |
+| Variable | `MCE_API_CA_BUNDLE` | Path to CA bundle for MCE TLS verification (recommended) |
 
 **GitHub Actions Environment: `rosa-stage`** (used by ROSA workflows):
 
@@ -566,6 +567,7 @@ The test suite integrates with GitHub Actions:
 | Variable | `MCE_API_URL` | MCE cluster API endpoint (optional, for MCE mode) |
 | Variable | `MCE_API_USER` | MCE cluster username (optional, default: `kubeadmin`) |
 | Secret | `MCE_API_PASSWORD` | MCE cluster password (optional, for MCE mode) |
+| Variable | `MCE_API_CA_BUNDLE` | Path to CA bundle for MCE TLS verification (recommended) |
 
 ## Contributing
 

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -85,6 +85,11 @@ func TestCheckDependencies_OptionalTools(t *testing.T) {
 // 3. Validates authentication with oc whoami
 // 4. Fails immediately if authentication fails
 // Runs FIRST to populate kubeconfig before TestCheckDependencies_ExternalKubeconfig validates it.
+//
+// TLS verification (in order of precedence):
+//   - MCE_API_CA_BUNDLE set: use --certificate-authority=<path> (recommended)
+//   - MCE_INSECURE_TLS=true: use --insecure-skip-tls-verify (opt-in for local dev only)
+//   - neither: rely on the system certificate store
 func TestCheckDependencies_MCEAuthentication(t *testing.T) {
 	config := NewTestConfig()
 
@@ -105,6 +110,9 @@ func TestCheckDependencies_MCEAuthentication(t *testing.T) {
 			"  - MCE_API_URL: MCE cluster API URL\n" +
 			"  - MCE_API_USER: MCE cluster username (default: kubeadmin)\n" +
 			"  - MCE_API_PASSWORD: MCE cluster password\n\n" +
+			"Optional TLS environment variables:\n" +
+			"  - MCE_API_CA_BUNDLE: path to CA bundle for TLS verification (recommended)\n" +
+			"  - MCE_INSECURE_TLS: set to 'true' to skip TLS verification (local dev only)\n\n" +
 			"Configure these in your environment or GitHub workflow.")
 	}
 
@@ -127,11 +135,24 @@ func TestCheckDependencies_MCEAuthentication(t *testing.T) {
 	PrintToTTY("Logging into MCE cluster...\n")
 	t.Logf("Attempting oc login to %s (KUBECONFIG=%s)", mceAPIURL, kubeconfigPath)
 
+	mceCABundle := GetEnvOrDefault("MCE_API_CA_BUNDLE", "")
+	mceInsecureTLS := GetEnvOrDefault("MCE_INSECURE_TLS", "false") == "true"
+
+	ocLoginArgs := []string{"login", mceAPIURL, "-u", mceUser}
+	switch {
+	case mceCABundle != "":
+		PrintToTTY("TLS: using certificate authority from MCE_API_CA_BUNDLE\n")
+		ocLoginArgs = append(ocLoginArgs, "--certificate-authority="+mceCABundle)
+	case mceInsecureTLS:
+		t.Logf("Warning: MCE_INSECURE_TLS=true — TLS certificate verification disabled")
+		PrintToTTY("TLS: certificate verification disabled (MCE_INSECURE_TLS=true)\n")
+		ocLoginArgs = append(ocLoginArgs, "--insecure-skip-tls-verify")
+	default:
+		PrintToTTY("TLS: using system certificate store\n")
+	}
+
 	// Pass password via stdin to avoid exposing it in process list (ps aux)
-	// oc login will prompt for password and read it from stdin
-	output, err := RunCommandWithStdin(t, mcePassword+"\n", "oc", "login", mceAPIURL,
-		"--insecure-skip-tls-verify",
-		"-u", mceUser)
+	output, err := RunCommandWithStdin(t, mcePassword+"\n", "oc", ocLoginArgs...)
 
 	if err != nil {
 		PrintToTTY("❌ Failed to login to MCE cluster\n\n")
@@ -143,7 +164,8 @@ func TestCheckDependencies_MCEAuthentication(t *testing.T) {
 		PrintToTTY("%s\n\n", ocVersion)
 		t.Fatalf("MCE authentication failed: %v\n\nOutput: %s\n\n"+
 			"KUBECONFIG: %s\n"+
-			"Ensure MCE_API_URL, MCE_API_USER, and MCE_API_PASSWORD are correct.", err, output, os.Getenv("KUBECONFIG"))
+			"Ensure MCE_API_URL, MCE_API_USER, MCE_API_PASSWORD are correct.\n"+
+			"For TLS: set MCE_API_CA_BUNDLE to the CA bundle path, or MCE_INSECURE_TLS=true for local dev.", err, output, os.Getenv("KUBECONFIG"))
 	}
 
 	PrintToTTY("✅ Successfully logged into MCE cluster\n\n")

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -135,8 +136,16 @@ func TestCheckDependencies_MCEAuthentication(t *testing.T) {
 	PrintToTTY("Logging into MCE cluster...\n")
 	t.Logf("Attempting oc login to %s (KUBECONFIG=%s)", mceAPIURL, kubeconfigPath)
 
-	mceCABundle := GetEnvOrDefault("MCE_API_CA_BUNDLE", "")
-	mceInsecureTLS := GetEnvOrDefault("MCE_INSECURE_TLS", "false") == "true"
+	mceCABundle := strings.TrimSpace(GetEnvOrDefault("MCE_API_CA_BUNDLE", ""))
+
+	mceInsecureTLS := false
+	if raw := strings.TrimSpace(os.Getenv("MCE_INSECURE_TLS")); raw != "" {
+		var parseErr error
+		mceInsecureTLS, parseErr = strconv.ParseBool(raw)
+		if parseErr != nil {
+			t.Fatalf("MCE_INSECURE_TLS must be a boolean (true/false), got: %q", raw)
+		}
+	}
 
 	ocLoginArgs := []string{"login", mceAPIURL, "-u", mceUser}
 	switch {

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -141,6 +141,11 @@ func TestCheckDependencies_MCEAuthentication(t *testing.T) {
 	ocLoginArgs := []string{"login", mceAPIURL, "-u", mceUser}
 	switch {
 	case mceCABundle != "":
+		if !FileExists(mceCABundle) {
+			t.Fatalf("MCE_API_CA_BUNDLE file not found: %s\n\n"+
+				"Set MCE_API_CA_BUNDLE to a valid CA bundle file path, "+
+				"or unset it to use the system certificate store.", mceCABundle)
+		}
 		PrintToTTY("TLS: using certificate authority from MCE_API_CA_BUNDLE\n")
 		ocLoginArgs = append(ocLoginArgs, "--certificate-authority="+mceCABundle)
 	case mceInsecureTLS:


### PR DESCRIPTION
## Description

Replace the hard-coded `--insecure-skip-tls-verify` flag on `oc login` with a
configurable TLS strategy for MCE cluster authentication. Insecure mode becomes
an explicit opt-in rather than the unconditional default.

## Changes Made

- `test/01_check_dependencies_test.go`: build `oc login` args conditionally based on `MCE_API_CA_BUNDLE` / `MCE_INSECURE_TLS`; validate that `MCE_API_CA_BUNDLE` file exists before passing to `oc`; update credential-missing error message to document TLS options
- `CLAUDE.md`: document `MCE_API_CA_BUNDLE` and `MCE_INSECURE_TLS` env vars
- `README.md`: add `MCE_API_CA_BUNDLE` to both GitHub Actions environment tables

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `MCE_API_CA_BUNDLE` | Path to CA bundle file for TLS verification of the MCE API server | *(none — uses system store)* |
| `MCE_INSECURE_TLS` | Set to `true` to skip TLS certificate verification (local dev only) | `false` |

**TLS priority order:**
1. `MCE_API_CA_BUNDLE` set → `--certificate-authority=<path>`
2. `MCE_INSECURE_TLS=true` → `--insecure-skip-tls-verify` (with warning log)
3. Neither → system certificate store

## Additional Notes

`MCE_INSECURE_TLS=true` should never be set in CI workflows. The existing
`MCE_API_PASSWORD` stdin-passing pattern is preserved unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)