### PR TITLE
Tag Prow image with git SHA and sign with cosign keyless

### DIFF
--- a/.github/workflows/build-prow-image.yml
+++ b/.github/workflows/build-prow-image.yml
@@ -5,7 +5,9 @@ on:
     branches: [main]
     paths: [Dockerfile.prow]
 
-permissions: read-all
+permissions:
+  contents: read
+  id-token: write  # required for cosign OIDC keyless signing
 
 jobs:
   build-and-push:
@@ -13,12 +15,23 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+    - name: Install cosign
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
     - name: Build image
-      run: docker build -f Dockerfile.prow -t quay.io/rcap/capi-tests-prow:latest .
+      env:
+        IMAGE_SHA: ${{ github.sha }}
+      run: |
+        docker build -f Dockerfile.prow \
+          -t "quay.io/rcap/capi-tests-prow:${IMAGE_SHA}" \
+          -t quay.io/rcap/capi-tests-prow:latest \
+          .
 
     - name: Push to quay.io
+      id: push
       env:
         QUAY_AUTH: ${{ secrets.QUAY_AUTH }}
+        IMAGE_SHA: ${{ github.sha }}
       run: |
         echo "::add-mask::${QUAY_AUTH}"
         DECODED=$(echo "${QUAY_AUTH}" | base64 -d)
@@ -27,7 +40,15 @@ jobs:
         PASSWORD="${DECODED#*:}"
         echo "::add-mask::${PASSWORD}"
         echo "${PASSWORD}" | docker login quay.io --username "${USERNAME}" --password-stdin
+        docker push "quay.io/rcap/capi-tests-prow:${IMAGE_SHA}"
         docker push quay.io/rcap/capi-tests-prow:latest
+        DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' quay.io/rcap/capi-tests-prow:latest)
+        echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+    - name: Sign image with cosign
+      env:
+        IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
+      run: cosign sign --yes "${IMAGE_DIGEST}"
 
     - name: Cleanup Docker credentials
       if: always()

--- a/.github/workflows/build-prow-image.yml
+++ b/.github/workflows/build-prow-image.yml
@@ -3,7 +3,10 @@ name: Build Prow Image
 on:
   push:
     branches: [main]
-    paths: [Dockerfile.prow]
+    paths:
+      - Dockerfile.prow
+      - .github/workflows/build-prow-image.yml
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -43,6 +46,10 @@ jobs:
         docker push "quay.io/rcap/capi-tests-prow:${IMAGE_SHA}"
         docker push quay.io/rcap/capi-tests-prow:latest
         DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' quay.io/rcap/capi-tests-prow:latest)
+        if [[ -z "${DIGEST}" ]]; then
+          echo "::error::Failed to resolve image digest — RepoDigests is empty after push"
+          exit 1
+        fi
         echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
     - name: Sign image with cosign


### PR DESCRIPTION
## Description

Two improvements to `build-prow-image.yml`:

1. **Immutable SHA tag** — image is now pushed as both
   `quay.io/rcap/capi-tests-prow:<git-sha>` and `:latest`, so downstream
   Prow job definitions can reference an immutable digest instead of the
   mutable `:latest` tag.

2. **Cosign keyless signing** — after pushing, the image is signed using
   [sigstore/cosign-installer](https://github.com/sigstore/cosign-installer)
   v4.1.2 with GitHub OIDC keyless signing. No long-lived signing key is
   needed; the OIDC token is scoped to this workflow run. `id-token: write`
   is added to the permissions block for this purpose.

All `${{ }}` expression values that flow into `run:` steps are passed
through `env:` variables to prevent injection.

## Changes Made

- `.github/workflows/build-prow-image.yml`:
  - `permissions: read-all` → explicit `contents: read` + `id-token: write`
  - Add `sigstore/cosign-installer@6f9f17...` step (pinned by SHA)
  - Build with two tags: `:<git-sha>` and `:latest`
  - Push both tags; capture digest from `docker inspect`
  - Sign image via `cosign sign --yes "${IMAGE_DIGEST}"`
  - Expression values moved to `env:` vars in all `run:` steps

## Additional Notes

Verify a pushed image with:
```bash
cosign verify quay.io/rcap/capi-tests-prow:<sha> \
  --certificate-identity-regexp 'https://github.com/stolostron/capi-tests/.*' \
  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)