### PR TITLE
fix: add curl retry flags to all binary downloads (ARO-29016)

### DIFF
--- a/.github/workflows/management-cluster-aro.yml
+++ b/.github/workflows/management-cluster-aro.yml
@@ -107,8 +107,8 @@ jobs:
       run: |
         KIND_VERSION=v0.31.0
         KIND_BIN=kind-linux-amd64
-        curl -fsSLo "./${KIND_BIN}" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}"
-        curl -fsSLo "./${KIND_BIN}.sha256sum" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}.sha256sum"
+        curl --retry 3 --retry-delay 5 -fsSLo "./${KIND_BIN}" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}"
+        curl --retry 3 --retry-delay 5 -fsSLo "./${KIND_BIN}.sha256sum" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}.sha256sum"
         sha256sum --check "./${KIND_BIN}.sha256sum"
         chmod +x "./${KIND_BIN}"
         sudo mv "./${KIND_BIN}" /usr/local/bin/kind
@@ -117,7 +117,7 @@ jobs:
     - name: Install kubectl
       run: |
         # kubectl - uses latest stable (compatible with Kubernetes 1.28+)
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        curl --retry 3 --retry-delay 5 -LO "https://dl.k8s.io/release/$(curl --retry 3 --retry-delay 5 -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
         chmod +x kubectl
         sudo mv kubectl /usr/local/bin/
         kubectl version --client

--- a/.github/workflows/management-cluster-rosa.yml
+++ b/.github/workflows/management-cluster-rosa.yml
@@ -84,8 +84,8 @@ jobs:
       run: |
         KIND_VERSION=v0.31.0
         KIND_BIN=kind-linux-amd64
-        curl -fsSLo "./${KIND_BIN}" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}"
-        curl -fsSLo "./${KIND_BIN}.sha256sum" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}.sha256sum"
+        curl --retry 3 --retry-delay 5 -fsSLo "./${KIND_BIN}" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}"
+        curl --retry 3 --retry-delay 5 -fsSLo "./${KIND_BIN}.sha256sum" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}.sha256sum"
         sha256sum --check "./${KIND_BIN}.sha256sum"
         chmod +x "./${KIND_BIN}"
         sudo mv "./${KIND_BIN}" /usr/local/bin/kind
@@ -94,7 +94,7 @@ jobs:
     - name: Install kubectl
       run: |
         # kubectl - uses latest stable (compatible with Kubernetes 1.28+)
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        curl --retry 3 --retry-delay 5 -LO "https://dl.k8s.io/release/$(curl --retry 3 --retry-delay 5 -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
         chmod +x kubectl
         sudo mv kubectl /usr/local/bin/
         kubectl version --client

--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -256,8 +256,8 @@ jobs:
       run: |
         KIND_VERSION=v0.31.0
         KIND_BIN=kind-linux-amd64
-        curl -fsSLo "./${KIND_BIN}" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}"
-        curl -fsSLo "./${KIND_BIN}.sha256sum" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}.sha256sum"
+        curl --retry 3 --retry-delay 5 -fsSLo "./${KIND_BIN}" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}"
+        curl --retry 3 --retry-delay 5 -fsSLo "./${KIND_BIN}.sha256sum" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}.sha256sum"
         sha256sum --check "./${KIND_BIN}.sha256sum"
         chmod +x "./${KIND_BIN}"
         sudo mv "./${KIND_BIN}" /usr/local/bin/kind
@@ -268,7 +268,7 @@ jobs:
         # Note: cluster-api does not publish checksums/signatures for clusterctl binaries
         # (upstream issues #9292, #9293). Verification only available for container images.
         CLUSTERCTL_VERSION=v1.12.2
-        curl -fsSL "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterctl-linux-amd64" -o clusterctl
+        curl --retry 3 --retry-delay 5 -fsSL "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterctl-linux-amd64" -o clusterctl
         chmod +x clusterctl
         sudo mv clusterctl /usr/local/bin/
         clusterctl version

--- a/.github/workflows/workload-cluster-rosa.yml
+++ b/.github/workflows/workload-cluster-rosa.yml
@@ -208,8 +208,8 @@ jobs:
       run: |
         KIND_VERSION=v0.31.0
         KIND_BIN=kind-linux-amd64
-        curl -fsSLo "./${KIND_BIN}" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}"
-        curl -fsSLo "./${KIND_BIN}.sha256sum" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}.sha256sum"
+        curl --retry 3 --retry-delay 5 -fsSLo "./${KIND_BIN}" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}"
+        curl --retry 3 --retry-delay 5 -fsSLo "./${KIND_BIN}.sha256sum" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BIN}.sha256sum"
         sha256sum --check "./${KIND_BIN}.sha256sum"
         chmod +x "./${KIND_BIN}"
         sudo mv "./${KIND_BIN}" /usr/local/bin/kind
@@ -220,7 +220,7 @@ jobs:
         # Note: cluster-api does not publish checksums/signatures for clusterctl binaries
         # (upstream issues #9292, #9293). Verification only available for container images.
         CLUSTERCTL_VERSION=v1.12.2
