### PR TITLE
fix: add --repo flag to gh commands in report-failure jobs

### DIFF
--- a/.github/workflows/management-cluster-aro.yml
+++ b/.github/workflows/management-cluster-aro.yml
@@ -289,11 +289,11 @@ jobs:
         PHASE2_OUTCOME: ${{ steps.phase2.outcome }}
         PHASE3_OUTCOME: ${{ steps.phase3.outcome }}
       run: |
-        EXISTING_ISSUE=$(gh issue list --label "automated" --label "test-failure" --state open --json number,title --jq ".[] | select(.title | contains(\"[$WORKFLOW_NAME]\")) | .number | select(. != null)" | head -1)
+        EXISTING_ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "automated" --label "test-failure" --state open --json number,title --jq ".[] | select(.title | contains(\"[$WORKFLOW_NAME]\")) | .number | select(. != null)" | head -1)
 
         if [ -n "$EXISTING_ISSUE" ]; then
           echo "Issue already exists: #$EXISTING_ISSUE"
-          gh issue comment "$EXISTING_ISSUE" --body "Workflow failed again in run: $RUN_URL"
+          gh issue comment "$EXISTING_ISSUE" --repo "$GITHUB_REPOSITORY" --body "Workflow failed again in run: $RUN_URL"
         else
           FAILED_TESTS=$(python3 -c "
         import xml.etree.ElementTree as ET
@@ -337,10 +337,11 @@ jobs:
           echo "*This issue was automatically created by the CI workflow*" >> issue_body.md
 
           # Ensure labels exist (gh issue create fails if label is missing)
-          gh label create "automated" --force 2>/dev/null || true
-          gh label create "test-failure" --color "d93f0b" --force 2>/dev/null || true
+          gh label create "automated" --repo "$GITHUB_REPOSITORY" --force 2>/dev/null || true
+          gh label create "test-failure" --repo "$GITHUB_REPOSITORY" --color "d93f0b" --force 2>/dev/null || true
 
           gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
             --title "[$WORKFLOW_NAME] Workflow failed on $REF_NAME" \
             --body-file issue_body.md \
             --label "automated" \

--- a/.github/workflows/management-cluster-rosa.yml
+++ b/.github/workflows/management-cluster-rosa.yml
@@ -266,11 +266,11 @@ jobs:
         PHASE2_OUTCOME: ${{ steps.phase2.outcome }}
         PHASE3_OUTCOME: ${{ steps.phase3.outcome }}
       run: |
-        EXISTING_ISSUE=$(gh issue list --label "automated" --label "test-failure" --state open --json number,title --jq ".[] | select(.title | contains(\"[$WORKFLOW_NAME]\")) | .number | select(. != null)" | head -1)
+        EXISTING_ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "automated" --label "test-failure" --state open --json number,title --jq ".[] | select(.title | contains(\"[$WORKFLOW_NAME]\")) | .number | select(. != null)" | head -1)
 
         if [ -n "$EXISTING_ISSUE" ]; then
           echo "Issue already exists: #$EXISTING_ISSUE"
-          gh issue comment "$EXISTING_ISSUE" --body "Workflow failed again in run: $RUN_URL"
+          gh issue comment "$EXISTING_ISSUE" --repo "$GITHUB_REPOSITORY" --body "Workflow failed again in run: $RUN_URL"
         else
           FAILED_TESTS=$(python3 -c "
         import xml.etree.ElementTree as ET
@@ -314,10 +314,11 @@ jobs:
           echo "*This issue was automatically created by the CI workflow*" >> issue_body.md
 
           # Ensure labels exist (gh issue create fails if label is missing)
-          gh label create "automated" --force 2>/dev/null || true
-          gh label create "test-failure" --color "d93f0b" --force 2>/dev/null || true
+          gh label create "automated" --repo "$GITHUB_REPOSITORY" --force 2>/dev/null || true
+          gh label create "test-failure" --repo "$GITHUB_REPOSITORY" --color "d93f0b" --force 2>/dev/null || true
 
           gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
             --title "[$WORKFLOW_NAME] Workflow failed on $REF_NAME" \
             --body-file issue_body.md \
             --label "automated" \

--- a/.github/workflows/security-gosec.yml
+++ b/.github/workflows/security-gosec.yml
@@ -93,7 +93,7 @@ jobs:
         SHA: ${{ github.sha }}
       run: |
         # Search for existing open issues with security labels (one issue per scanner type)
-        EXISTING_ISSUE=$(gh issue list --state open --label "security" --label "gosec" --json number --jq ".[0].number" 2>/dev/null || echo "")
+        EXISTING_ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "security" --label "gosec" --json number --jq ".[0].number" 2>/dev/null || echo "")
 
         if [ -n "$EXISTING_ISSUE" ]; then
           echo "Existing issue found: #$EXISTING_ISSUE"
@@ -127,7 +127,7 @@ jobs:
             echo "**Action Required**: Security issues persist. Please review and fix."
           } > comment_body.md
 
