### PR TITLE
Avoid passing Azure SP secret as az login process argument

### DIFF
--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3686,12 +3686,14 @@ func ValidateServicePrincipalCredentials(t *testing.T) error {
 			clientID != "", clientSecret != "", tenantID != "")
 	}
 
-	// Test login with service principal (using --allow-no-subscriptions in case SP has no subscription access)
+	// Test login with service principal (using --allow-no-subscriptions in case SP has no subscription access).
+	// AZURE_CLIENT_SECRET is read from the environment by az — do not pass via -p argv to
+	// avoid the secret appearing in /proc/*/cmdline for the lifetime of the az process.
 	t.Log("Validating service principal credentials...")
+	_ = clientSecret // validated non-empty above; az reads AZURE_CLIENT_SECRET from env
 	_, err := RunCommandQuiet(t, "az", "login",
 		"--service-principal",
 		"-u", clientID,
-		"-p", clientSecret,
 		"--tenant", tenantID,
 		"--allow-no-subscriptions")
 	if err != nil {
@@ -3734,14 +3736,14 @@ func EnsureAzureCliLogin(t *testing.T) error {
 		}
 
 		clientID := os.Getenv("AZURE_CLIENT_ID")
-		clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
 		tenantID := os.Getenv("AZURE_TENANT_ID")
 
+		// AZURE_CLIENT_SECRET is read from the environment by az — do not pass via -p argv to
+		// avoid the secret appearing in /proc/*/cmdline for the lifetime of the az process.
 		t.Log("Azure CLI not logged in, authenticating with service principal...")
 		if _, err := RunCommandQuiet(t, "az", "login",
 			"--service-principal",
 			"-u", clientID,
-			"-p", clientSecret,
 			"--tenant", tenantID,
 			"--allow-no-subscriptions"); err != nil {
 			return fmt.Errorf("az login with service principal failed: %w", err)


### PR DESCRIPTION
## Description

`ValidateServicePrincipalCredentials` and `EnsureAzureCliLogin` previously
passed `AZURE_CLIENT_SECRET` as a positional `-p` argument to `az login`,
making the raw secret visible in `/proc/*/cmdline` for the lifetime of the
`az` process. Azure CLI natively reads `AZURE_CLIENT_SECRET` from the
environment when `-p` is omitted, so removing the argument is sufficient —
the secret is already in the environment at the point both functions are called.

## Changes Made

- `test/helpers.go` (`ValidateServicePrincipalCredentials`): remove `-p clientSecret` from `az login` argv; add comment explaining the env-based delivery
- `test/helpers.go` (`EnsureAzureCliLogin`): same — remove `-p clientSecret` and the now-unused `clientSecret` local variable

## Additional Notes

This mirrors the pattern already used elsewhere in the repo
(`RunCommandWithStdin` for passwords, `--patch-file` for kubectl patches)
of keeping secrets out of process arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)