-        curl -fsSL "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterctl-linux-amd64" -o clusterctl
+        curl --retry 3 --retry-delay 5 -fsSL "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterctl-linux-amd64" -o clusterctl
         chmod +x clusterctl
         sudo mv clusterctl /usr/local/bin/
         clusterctl version

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -10,7 +10,7 @@ ARG GOTESTSUM_VERSION=v1.13.0
 
 # Install OpenShift CLI
 ARG OC_VERSION=latest
-RUN curl -fsSL "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz" -o /tmp/oc.tar.gz && \
+RUN curl --retry 3 --retry-delay 5 -fsSL "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz" -o /tmp/oc.tar.gz && \
     tar xz -C /usr/local/bin -f /tmp/oc.tar.gz oc && \
     chmod +x /usr/local/bin/oc && \
     rm -f /tmp/oc.tar.gz
@@ -33,14 +33,14 @@ RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install kubectl (with checksum verification)
-RUN curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
-    curl -Lo /tmp/kubectl.sha256 "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" && \
+RUN curl --retry 3 --retry-delay 5 -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    curl --retry 3 --retry-delay 5 -Lo /tmp/kubectl.sha256 "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" && \
     echo "$(cat /tmp/kubectl.sha256)  /usr/local/bin/kubectl" | sha256sum -c && \
     chmod +x /usr/local/bin/kubectl && rm -f /tmp/kubectl.sha256
 
 # Install helm (with checksum verification)
-RUN curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o /tmp/helm.tar.gz && \
-    curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum" -o /tmp/helm.sha256sum && \
+RUN curl --retry 3 --retry-delay 5 -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o /tmp/helm.tar.gz && \
+    curl --retry 3 --retry-delay 5 -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum" -o /tmp/helm.sha256sum && \
     echo "$(awk '{print $1}' /tmp/helm.sha256sum)  /tmp/helm.tar.gz" | sha256sum -c && \
     tar xz -C /tmp -f /tmp/helm.tar.gz && \
     mv /tmp/linux-amd64/helm /usr/local/bin/helm && chmod +x /usr/local/bin/helm && \
@@ -50,6 +50,6 @@ RUN curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o 
 RUN GOFLAGS='' GOBIN=/usr/local/bin go install gotest.tools/gotestsum@${GOTESTSUM_VERSION}
 
 # Install clusterctl (with checksum verification via hardcoded digest)
-RUN curl -Lo /usr/local/bin/clusterctl "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterctl-linux-amd64" && \
+RUN curl --retry 3 --retry-delay 5 -Lo /usr/local/bin/clusterctl "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterctl-linux-amd64" && \
     echo "${CLUSTERCTL_SHA256}  /usr/local/bin/clusterctl" | sha256sum -c && \
     chmod +x /usr/local/bin/clusterctl

--- a/openshift-ci/step-registry/capz-test-k3s-e2e-commands.sh
+++ b/openshift-ci/step-registry/capz-test-k3s-e2e-commands.sh
@@ -38,7 +38,7 @@ fi
 # ---- Install k3s ----
 echo "[k3s] Installing k3s ${K3S_VERSION}"
 K3S_URL="https://github.com/k3s-io/k3s/releases/download/$(echo "${K3S_VERSION}" | sed 's/+/%2B/')/k3s"
-curl -sLo /tmp/k3s "${K3S_URL}"
+curl --retry 3 --retry-delay 5 -sLo /tmp/k3s "${K3S_URL}"
 chmod +x /tmp/k3s
 export PATH="/tmp:${PATH}"
 echo "[k3s] Installed: $(k3s --version)"


### PR DESCRIPTION
## Description

Add `--retry 3 --retry-delay 5` to all external `curl` binary downloads
across the full CI pipeline (Prow image build, k3s step script, and all
GitHub Actions workflows). Without retry flags, a single transient DNS
failure kills the entire CI build before any test step runs.

JIRA: https://redhat.atlassian.net/browse/ARO-29016

## Changes Made

- `Dockerfile.prow` — added `--retry 3 --retry-delay 5` to all curl
  download calls (oc, kubectl, kubectl checksum, helm, helm checksum,
  clusterctl)
- `openshift-ci/step-registry/capz-test-k3s-e2e-commands.sh` — added
  retry flags to the k3s binary download
- `.github/workflows/management-cluster-aro.yml` — added retry flags to
  kind (x2) and kubectl (including nested version-lookup curl) downloads
- `.github/workflows/management-cluster-rosa.yml` — added retry flags to
  kind (x2) and kubectl (including nested version-lookup curl) downloads
- `.github/workflows/workload-cluster-aro.yml` — added retry flags to
  kind (x2) and clusterctl downloads
- `.github/workflows/workload-cluster-rosa.yml` — added retry flags to
  kind (x2) and clusterctl downloads

## Configuration Changes

N/A

## Additional Notes

Root cause identified from run 2087630250363064320 of
periodic-ci-Azure-ARO-HCP-main-capz-e2e-production:
`curl: (6) Could not resolve host: dl.k8s.io` at the kubectl download step
(Dockerfile.prow line 36). The build failed in 8m32s, before any
infrastructure or test step ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)