-          gh issue comment "$EXISTING_ISSUE" --body-file comment_body.md
+          gh issue comment "$EXISTING_ISSUE" --repo "$GITHUB_REPOSITORY" --body-file comment_body.md
         else
           echo "Creating new issue..."
 
@@ -231,6 +231,7 @@ jobs:
 
           # Create issue with security labels
           gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
             --title "🚨 [gosec] Security issues detected on ${REF_NAME}" \
             --label "security" \
             --label "gosec" \

--- a/.github/workflows/security-govulncheck.yml
+++ b/.github/workflows/security-govulncheck.yml
@@ -78,7 +78,7 @@ jobs:
         EVENT_NAME: ${{ github.event_name }}
       run: |
         # Search for existing open issues with security labels (one issue per scanner type)
-        EXISTING_ISSUE=$(gh issue list --state open --label "security" --label "govulncheck" --json number --jq ".[0].number" 2>/dev/null || echo "")
+        EXISTING_ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "security" --label "govulncheck" --json number --jq ".[0].number" 2>/dev/null || echo "")
 
         if [ -n "$EXISTING_ISSUE" ]; then
           echo "Existing issue found: #$EXISTING_ISSUE"
@@ -106,7 +106,7 @@ jobs:
             echo "**Action Required**: The vulnerabilities listed in this issue are still present. Please prioritize remediation."
           } > comment_body.md
 
-          gh issue comment "$EXISTING_ISSUE" --body-file comment_body.md
+          gh issue comment "$EXISTING_ISSUE" --repo "$GITHUB_REPOSITORY" --body-file comment_body.md
         else
           echo "Creating new issue..."
 
@@ -195,6 +195,7 @@ jobs:
 
           # Create issue with security labels
           gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
             --title "🚨 [govulncheck] Vulnerabilities detected on ${REF_NAME}" \
             --label "security" \
             --label "govulncheck" \

--- a/.github/workflows/security-nancy.yml
+++ b/.github/workflows/security-nancy.yml
@@ -130,7 +130,7 @@ jobs:
         EVENT_NAME: ${{ github.event_name }}
       run: |
         # Search for existing open issues with security labels (one issue per scanner type)
-        EXISTING_ISSUE=$(gh issue list --state open --label "security" --label "nancy" --json number --jq ".[0].number" 2>/dev/null || echo "")
+        EXISTING_ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "security" --label "nancy" --json number --jq ".[0].number" 2>/dev/null || echo "")
 
         if [ -n "$EXISTING_ISSUE" ]; then
           echo "Existing issue found: #$EXISTING_ISSUE"
@@ -158,7 +158,7 @@ jobs:
             echo "**Action Required**: Update vulnerable dependencies to patched versions."
           } > comment_body.md
 
-          gh issue comment "$EXISTING_ISSUE" --body-file comment_body.md
+          gh issue comment "$EXISTING_ISSUE" --repo "$GITHUB_REPOSITORY" --body-file comment_body.md
         else
           echo "Creating new issue..."
 
@@ -314,6 +314,7 @@ jobs:
 
           # Create issue with security labels
           gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
             --title "🚨 [nancy] Vulnerable dependencies detected on ${REF_NAME}" \
             --label "security" \
             --label "nancy" \

--- a/.github/workflows/security-trivy.yml
+++ b/.github/workflows/security-trivy.yml
@@ -123,7 +123,7 @@ jobs:
         SHA: ${{ github.sha }}
       run: |
         # Search for existing open issues with security labels (one issue per scanner type)
-        EXISTING_ISSUE=$(gh issue list --state open --label "security" --label "trivy" --json number --jq ".[0].number" 2>/dev/null || echo "")
+        EXISTING_ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "security" --label "trivy" --json number --jq ".[0].number" 2>/dev/null || echo "")
 
         # Count vulnerabilities by severity
         CRITICAL=$(grep -o "CRITICAL" trivy-results.txt 2>/dev/null | wc -l || echo "0")
@@ -170,7 +170,7 @@ jobs:
             echo "**Security Tab**: Check the [Security tab](${SERVER_URL}/${REPO}/security/code-scanning) for detailed SARIF results."
           } > comment_body.md
 
-          gh issue comment "$EXISTING_ISSUE" --body-file comment_body.md
+          gh issue comment "$EXISTING_ISSUE" --repo "$GITHUB_REPOSITORY" --body-file comment_body.md
         else
           echo "Creating new issue..."
 
@@ -316,6 +316,7 @@ jobs:
 
           # Create issue with security labels
           gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
             --title "🚨 [Trivy] $TOTAL vulnerabilities detected on ${REF_NAME}" \
             --label "security" \
             --label "trivy" \

--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -524,11 +524,11 @@ jobs:
         EVENT_NAME: ${{ github.event_name }}
         PHASE3_OUTCOME: ${{ needs.management-cluster.outputs.phase3_outcome }}
       run: |
