### PR TITLE
Enable Management Cluster (ROSA) workflow

### DIFF
--- a/.github/workflows/management-cluster-rosa.yml
+++ b/.github/workflows/management-cluster-rosa.yml
@@ -1,12 +1,8 @@
 name: Management Cluster (ROSA)
 
-# DISABLED: AWS/ROSA support removed — no capacity to maintain (ARO-27468)
-#
 # Management cluster deployment only (no workload cluster provisioning).
 # This workflow deploys a Kind cluster with CAPI/CAPA controllers and validates setup.
 # Does NOT provision ROSA workload clusters.
-#
-# Triggers: DISABLED
 #
 # Requires:
 #   - Repository secret: QUAY_AUTH
@@ -31,7 +27,6 @@ env:
 
 jobs:
   management-cluster:
-    if: false  # DISABLED: AWS/ROSA support removed (ARO-27468)
     name: Management Cluster (ROSA/CAPA)
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
## Summary

- Removes `if: false` guard that was disabling the Management Cluster (ROSA) workflow (added in ARO-27468)
- Cleans up the stale "DISABLED" comments from the workflow header

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and verify it runs (no longer skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)