### PR TITLE
fix: Kind cluster substring match + az login SP secret handling

### DIFF
--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -364,7 +364,13 @@ func TestKindCluster_01_ClusterReady(t *testing.T) {
 		PrintToTTY("\n=== Checking for existing Kind management cluster ===\n")
 		t.Log("Checking for existing Kind cluster")
 		output, _ = RunCommand(t, "kind", "get", "clusters")
-		clusterExists := strings.Contains(output, config.ManagementClusterName)
+		clusterExists := false
+		for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+			if strings.TrimSpace(line) == config.ManagementClusterName {
+				clusterExists = true
+				break
+			}
+		}
 		needsDeployment = !clusterExists
 	}
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3687,13 +3687,25 @@ func ValidateServicePrincipalCredentials(t *testing.T) error {
 	}
 
 	// Test login with service principal (using --allow-no-subscriptions in case SP has no subscription access).
-	// AZURE_CLIENT_SECRET is read from the environment by az — do not pass via -p argv to
-	// avoid the secret appearing in /proc/*/cmdline for the lifetime of the az process.
+	// Write the secret to a temp file and pass via -p @file to keep it out of /proc/*/cmdline.
 	t.Log("Validating service principal credentials...")
-	_ = clientSecret // validated non-empty above; az reads AZURE_CLIENT_SECRET from env
-	_, err := RunCommandQuiet(t, "az", "login",
+	secretFile, err := os.CreateTemp("", "az-sp-secret-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file for SP secret: %w", err)
+	}
+	defer os.Remove(secretFile.Name())
+	if _, err := secretFile.WriteString(clientSecret); err != nil {
+		_ = secretFile.Close()
+		return fmt.Errorf("failed to write SP secret to temp file: %w", err)
+	}
+	if err := secretFile.Close(); err != nil {
+		return fmt.Errorf("failed to close SP secret temp file: %w", err)
+	}
+
+	_, err = RunCommandQuiet(t, "az", "login",
 		"--service-principal",
 		"-u", clientID,
+		"-p", "@"+secretFile.Name(),
 		"--tenant", tenantID,
 		"--allow-no-subscriptions")
 	if err != nil {
@@ -3736,14 +3748,28 @@ func EnsureAzureCliLogin(t *testing.T) error {
 		}
 
 		clientID := os.Getenv("AZURE_CLIENT_ID")
+		clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
 		tenantID := os.Getenv("AZURE_TENANT_ID")
 
-		// AZURE_CLIENT_SECRET is read from the environment by az — do not pass via -p argv to
-		// avoid the secret appearing in /proc/*/cmdline for the lifetime of the az process.
+		// Write the secret to a temp file and pass via -p @file to keep it out of /proc/*/cmdline.
 		t.Log("Azure CLI not logged in, authenticating with service principal...")
+		secretFile, fileErr := os.CreateTemp("", "az-sp-secret-*")
+		if fileErr != nil {
+			return fmt.Errorf("failed to create temp file for SP secret: %w", fileErr)
+		}
+		defer os.Remove(secretFile.Name())
+		if _, fileErr = secretFile.WriteString(clientSecret); fileErr != nil {
+			_ = secretFile.Close()
+			return fmt.Errorf("failed to write SP secret to temp file: %w", fileErr)
+		}
+		if fileErr = secretFile.Close(); fileErr != nil {
+			return fmt.Errorf("failed to close SP secret temp file: %w", fileErr)
+		}
+
 		if _, err := RunCommandQuiet(t, "az", "login",
 			"--service-principal",
 			"-u", clientID,
+			"-p", "@"+secretFile.Name(),
 			"--tenant", tenantID,
 			"--allow-no-subscriptions"); err != nil {
 			return fmt.Errorf("az login with service principal failed: %w", err)


### PR DESCRIPTION
## Summary
- **Commit 1**: Fix `strings.Contains` substring match in `03_cluster_test.go:367` that causes false positives when detecting existing Kind management clusters. A leftover workload cluster `capz-tests-stage-workload` falsely matches `capz-tests-stage`.
- **Commit 2**: Fix `az login --service-principal` broken by #799 — `az` does not read `AZURE_CLIENT_SECRET` from the environment or stdin. Write the secret to a temp file and pass via `-p @file` to keep it out of `/proc/*/cmdline`.

## Test plan
- [ ] Run `test0.sh aro` with stale Kind workload clusters present — management cluster should be created correctly
- [ ] Verify `az login` succeeds during `TestCheckDependencies_AzureAuthentication`
- [ ] Verify SP secret does not appear in `ps aux` output during `az login`

Fixes: [ARO-28873](https://redhat.atlassian.net/browse/ARO-28873), [ARO-28874](https://redhat.atlassian.net/browse/ARO-28874)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-28873]: https://redhat.atlassian.net/browse/ARO-28873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARO-28874]: https://redhat.atlassian.net/browse/ARO-28874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