-        EXISTING_ISSUE=$(gh issue list --label "automated" --label "test-failure" --state open --json number,title --jq ".[] | select(.title | contains(\"[$WORKFLOW_NAME]\")) | .number | select(. != null)" | head -1)
+        EXISTING_ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "automated" --label "test-failure" --state open --json number,title --jq ".[] | select(.title | contains(\"[$WORKFLOW_NAME]\")) | .number | select(. != null)" | head -1)
 
         if [ -n "$EXISTING_ISSUE" ]; then
           echo "Issue already exists: #$EXISTING_ISSUE"
-          gh issue comment "$EXISTING_ISSUE" --body "Workflow failed again in run: $RUN_URL"
+          gh issue comment "$EXISTING_ISSUE" --repo "$GITHUB_REPOSITORY" --body "Workflow failed again in run: $RUN_URL"
         else
           FAILED_TESTS=$(python3 -c "
         import xml.etree.ElementTree as ET
@@ -570,10 +570,11 @@ jobs:
           echo "*This issue was automatically created by the CI workflow*" >> issue_body.md
 
           # Ensure labels exist (gh issue create fails if label is missing)
-          gh label create "automated" --force 2>/dev/null || true
-          gh label create "test-failure" --color "d93f0b" --force 2>/dev/null || true
+          gh label create "automated" --repo "$GITHUB_REPOSITORY" --force 2>/dev/null || true
+          gh label create "test-failure" --repo "$GITHUB_REPOSITORY" --color "d93f0b" --force 2>/dev/null || true
 
           gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
             --title "[$WORKFLOW_NAME] Workflow failed on $REF_NAME" \
             --body-file issue_body.md \
             --label "automated" \

--- a/.github/workflows/workload-cluster-rosa.yml
+++ b/.github/workflows/workload-cluster-rosa.yml
@@ -440,11 +440,11 @@ jobs:
         EVENT_NAME: ${{ github.event_name }}
         PHASE3_OUTCOME: ${{ needs.management-cluster.outputs.phase3_outcome }}
       run: |
-        EXISTING_ISSUE=$(gh issue list --label "automated" --label "test-failure" --state open --json number,title --jq ".[] | select(.title | contains(\"[$WORKFLOW_NAME]\")) | .number | select(. != null)" | head -1)
+        EXISTING_ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "automated" --label "test-failure" --state open --json number,title --jq ".[] | select(.title | contains(\"[$WORKFLOW_NAME]\")) | .number | select(. != null)" | head -1)
 
         if [ -n "$EXISTING_ISSUE" ]; then
           echo "Issue already exists: #$EXISTING_ISSUE"
-          gh issue comment "$EXISTING_ISSUE" --body "Workflow failed again in run: $RUN_URL"
+          gh issue comment "$EXISTING_ISSUE" --repo "$GITHUB_REPOSITORY" --body "Workflow failed again in run: $RUN_URL"
         else
           FAILED_TESTS=$(python3 -c "
         import xml.etree.ElementTree as ET
@@ -486,10 +486,11 @@ jobs:
           echo "*This issue was automatically created by the CI workflow*" >> issue_body.md
 
           # Ensure labels exist (gh issue create fails if label is missing)
-          gh label create "automated" --force 2>/dev/null || true
-          gh label create "test-failure" --color "d93f0b" --force 2>/dev/null || true
+          gh label create "automated" --repo "$GITHUB_REPOSITORY" --force 2>/dev/null || true
+          gh label create "test-failure" --repo "$GITHUB_REPOSITORY" --color "d93f0b" --force 2>/dev/null || true
 
           gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
             --title "[$WORKFLOW_NAME] Workflow failed on $REF_NAME" \
             --body-file issue_body.md \
             --label "automated" \


### PR DESCRIPTION
## Description

The report-failure and security issue-creation jobs in multiple GitHub Actions workflows crash with
`fatal: not a git repository` when trying to create/comment on GitHub issues. These jobs run on
fresh runners without a checkout step, so `gh` CLI cannot resolve the repository from the working
directory.

Fixes ARO-28938

## Changes Made

- Add `--repo "$GITHUB_REPOSITORY"` to all `gh` commands in the report-failure job of `workload-cluster-aro.yml` and `workload-cluster-rosa.yml`
- Add `--repo "$GITHUB_REPOSITORY"` to all `gh` commands in the report-failure job of `management-cluster-aro.yml` and `management-cluster-rosa.yml`
- Add `--repo "$GITHUB_REPOSITORY"` to all `gh` commands in the issue-creation steps of `security-gosec.yml`, `security-govulncheck.yml`, `security-nancy.yml`, and `security-trivy.yml`

## Configuration Changes

No configuration changes.

## Additional Notes

Discovered during investigation of [run 31241352843](https://github.com/stolostron/capi-tests/actions/runs/31241352843) which had a transient CAPZ image pull failure. The primary failure was transient (quay.io hiccup), but the report-failure job bug is a real defect that would silently fail every time a test failure needs reporting. The same pattern existed in all workflow files that use `gh` commands without a prior checkout step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)