### PR TITLE
fix: auto-extract CA bundle for MCE clusters with self-signed or incomplete TLS chains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,7 +414,7 @@ This is validated during Check Dependencies (phase 1) to prevent late deployment
 ### MCE Component Management
 - `MCE_AUTO_ENABLE` - Auto-enable MCE CAPI/CAPZ components if not found on external cluster (default: `true` when `USE_KUBECONFIG` is set)
 - `MCE_ENABLEMENT_TIMEOUT` - Timeout for waiting after MCE component enablement (default: `15m`, format: Go duration)
-- `MCE_API_CA_BUNDLE` - Path to CA bundle file for TLS verification of the MCE API server (recommended for production use)
+- `MCE_API_CA_BUNDLE` - CA bundle for TLS verification of the MCE API server (recommended for production use). Accepts either a file path or inline PEM content (inline content is written to a temp file and passed via `--certificate-authority`), so CI can inject it directly from a secret store without pre-staging a file on the runner.
 - `MCE_INSECURE_TLS` - Set to `true` to skip TLS certificate verification for MCE cluster login (local dev only; never set in CI)
 
 When using an external MCE cluster (`USE_KUBECONFIG`), the test suite will:

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -165,13 +165,14 @@ func TestCheckDependencies_MCEAuthentication(t *testing.T) {
 		PrintToTTY("TLS: auto-extracting CA bundle from server...\n")
 		caPath, extractErr := AutoExtractMCECACert(t, mceAPIURL)
 		if extractErr != nil {
-			t.Logf("Warning: CA auto-extraction failed (%v) — falling back to --insecure-skip-tls-verify", extractErr)
-			PrintToTTY("TLS: CA not obtainable from chain, using insecure mode (set MCE_API_CA_BUNDLE to fix)\n")
-			ocLoginArgs = append(ocLoginArgs, "--insecure-skip-tls-verify")
-		} else {
-			PrintToTTY("TLS: using auto-extracted CA bundle\n")
-			ocLoginArgs = append(ocLoginArgs, "--certificate-authority="+caPath)
+			t.Fatalf("TLS: CA auto-extraction failed: %v\n\n"+
+				"The MCE server at %s uses a certificate the runner does not trust.\n"+
+				"Fix with one of:\n"+
+				"  • Set MCE_API_CA_BUNDLE to the CA bundle file path (most secure)\n"+
+				"  • Set MCE_INSECURE_TLS=true (local dev only — never in CI)", extractErr, mceAPIURL)
 		}
+		PrintToTTY("TLS: using auto-extracted CA bundle\n")
+		ocLoginArgs = append(ocLoginArgs, "--certificate-authority="+caPath)
 	}
 
 	// Pass password via stdin to avoid exposing it in process list (ps aux)

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -162,7 +162,16 @@ func TestCheckDependencies_MCEAuthentication(t *testing.T) {
 		PrintToTTY("TLS: certificate verification disabled (MCE_INSECURE_TLS=true)\n")
 		ocLoginArgs = append(ocLoginArgs, "--insecure-skip-tls-verify")
 	default:
-		PrintToTTY("TLS: using system certificate store\n")
+		PrintToTTY("TLS: auto-extracting CA bundle from server...\n")
+		caPath, extractErr := AutoExtractMCECACert(t, mceAPIURL)
+		if extractErr != nil {
+			t.Logf("Warning: CA auto-extraction failed (%v) — falling back to --insecure-skip-tls-verify", extractErr)
+			PrintToTTY("TLS: CA not obtainable from chain, using insecure mode (set MCE_API_CA_BUNDLE to fix)\n")
+			ocLoginArgs = append(ocLoginArgs, "--insecure-skip-tls-verify")
+		} else {
+			PrintToTTY("TLS: using auto-extracted CA bundle\n")
+			ocLoginArgs = append(ocLoginArgs, "--certificate-authority="+caPath)
+		}
 	}
 
 	// Pass password via stdin to avoid exposing it in process list (ps aux)

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -88,7 +88,8 @@ func TestCheckDependencies_OptionalTools(t *testing.T) {
 // Runs FIRST to populate kubeconfig before TestCheckDependencies_ExternalKubeconfig validates it.
 //
 // TLS verification (in order of precedence):
-//   - MCE_API_CA_BUNDLE set: use --certificate-authority=<path> (recommended)
+//   - MCE_API_CA_BUNDLE set: use --certificate-authority (recommended). The value may be
+//     a file path or inline PEM content (inline content is written to a temp file).
 //   - MCE_INSECURE_TLS=true: use --insecure-skip-tls-verify (opt-in for local dev only)
 //   - neither: rely on the system certificate store
 func TestCheckDependencies_MCEAuthentication(t *testing.T) {
@@ -150,13 +151,29 @@ func TestCheckDependencies_MCEAuthentication(t *testing.T) {
 	ocLoginArgs := []string{"login", mceAPIURL, "-u", mceUser}
 	switch {
 	case mceCABundle != "":
-		if !FileExists(mceCABundle) {
-			t.Fatalf("MCE_API_CA_BUNDLE file not found: %s\n\n"+
-				"Set MCE_API_CA_BUNDLE to a valid CA bundle file path, "+
-				"or unset it to use the system certificate store.", mceCABundle)
+		caPath := mceCABundle
+		if strings.Contains(mceCABundle, "-----BEGIN") {
+			// Inline PEM content (e.g. injected from a CI secret store): persist it to a
+			// file next to the kubeconfig and reference that via --certificate-authority.
+			// This file must NOT be deleted after login — oc records the path in the
+			// kubeconfig, so subsequent kubectl/oc commands (later test phases, which run
+			// as separate processes reusing this kubeconfig) need it to remain. Placing it
+			// beside the kubeconfig keeps oc's relativized path resolvable and ties the
+			// bundle's lifetime to the kubeconfig it belongs to.
+			caPath = kubeconfigPath + ".mce-ca.crt"
+			if err := os.WriteFile(caPath, []byte(mceCABundle+"\n"), 0o600); err != nil {
+				t.Fatalf("failed to write MCE_API_CA_BUNDLE content to %s: %v", caPath, err)
+			}
+			PrintToTTY("TLS: using certificate authority from MCE_API_CA_BUNDLE (inline PEM content)\n")
+		} else {
+			if !FileExists(mceCABundle) {
+				t.Fatalf("MCE_API_CA_BUNDLE file not found: %s\n\n"+
+					"Set MCE_API_CA_BUNDLE to a valid CA bundle file path or inline PEM content, "+
+					"or unset it to use the system certificate store.", mceCABundle)
+			}
+			PrintToTTY("TLS: using certificate authority from MCE_API_CA_BUNDLE (file)\n")
 		}
-		PrintToTTY("TLS: using certificate authority from MCE_API_CA_BUNDLE\n")
-		ocLoginArgs = append(ocLoginArgs, "--certificate-authority="+mceCABundle)
+		ocLoginArgs = append(ocLoginArgs, "--certificate-authority="+caPath)
 	case mceInsecureTLS:
 		t.Logf("Warning: MCE_INSECURE_TLS=true — TLS certificate verification disabled")
 		PrintToTTY("TLS: certificate verification disabled (MCE_INSECURE_TLS=true)\n")

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -162,17 +162,7 @@ func TestCheckDependencies_MCEAuthentication(t *testing.T) {
 		PrintToTTY("TLS: certificate verification disabled (MCE_INSECURE_TLS=true)\n")
 		ocLoginArgs = append(ocLoginArgs, "--insecure-skip-tls-verify")
 	default:
-		PrintToTTY("TLS: auto-extracting CA bundle from server...\n")
-		caPath, extractErr := AutoExtractMCECACert(t, mceAPIURL)
-		if extractErr != nil {
-			t.Fatalf("TLS: CA auto-extraction failed: %v\n\n"+
-				"The MCE server at %s uses a certificate the runner does not trust.\n"+
-				"Fix with one of:\n"+
-				"  • Set MCE_API_CA_BUNDLE to the CA bundle file path (most secure)\n"+
-				"  • Set MCE_INSECURE_TLS=true (local dev only — never in CI)", extractErr, mceAPIURL)
-		}
-		PrintToTTY("TLS: using auto-extracted CA bundle\n")
-		ocLoginArgs = append(ocLoginArgs, "--certificate-authority="+caPath)
+		PrintToTTY("TLS: using system certificate store\n")
 	}
 
 	// Pass password via stdin to avoid exposing it in process list (ps aux)

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1,11 +1,8 @@
 package test
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"net"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -4730,142 +4727,6 @@ func FormatMismatchedClustersError(mismatched []string, expectedClusterName, nam
 // =============================================================================
 // MCE (MultiClusterEngine) Helper Functions
 // =============================================================================
-
-// AutoExtractMCECACert connects to the MCE API server and attempts to extract a
-// usable CA certificate via openssl s_client. Returns the path to a temp file
-// containing the CA bundle, or an error if no usable CA cert could be obtained.
-// A cleanup is registered to delete the temp file when the test ends.
-//
-// WARNING: this uses Trust-On-First-Use (TOFU). The initial connection to the
-// server is unauthenticated, so a MITM in position before extraction can inject
-// their own certificate. For adversarial or shared CI networks set MCE_API_CA_BUNDLE
-// to a pre-verified CA bundle instead.
-//
-// Handles three cases:
-//   - Full chain (multiple certs): uses certs[1:] as CA bundle
-//   - Single self-signed cert: uses that cert as CA
-//   - Single non-self-signed leaf cert: returns error (CA not obtainable)
-func AutoExtractMCECACert(t *testing.T, apiURL string) (string, error) {
-	t.Helper()
-
-	// Use url.Parse + net.SplitHostPort so IPv6 literals and non-standard forms work correctly.
-	u, parseErr := url.Parse(apiURL)
-	if parseErr != nil {
-		return "", fmt.Errorf("invalid MCE_API_URL %q: %w", apiURL, parseErr)
-	}
-	hostname, port, splitErr := net.SplitHostPort(u.Host)
-	if splitErr != nil {
-		// URL has no explicit port (e.g. https://host) — default to 443.
-		hostname = u.Host
-		port = "443"
-	}
-	connectAddr := net.JoinHostPort(hostname, port)
-
-	if !CommandExists("openssl") {
-		return "", fmt.Errorf("openssl not found — set MCE_API_CA_BUNDLE or MCE_INSECURE_TLS=true")
-	}
-
-	t.Logf("⚠ TOFU: auto-extracting CA bundle from %s via openssl s_client — "+
-		"connection is unauthenticated; set MCE_API_CA_BUNDLE to a pre-verified CA bundle "+
-		"for adversarial or shared CI networks", connectAddr)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	// #nosec G204 — connectAddr derived from validated MCE_API_URL, not raw user input
-	cmd := exec.CommandContext(ctx, "openssl", "s_client", "-connect", connectAddr, "-servername", hostname, "-showcerts")
-	cmd.Stdin = strings.NewReader("")
-	// openssl s_client exits non-zero even on success; capture stdout only.
-	output, _ := cmd.Output()
-	if len(output) == 0 {
-		return "", fmt.Errorf("openssl s_client returned no output from %s", connectAddr)
-	}
-
-	certs := extractPEMCerts(string(output))
-	if len(certs) == 0 {
-		return "", fmt.Errorf("no certificates found in TLS chain from %s", connectAddr)
-	}
-
-	var caBundleCerts []string
-	if len(certs) > 1 {
-		// Full chain: skip cert[0] (leaf), use the rest as CA bundle.
-		caBundleCerts = certs[1:]
-	} else {
-		// Single cert: only usable if self-signed (cert is its own CA).
-		if !isSelfSignedCert(certs[0]) {
-			return "", fmt.Errorf("server sent only a leaf certificate (not self-signed) " +
-				"and the CA is not in the TLS chain — set MCE_API_CA_BUNDLE to the CA bundle path")
-		}
-		caBundleCerts = certs
-	}
-
-	tmpFile, err := os.CreateTemp("", "mce-ca-*.crt")
-	if err != nil {
-		return "", fmt.Errorf("failed to create temp CA bundle file: %w", err)
-	}
-	caPath := tmpFile.Name()
-
-	_, writeErr := tmpFile.WriteString(strings.Join(caBundleCerts, "\n"))
-	_ = tmpFile.Close()
-	if writeErr != nil {
-		_ = os.Remove(caPath)
-		return "", fmt.Errorf("failed to write CA bundle: %w", writeErr)
-	}
-
-	t.Cleanup(func() { _ = os.Remove(caPath) })
-
-	// Log SHA-256 fingerprint so operators can detect unexpected cert changes.
-	fpCtx, fpCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer fpCancel()
-	// #nosec G204 — caPath is an os.CreateTemp path, not user-controlled
-	fpCmd := exec.CommandContext(fpCtx, "openssl", "x509", "-noout", "-fingerprint", "-sha256", "-in", caPath)
-	if fpOut, fpErr := fpCmd.Output(); fpErr == nil {
-		t.Logf("Auto-extracted CA bundle written to %s (%d cert(s)): %s", caPath, len(caBundleCerts), strings.TrimSpace(string(fpOut)))
-	} else {
-		t.Logf("Auto-extracted CA bundle written to %s (%d cert(s) in chain)", caPath, len(caBundleCerts))
-	}
-	return caPath, nil
-}
-
-// isSelfSignedCert returns true if the PEM-encoded cert's Subject equals its Issuer.
-func isSelfSignedCert(pemCert string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	// #nosec G204 — openssl binary with static args, cert content from TLS handshake
-	cmd := exec.CommandContext(ctx, "openssl", "x509", "-noout", "-subject", "-issuer")
-	cmd.Stdin = strings.NewReader(pemCert)
-	output, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	if len(lines) < 2 {
-		return false
-	}
-	subject := strings.TrimSpace(strings.TrimPrefix(lines[0], "subject="))
-	issuer := strings.TrimSpace(strings.TrimPrefix(lines[1], "issuer="))
-	return subject == issuer
-}
-
-// extractPEMCerts parses all PEM certificate blocks from a string.
-func extractPEMCerts(data string) []string {
-	var certs []string
-	var current strings.Builder
-	inCert := false
-	for _, line := range strings.Split(data, "\n") {
-		if strings.HasPrefix(line, "-----BEGIN CERTIFICATE-----") {
-			inCert = true
-			current.Reset()
-		}
-		if inCert {
-			current.WriteString(line + "\n")
-		}
-		if strings.HasPrefix(line, "-----END CERTIFICATE-----") {
-			inCert = false
-			certs = append(certs, current.String())
-		}
-	}
-	return certs
-}
 
 // IsMCECluster checks if the external cluster has MCE (MultiClusterEngine) installed.
 // Returns true if the 'multiclusterengine' resource exists, false otherwise.

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -4760,7 +4760,8 @@ func AutoExtractMCECACert(t *testing.T, apiURL string) (string, error) {
 		hostOnly = host[:colonIdx]
 	}
 
-	t.Logf("Auto-extracting CA bundle from %s via openssl s_client", host)
+	t.Logf("Auto-extracting CA bundle from %s via openssl s_client (TOFU — "+
+		"set MCE_API_CA_BUNDLE to a pre-verified CA bundle for shared/cloud CI networks)", host)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -4805,7 +4806,14 @@ func AutoExtractMCECACert(t *testing.T, apiURL string) (string, error) {
 	}
 
 	t.Cleanup(func() { os.Remove(caPath) })
-	t.Logf("Auto-extracted CA bundle written to %s (%d cert(s) in chain)", caPath, len(caBundleCerts))
+
+	// Log the SHA-256 fingerprint so operators can detect unexpected cert changes.
+	// #nosec G204 — caPath is an os.CreateTemp path, not user-controlled
+	if fpOut, fpErr := exec.Command("openssl", "x509", "-noout", "-fingerprint", "-sha256", "-in", caPath).Output(); fpErr == nil {
+		t.Logf("Auto-extracted CA bundle written to %s (%d cert(s)): %s", caPath, len(caBundleCerts), strings.TrimSpace(string(fpOut)))
+	} else {
+		t.Logf("Auto-extracted CA bundle written to %s (%d cert(s) in chain)", caPath, len(caBundleCerts))
+	}
 	return caPath, nil
 }
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -4754,10 +4755,17 @@ func AutoExtractMCECACert(t *testing.T, apiURL string) (string, error) {
 		return "", fmt.Errorf("openssl not found — set MCE_API_CA_BUNDLE or MCE_INSECURE_TLS=true")
 	}
 
+	hostOnly := host
+	if colonIdx := strings.LastIndex(host, ":"); colonIdx >= 0 {
+		hostOnly = host[:colonIdx]
+	}
+
 	t.Logf("Auto-extracting CA bundle from %s via openssl s_client", host)
 
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	// #nosec G204 — host derived from validated MCE_API_URL, not raw user input
-	cmd := exec.Command("openssl", "s_client", "-connect", host, "-showcerts")
+	cmd := exec.CommandContext(ctx, "openssl", "s_client", "-connect", host, "-servername", hostOnly, "-showcerts")
 	cmd.Stdin = strings.NewReader("")
 	// openssl s_client exits non-zero even on success; capture stdout only
 	output, _ := cmd.Output()

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -4805,7 +4805,7 @@ func AutoExtractMCECACert(t *testing.T, apiURL string) (string, error) {
 	caPath := tmpFile.Name()
 
 	_, writeErr := tmpFile.WriteString(strings.Join(caBundleCerts, "\n"))
-	tmpFile.Close()
+	_ = tmpFile.Close()
 	if writeErr != nil {
 		_ = os.Remove(caPath)
 		return "", fmt.Errorf("failed to write CA bundle: %w", writeErr)

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -4734,59 +4736,63 @@ func FormatMismatchedClustersError(mismatched []string, expectedClusterName, nam
 // containing the CA bundle, or an error if no usable CA cert could be obtained.
 // A cleanup is registered to delete the temp file when the test ends.
 //
+// WARNING: this uses Trust-On-First-Use (TOFU). The initial connection to the
+// server is unauthenticated, so a MITM in position before extraction can inject
+// their own certificate. For adversarial or shared CI networks set MCE_API_CA_BUNDLE
+// to a pre-verified CA bundle instead.
+//
 // Handles three cases:
-//   - Server sends full chain (multiple certs): uses certs[1:] as CA bundle
-//   - Server sends only a self-signed cert: uses that cert as CA
-//   - Server sends only a non-self-signed leaf cert: returns error (CA not obtainable)
+//   - Full chain (multiple certs): uses certs[1:] as CA bundle
+//   - Single self-signed cert: uses that cert as CA
+//   - Single non-self-signed leaf cert: returns error (CA not obtainable)
 func AutoExtractMCECACert(t *testing.T, apiURL string) (string, error) {
 	t.Helper()
 
-	// Parse host:port from URL (e.g. https://api.example.com:6443 → api.example.com:6443)
-	host := strings.TrimPrefix(apiURL, "https://")
-	host = strings.TrimPrefix(host, "http://")
-	if idx := strings.Index(host, "/"); idx >= 0 {
-		host = host[:idx]
+	// Use url.Parse + net.SplitHostPort so IPv6 literals and non-standard forms work correctly.
+	u, parseErr := url.Parse(apiURL)
+	if parseErr != nil {
+		return "", fmt.Errorf("invalid MCE_API_URL %q: %w", apiURL, parseErr)
 	}
-	if !strings.Contains(host, ":") {
-		host += ":443"
+	hostname, port, splitErr := net.SplitHostPort(u.Host)
+	if splitErr != nil {
+		// URL has no explicit port (e.g. https://host) — default to 443.
+		hostname = u.Host
+		port = "443"
 	}
+	connectAddr := net.JoinHostPort(hostname, port)
 
 	if !CommandExists("openssl") {
 		return "", fmt.Errorf("openssl not found — set MCE_API_CA_BUNDLE or MCE_INSECURE_TLS=true")
 	}
 
-	hostOnly := host
-	if colonIdx := strings.LastIndex(host, ":"); colonIdx >= 0 {
-		hostOnly = host[:colonIdx]
-	}
-
-	t.Logf("Auto-extracting CA bundle from %s via openssl s_client (TOFU — "+
-		"set MCE_API_CA_BUNDLE to a pre-verified CA bundle for shared/cloud CI networks)", host)
+	t.Logf("⚠ TOFU: auto-extracting CA bundle from %s via openssl s_client — "+
+		"connection is unauthenticated; set MCE_API_CA_BUNDLE to a pre-verified CA bundle "+
+		"for adversarial or shared CI networks", connectAddr)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	// #nosec G204 — host derived from validated MCE_API_URL, not raw user input
-	cmd := exec.CommandContext(ctx, "openssl", "s_client", "-connect", host, "-servername", hostOnly, "-showcerts")
+	// #nosec G204 — connectAddr derived from validated MCE_API_URL, not raw user input
+	cmd := exec.CommandContext(ctx, "openssl", "s_client", "-connect", connectAddr, "-servername", hostname, "-showcerts")
 	cmd.Stdin = strings.NewReader("")
-	// openssl s_client exits non-zero even on success; capture stdout only
+	// openssl s_client exits non-zero even on success; capture stdout only.
 	output, _ := cmd.Output()
 	if len(output) == 0 {
-		return "", fmt.Errorf("openssl s_client returned no output from %s", host)
+		return "", fmt.Errorf("openssl s_client returned no output from %s", connectAddr)
 	}
 
 	certs := extractPEMCerts(string(output))
 	if len(certs) == 0 {
-		return "", fmt.Errorf("no certificates found in TLS chain from %s", host)
+		return "", fmt.Errorf("no certificates found in TLS chain from %s", connectAddr)
 	}
 
 	var caBundleCerts []string
 	if len(certs) > 1 {
-		// Full chain: skip cert[0] (leaf), use the rest as CA bundle
+		// Full chain: skip cert[0] (leaf), use the rest as CA bundle.
 		caBundleCerts = certs[1:]
 	} else {
-		// Single cert: only usable if self-signed (cert is its own CA)
+		// Single cert: only usable if self-signed (cert is its own CA).
 		if !isSelfSignedCert(certs[0]) {
-			return "", fmt.Errorf("server sent only a leaf certificate (issuer: not self-signed) " +
+			return "", fmt.Errorf("server sent only a leaf certificate (not self-signed) " +
 				"and the CA is not in the TLS chain — set MCE_API_CA_BUNDLE to the CA bundle path")
 		}
 		caBundleCerts = certs
@@ -4801,15 +4807,18 @@ func AutoExtractMCECACert(t *testing.T, apiURL string) (string, error) {
 	_, writeErr := tmpFile.WriteString(strings.Join(caBundleCerts, "\n"))
 	tmpFile.Close()
 	if writeErr != nil {
-		os.Remove(caPath)
+		_ = os.Remove(caPath)
 		return "", fmt.Errorf("failed to write CA bundle: %w", writeErr)
 	}
 
-	t.Cleanup(func() { os.Remove(caPath) })
+	t.Cleanup(func() { _ = os.Remove(caPath) })
 
-	// Log the SHA-256 fingerprint so operators can detect unexpected cert changes.
+	// Log SHA-256 fingerprint so operators can detect unexpected cert changes.
+	fpCtx, fpCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer fpCancel()
 	// #nosec G204 — caPath is an os.CreateTemp path, not user-controlled
-	if fpOut, fpErr := exec.Command("openssl", "x509", "-noout", "-fingerprint", "-sha256", "-in", caPath).Output(); fpErr == nil {
+	fpCmd := exec.CommandContext(fpCtx, "openssl", "x509", "-noout", "-fingerprint", "-sha256", "-in", caPath)
+	if fpOut, fpErr := fpCmd.Output(); fpErr == nil {
 		t.Logf("Auto-extracted CA bundle written to %s (%d cert(s)): %s", caPath, len(caBundleCerts), strings.TrimSpace(string(fpOut)))
 	} else {
 		t.Logf("Auto-extracted CA bundle written to %s (%d cert(s) in chain)", caPath, len(caBundleCerts))
@@ -4819,8 +4828,10 @@ func AutoExtractMCECACert(t *testing.T, apiURL string) (string, error) {
 
 // isSelfSignedCert returns true if the PEM-encoded cert's Subject equals its Issuer.
 func isSelfSignedCert(pemCert string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	// #nosec G204 — openssl binary with static args, cert content from TLS handshake
-	cmd := exec.Command("openssl", "x509", "-noout", "-subject", "-issuer")
+	cmd := exec.CommandContext(ctx, "openssl", "x509", "-noout", "-subject", "-issuer")
 	cmd.Stdin = strings.NewReader(pemCert)
 	output, err := cmd.Output()
 	if err != nil {
@@ -4830,9 +4841,9 @@ func isSelfSignedCert(pemCert string) bool {
 	if len(lines) < 2 {
 		return false
 	}
-	subject := strings.TrimPrefix(lines[0], "subject=")
-	issuer := strings.TrimPrefix(lines[1], "issuer=")
-	return strings.TrimSpace(subject) == strings.TrimSpace(issuer)
+	subject := strings.TrimSpace(strings.TrimPrefix(lines[0], "subject="))
+	issuer := strings.TrimSpace(strings.TrimPrefix(lines[1], "issuer="))
+	return subject == issuer
 }
 
 // extractPEMCerts parses all PEM certificate blocks from a string.

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -4728,6 +4728,118 @@ func FormatMismatchedClustersError(mismatched []string, expectedClusterName, nam
 // MCE (MultiClusterEngine) Helper Functions
 // =============================================================================
 
+// AutoExtractMCECACert connects to the MCE API server and attempts to extract a
+// usable CA certificate via openssl s_client. Returns the path to a temp file
+// containing the CA bundle, or an error if no usable CA cert could be obtained.
+// A cleanup is registered to delete the temp file when the test ends.
+//
+// Handles three cases:
+//   - Server sends full chain (multiple certs): uses certs[1:] as CA bundle
+//   - Server sends only a self-signed cert: uses that cert as CA
+//   - Server sends only a non-self-signed leaf cert: returns error (CA not obtainable)
+func AutoExtractMCECACert(t *testing.T, apiURL string) (string, error) {
+	t.Helper()
+
+	// Parse host:port from URL (e.g. https://api.example.com:6443 → api.example.com:6443)
+	host := strings.TrimPrefix(apiURL, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	if idx := strings.Index(host, "/"); idx >= 0 {
+		host = host[:idx]
+	}
+	if !strings.Contains(host, ":") {
+		host += ":443"
+	}
+
+	if !CommandExists("openssl") {
+		return "", fmt.Errorf("openssl not found — set MCE_API_CA_BUNDLE or MCE_INSECURE_TLS=true")
+	}
+
+	t.Logf("Auto-extracting CA bundle from %s via openssl s_client", host)
+
+	// #nosec G204 — host derived from validated MCE_API_URL, not raw user input
+	cmd := exec.Command("openssl", "s_client", "-connect", host, "-showcerts")
+	cmd.Stdin = strings.NewReader("")
+	// openssl s_client exits non-zero even on success; capture stdout only
+	output, _ := cmd.Output()
+	if len(output) == 0 {
+		return "", fmt.Errorf("openssl s_client returned no output from %s", host)
+	}
+
+	certs := extractPEMCerts(string(output))
+	if len(certs) == 0 {
+		return "", fmt.Errorf("no certificates found in TLS chain from %s", host)
+	}
+
+	var caBundleCerts []string
+	if len(certs) > 1 {
+		// Full chain: skip cert[0] (leaf), use the rest as CA bundle
+		caBundleCerts = certs[1:]
+	} else {
+		// Single cert: only usable if self-signed (cert is its own CA)
+		if !isSelfSignedCert(certs[0]) {
+			return "", fmt.Errorf("server sent only a leaf certificate (issuer: not self-signed) " +
+				"and the CA is not in the TLS chain — set MCE_API_CA_BUNDLE to the CA bundle path")
+		}
+		caBundleCerts = certs
+	}
+
+	tmpFile, err := os.CreateTemp("", "mce-ca-*.crt")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp CA bundle file: %w", err)
+	}
+	caPath := tmpFile.Name()
+
+	_, writeErr := tmpFile.WriteString(strings.Join(caBundleCerts, "\n"))
+	tmpFile.Close()
+	if writeErr != nil {
+		os.Remove(caPath)
+		return "", fmt.Errorf("failed to write CA bundle: %w", writeErr)
+	}
+
+	t.Cleanup(func() { os.Remove(caPath) })
+	t.Logf("Auto-extracted CA bundle written to %s (%d cert(s) in chain)", caPath, len(caBundleCerts))
+	return caPath, nil
+}
+
+// isSelfSignedCert returns true if the PEM-encoded cert's Subject equals its Issuer.
+func isSelfSignedCert(pemCert string) bool {
+	// #nosec G204 — openssl binary with static args, cert content from TLS handshake
+	cmd := exec.Command("openssl", "x509", "-noout", "-subject", "-issuer")
+	cmd.Stdin = strings.NewReader(pemCert)
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	if len(lines) < 2 {
+		return false
+	}
+	subject := strings.TrimPrefix(lines[0], "subject=")
+	issuer := strings.TrimPrefix(lines[1], "issuer=")
+	return strings.TrimSpace(subject) == strings.TrimSpace(issuer)
+}
+
+// extractPEMCerts parses all PEM certificate blocks from a string.
+func extractPEMCerts(data string) []string {
+	var certs []string
+	var current strings.Builder
+	inCert := false
+	for _, line := range strings.Split(data, "\n") {
+		if strings.HasPrefix(line, "-----BEGIN CERTIFICATE-----") {
+			inCert = true
+			current.Reset()
+		}
+		if inCert {
+			current.WriteString(line + "\n")
+		}
+		if strings.HasPrefix(line, "-----END CERTIFICATE-----") {
+			inCert = false
+			certs = append(certs, current.String())
+		}
+	}
+	return certs
+}
+
 // IsMCECluster checks if the external cluster has MCE (MultiClusterEngine) installed.
 // Returns true if the 'multiclusterengine' resource exists, false otherwise.
 func IsMCECluster(t *testing.T, kubeContext string) bool {


### PR DESCRIPTION
## Description

Extend `MCE_API_CA_BUNDLE` (introduced in #798) so it accepts **either a file
path or inline PEM content**. When the value contains a PEM certificate block,
it is written to a stable file next to the kubeconfig (`<kubeconfig>.mce-ca.crt`)
and passed to `oc login` via `--certificate-authority`. This lets CI inject the
CA directly from a secret store without pre-staging a file on the runner.

TLS verification precedence is unchanged:
- `MCE_API_CA_BUNDLE` set (file path or inline PEM) → `--certificate-authority=<file>`
- `MCE_INSECURE_TLS=true` (local dev only) → `--insecure-skip-tls-verify`
- neither → system certificate store

Ref: ARO-29054

## Changes Made

- `test/01_check_dependencies_test.go` — `MCE_API_CA_BUNDLE` now detects inline
  PEM content (`-----BEGIN` marker) and writes it to `<kubeconfig>.mce-ca.crt`
  (mode `0o600`) before passing `--certificate-authority`; file-path values keep
  the existing `FileExists` validation. The CA file is intentionally not deleted,
  since `oc` records its path in the kubeconfig for later test phases.
- `CLAUDE.md` — documented that `MCE_API_CA_BUNDLE` accepts a file path or inline
  PEM content.

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `MCE_API_CA_BUNDLE` | CA bundle for MCE API TLS verification. Accepts a file path **or** inline PEM content. | unset (system cert store) |
| `MCE_INSECURE_TLS` | Skip TLS verification for MCE login (local dev only; never set in CI). | unset |

## Additional Notes

This PR supersedes the earlier auto-extraction (TOFU) approach that appeared in
earlier commits on this branch — it was reverted in favour of operator-provided
trust via `MCE_API_CA_BUNDLE`. For CI, inject the CA bundle from a secret store
into `MCE_API_CA_BUNDLE` (inline PEM is now supported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)